### PR TITLE
chore: bump Go to 1.26.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib
 // For the OpenTelemetry Collector Contrib distribution specifically, see
 // https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 
-go 1.24.0
+go 1.26.0
 
 retract (
 	v0.76.2


### PR DESCRIPTION
## Summary
- Bumps \`go\` directive in \`go.mod\` to \`1.26.0\`
- Runs \`go mod tidy\` to update \`go.sum\`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line metadata change in `go.mod`; main risk is CI/toolchain incompatibility if Go 1.26 isn’t available everywhere.
> 
> **Overview**
> Updates the module `go` directive in `go.mod` from `1.24.0` to `1.26.0` to reflect building/testing with the newer Go toolchain.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a596a8269e7f0127ec06a59c7792bc85518ad441. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the project to Go 1.26.0 by updating the go directive in go.mod. This aligns local and CI builds with Go 1.26 and enables the latest compiler and stdlib features.

- **Migration**
  - Update local and CI toolchains to Go 1.26.0+.
  - Run go mod tidy after upgrading if dependencies change locally.

<sup>Written for commit a596a8269e7f0127ec06a59c7792bc85518ad441. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

