### PR TITLE
[chore] ci: auto-tag loadbalancingexporter module on main merges

### DIFF
--- a/.chloggen/17-module-tag-loadbalancingexporter.yaml
+++ b/.chloggen/17-module-tag-loadbalancingexporter.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add CI workflow to auto-tag Sawmills loadbalancingexporter module versions on merges to main.
+issues: [17]
+change_logs: [user]

--- a/.github/workflows/module-tag-loadbalancingexporter.yml
+++ b/.github/workflows/module-tag-loadbalancingexporter.yml
@@ -83,5 +83,7 @@ jobs:
           NEW_TAG="${TAG_PREFIX}${NEXT_INDEX}"
 
           echo "Creating ${NEW_TAG} at ${GITHUB_SHA}"
+          GIT_COMMITTER_NAME="github-actions[bot]" \
+          GIT_COMMITTER_EMAIL="41898282+github-actions[bot]@users.noreply.github.com" \
           git tag -a "${NEW_TAG}" "${GITHUB_SHA}" -m "Sawmills release ${NEW_TAG}"
           git push origin "${NEW_TAG}"

--- a/.github/workflows/module-tag-loadbalancingexporter.yml
+++ b/.github/workflows/module-tag-loadbalancingexporter.yml
@@ -13,9 +13,6 @@ on:
         required: false
         type: string
 
-permissions:
-  contents: write
-
 concurrency:
   group: module-tag-loadbalancingexporter-${{ github.ref }}
   cancel-in-progress: false
@@ -23,6 +20,8 @@ concurrency:
 jobs:
   tag-module:
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     env:
       MODULE_PREFIX: exporter/loadbalancingexporter
@@ -74,5 +73,5 @@ jobs:
           NEW_TAG="${TAG_PREFIX}${NEXT_INDEX}"
 
           echo "Creating ${NEW_TAG} at ${GITHUB_SHA}"
-          git tag "${NEW_TAG}" "${GITHUB_SHA}"
+          git tag -a "${NEW_TAG}" "${GITHUB_SHA}" -m "Sawmills release ${NEW_TAG}"
           git push origin "${NEW_TAG}"

--- a/.github/workflows/module-tag-loadbalancingexporter.yml
+++ b/.github/workflows/module-tag-loadbalancingexporter.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MODULE_PREFIX: exporter/loadbalancingexporter
+      # Intentionally pinned to SAW-6556 backport line.
       DEFAULT_BASE_VERSION: "0.136.0"
     steps:
       - name: Checkout
@@ -39,8 +40,6 @@ jobs:
           INPUT_BASE_VERSION: ${{ github.event.inputs.base_version }}
         run: |
           set -euo pipefail
-
-          git fetch --tags --force
 
           BASE_VERSION="${INPUT_BASE_VERSION}"
           if [[ -z "${BASE_VERSION}" ]]; then
@@ -59,11 +58,16 @@ jobs:
             exit 0
           fi
 
-          LAST_TAG="$(git tag --list "${TAG_PREFIX}*" --sort=-v:refname | head -n1)"
+          readarray -t MATCHING_TAGS < <(git tag --list "${TAG_PREFIX}*" --sort=-v:refname)
+          LAST_TAG="${MATCHING_TAGS[0]:-}"
           if [[ -z "${LAST_TAG}" ]]; then
             NEXT_INDEX=1
           else
             LAST_INDEX="${LAST_TAG##*.}"
+            if [[ ! "${LAST_INDEX}" =~ ^[0-9]+$ ]]; then
+              echo "Unexpected non-numeric tag suffix: ${LAST_INDEX} (tag: ${LAST_TAG})"
+              exit 1
+            fi
             NEXT_INDEX=$((LAST_INDEX + 1))
           fi
 

--- a/.github/workflows/module-tag-loadbalancingexporter.yml
+++ b/.github/workflows/module-tag-loadbalancingexporter.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   tag-module:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     env:
       MODULE_PREFIX: exporter/loadbalancingexporter
@@ -34,14 +35,20 @@ jobs:
 
       - name: Compute and create next module tag
         shell: bash
+        env:
+          INPUT_BASE_VERSION: ${{ github.event.inputs.base_version }}
         run: |
           set -euo pipefail
 
           git fetch --tags --force
 
-          BASE_VERSION="${{ github.event.inputs.base_version }}"
+          BASE_VERSION="${INPUT_BASE_VERSION}"
           if [[ -z "${BASE_VERSION}" ]]; then
             BASE_VERSION="${DEFAULT_BASE_VERSION}"
+          fi
+          if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid base_version '${BASE_VERSION}'. Expected format: X.Y.Z"
+            exit 1
           fi
 
           TAG_PREFIX="${MODULE_PREFIX}/v${BASE_VERSION}-sawmills."

--- a/.github/workflows/module-tag-loadbalancingexporter.yml
+++ b/.github/workflows/module-tag-loadbalancingexporter.yml
@@ -25,8 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MODULE_PREFIX: exporter/loadbalancingexporter
-      # Intentionally pinned to SAW-6556 backport line.
-      DEFAULT_BASE_VERSION: "0.136.0"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -42,7 +40,18 @@ jobs:
 
           BASE_VERSION="${INPUT_BASE_VERSION}"
           if [[ -z "${BASE_VERSION}" ]]; then
-            BASE_VERSION="${DEFAULT_BASE_VERSION}"
+            # Discover base semver from latest existing module tag.
+            readarray -t DISCOVERY_TAGS < <(git tag --list "${MODULE_PREFIX}/v*" --sort=-v:refname)
+            for TAG in "${DISCOVERY_TAGS[@]}"; do
+              if [[ "${TAG}" =~ ^${MODULE_PREFIX}/v([0-9]+\.[0-9]+\.[0-9]+)(-sawmills\.[0-9]+)?$ ]]; then
+                BASE_VERSION="${BASH_REMATCH[1]}"
+                break
+              fi
+            done
+          fi
+          if [[ -z "${BASE_VERSION}" ]]; then
+            echo "Unable to derive base_version from module tags; pass workflow_dispatch input base_version."
+            exit 1
           fi
           if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Invalid base_version '${BASE_VERSION}'. Expected format: X.Y.Z"
@@ -52,7 +61,8 @@ jobs:
           TAG_PREFIX="${MODULE_PREFIX}/v${BASE_VERSION}-sawmills."
 
           # Idempotency: do not create another tag if this commit was already tagged.
-          if git tag --points-at "${GITHUB_SHA}" --list "${TAG_PREFIX}*" | grep -q .; then
+          readarray -t CURRENT_COMMIT_TAGS < <(git tag --points-at "${GITHUB_SHA}" --list "${TAG_PREFIX}*")
+          if [[ ${#CURRENT_COMMIT_TAGS[@]} -gt 0 ]]; then
             echo "Commit ${GITHUB_SHA} already has ${TAG_PREFIX}* tag. Nothing to do."
             exit 0
           fi

--- a/.github/workflows/module-tag-loadbalancingexporter.yml
+++ b/.github/workflows/module-tag-loadbalancingexporter.yml
@@ -1,0 +1,67 @@
+name: Module Tag - loadbalancingexporter
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - exporter/loadbalancingexporter/**
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: Base semver (without v), e.g. 0.136.0
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: module-tag-loadbalancingexporter-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag-module:
+    runs-on: ubuntu-latest
+    env:
+      MODULE_PREFIX: exporter/loadbalancingexporter
+      DEFAULT_BASE_VERSION: "0.136.0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute and create next module tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force
+
+          BASE_VERSION="${{ github.event.inputs.base_version }}"
+          if [[ -z "${BASE_VERSION}" ]]; then
+            BASE_VERSION="${DEFAULT_BASE_VERSION}"
+          fi
+
+          TAG_PREFIX="${MODULE_PREFIX}/v${BASE_VERSION}-sawmills."
+
+          # Idempotency: do not create another tag if this commit was already tagged.
+          if git tag --points-at "${GITHUB_SHA}" --list "${TAG_PREFIX}*" | grep -q .; then
+            echo "Commit ${GITHUB_SHA} already has ${TAG_PREFIX}* tag. Nothing to do."
+            exit 0
+          fi
+
+          LAST_TAG="$(git tag --list "${TAG_PREFIX}*" --sort=-v:refname | head -n1)"
+          if [[ -z "${LAST_TAG}" ]]; then
+            NEXT_INDEX=1
+          else
+            LAST_INDEX="${LAST_TAG##*.}"
+            NEXT_INDEX=$((LAST_INDEX + 1))
+          fi
+
+          NEW_TAG="${TAG_PREFIX}${NEXT_INDEX}"
+
+          echo "Creating ${NEW_TAG} at ${GITHUB_SHA}"
+          git tag "${NEW_TAG}" "${GITHUB_SHA}"
+          git push origin "${NEW_TAG}"


### PR DESCRIPTION
## Summary
- add a focused workflow to auto-create `exporter/loadbalancingexporter` module tags on pushes to `main`
- tag format: `exporter/loadbalancingexporter/v0.136.0-sawmills.N`
- include idempotency guard to avoid duplicate tags on reruns
- add optional manual `workflow_dispatch` override for base version

## Context
SAW-6556


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated module versioning infrastructure for internal development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a focused GitHub Actions workflow to automatically create module tags for `loadbalancingexporter` when changes are pushed to main. The workflow generates incremental tags in the format `exporter/loadbalancingexporter/v{BASE_VERSION}-sawmills.{INDEX}`, starting from index 1 for each base version.

**Key features:**
- Idempotency guard prevents duplicate tags on workflow reruns for the same commit and base version
- Manual trigger option with optional base version override
- Proper concurrency control (`cancel-in-progress: false`) to prevent race conditions
- Uses `set -euo pipefail` for robust error handling
- Fetches full git history and tags with `fetch-depth: 0`

**Implementation notes:**
- Tag index extraction uses `${LAST_TAG##*.}` to get the numeric suffix after the last dot
- Workflow correctly handles the case when no prior tags exist (starts at index 1)
- Same commit can receive multiple tags if base version changes (appears intentional)

The workflow is well-structured and follows GitHub Actions best practices.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- The workflow is well-designed with proper error handling, idempotency guards, and concurrency controls. The tag generation logic is sound and the implementation follows GitHub Actions best practices. Minor robustness improvements could be made for edge cases (like validating numeric indices), but these would only matter if tags are manually created in malformed formats.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/module-tag-loadbalancingexporter.yml | New GitHub Actions workflow for auto-tagging loadbalancingexporter module with incremental version numbers. Includes idempotency guard and manual trigger option. Well-structured with good error handling practices. |

</details>



<sub>Last reviewed commit: 503296a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new GitHub Actions workflow that creates/pushes git tags; main impact is on release/versioning automation rather than runtime code.
> 
> **Overview**
> Adds a dedicated GitHub Actions workflow to automatically create and push incremental Sawmills module tags for `exporter/loadbalancingexporter` on pushes to `main` (and via manual dispatch with an optional `base_version` override).
> 
> The workflow validates the base semver, computes the next `.../vX.Y.Z-sawmills.N` tag, and includes an idempotency check to avoid creating duplicate tags on reruns. A changelog entry documents the CI enhancement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce19b4c348453212e705208f10eb305723a1c78f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to auto-tag exporter/loadbalancingexporter on main merges, creating incremental Sawmills tags for internal releases. Derives base semver from existing module tags, validates inputs, and uses annotated tags with a configured committer identity. Supports SAW-6556.

- **New Features**
  - Creates tags like exporter/loadbalancingexporter/v{BASE}-sawmills.N; base semver is auto-discovered (workflow_dispatch can override; requires input if none exist).
  - Runs only for changes under exporter/loadbalancingexporter on main; validates base semver and numeric index; starts at 1; skips if the commit is already tagged.
  - Concurrency prevents races; scoped permissions (contents: write); sets committer to github-actions[bot]; adds changelog entry.

<sup>Written for commit 386a90426749afda8b8625d18a4a605405e3f4d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

