### PR TITLE
fix(loadbalancingexporter): restore compress_in_memory validation

### DIFF
--- a/.chloggen/saw-6764-loadbalancing-compress-in-memory.yaml
+++ b/.chloggen/saw-6764-loadbalancing-compress-in-memory.yaml
@@ -1,0 +1,8 @@
+change_type: bug_fix
+component: exporter/loadbalancing
+note: Restore `sending_queue.compress_in_memory` support for the loadbalancing exporter when queueing is enabled with snappy or zstd payload compression.
+issues: [6764]
+subtext: |
+  This fixes a regression in `v0.136.0-sawmills.4` that rejected `compress_in_memory` unconditionally.
+  Coverage now includes queue compression together with the optional `log_batcher` path.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -125,8 +125,11 @@ func (q QueueSettings) Validate() error {
 		return fmt.Errorf("sending_queue.payload_compression must be one of [none, snappy, zstd], found %q", q.PayloadCompression)
 	}
 
-	if q.CompressInMemory {
-		return errors.New("sending_queue.compress_in_memory is not supported by this exporter helper version; use sending_queue.payload_compression instead")
+	if q.CompressInMemory && !q.Enabled {
+		return errors.New("sending_queue.compress_in_memory requires sending_queue.enabled=true")
+	}
+	if q.CompressInMemory && (q.PayloadCompression == "" || q.PayloadCompression == QueuePayloadCompressionNone) {
+		return errors.New("sending_queue.compress_in_memory requires sending_queue.payload_compression to be set to snappy or zstd")
 	}
 
 	return nil

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -44,15 +44,21 @@ func TestConfigValidatePayloadCompression(t *testing.T) {
 }
 
 func TestConfigValidateCompressInMemory(t *testing.T) {
-	// compress_in_memory is unsupported; any use must fail immediately regardless of other settings.
 	cfg := createDefaultConfig().(*Config)
 	cfg.QueueSettings.CompressInMemory = true
-	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory is not supported")
+	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory requires sending_queue.enabled=true")
 
-	// Same error even when enabled=true and payload_compression is set.
 	cfg.QueueSettings.Enabled = true
+	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory requires sending_queue.payload_compression")
+
+	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionNone
+	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory requires sending_queue.payload_compression")
+
 	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionSnappy
-	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory is not supported")
+	require.NoError(t, cfg.Validate())
+
+	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
+	require.NoError(t, cfg.Validate())
 }
 
 func TestConfigValidateLogBatcher(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -22,6 +22,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -261,6 +262,59 @@ func TestConsumeLogsEmitsOnlyParentExporterMetrics(t *testing.T) {
 	require.Len(t, childSettings, 1)
 	assert.IsType(t, metricnoop.NewMeterProvider(), childSettings[0].MeterProvider)
 	assert.IsType(t, tracenoop.NewTracerProvider(), childSettings[0].TracerProvider)
+}
+
+func TestConsumeLogsWithQueueCompressionAndLogBatcher(t *testing.T) {
+	ctx := t.Context()
+	shutdownCtx := context.Background() //nolint:usetesting // Context must outlive test for cleanup
+
+	cfg := simpleConfig()
+	cfg.QueueSettings.QueueBatchConfig = exporterhelper.NewDefaultQueueConfig()
+	cfg.QueueSettings.Enabled = true
+	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionSnappy
+	cfg.QueueSettings.CompressInMemory = true
+	cfg.LogBatcher.Enabled = true
+	cfg.LogBatcher.MaxRecords = 32
+	cfg.LogBatcher.MaxBytes = 1 << 20
+	cfg.LogBatcher.FlushInterval = time.Hour
+
+	ts := exportertest.NewNopSettings(metadata.Type)
+	logsExporter, err := newLogsExporter(ts, cfg)
+	require.NoError(t, err)
+
+	sink := new(consumertest.LogsSink)
+	logsExporter.loadBalancer.componentFactory = func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(sink.ConsumeLogs), nil
+	}
+
+	payloadCodec := newQueuePayloadCodecIfEnabled(cfg)
+	require.NotNil(t, payloadCodec)
+
+	wrappedExporter, err := exporterhelper.NewLogs(
+		ctx,
+		ts,
+		cfg,
+		logsExporter.ConsumeLogs,
+		buildExporterResilienceOptions(
+			[]exporterhelper.Option{
+				exporterhelper.WithStart(logsExporter.Start),
+				exporterhelper.WithShutdown(shutdownWithCodec(component.ShutdownFunc(logsExporter.Shutdown), payloadCodec)),
+				exporterhelper.WithCapabilities(logsExporter.Capabilities()),
+			},
+			cfg,
+			payloadCodec,
+			xexporterhelper.NewLogsQueueBatchSettings(),
+		)...,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, wrappedExporter.Start(ctx, componenttest.NewNopHost()))
+	require.NoError(t, wrappedExporter.ConsumeLogs(ctx, simpleLogs()))
+	require.NoError(t, wrappedExporter.ConsumeLogs(ctx, simpleLogs()))
+	require.NoError(t, wrappedExporter.Shutdown(shutdownCtx))
+
+	require.Len(t, sink.AllLogs(), 1)
+	assert.Equal(t, 2, sink.AllLogs()[0].LogRecordCount())
 }
 
 func generateSingleLogRecord() plog.Logs {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -322,6 +322,7 @@ func TestConsumeLogsWithQueueCompressionAndLogBatcher(t *testing.T) {
 	require.NoError(t, wrappedExporter.ConsumeLogs(ctx, simpleLogs()))
 	shutdown()
 
+	require.NotEmpty(t, sink.AllLogs())
 	assert.Equal(t, 2, sink.AllLogs()[0].LogRecordCount())
 }
 

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -315,7 +315,9 @@ func TestConsumeLogsWithQueueCompressionAndLogBatcher(t *testing.T) {
 	require.NoError(t, wrappedExporter.ConsumeLogs(ctx, simpleLogs()))
 	require.NoError(t, wrappedExporter.ConsumeLogs(ctx, simpleLogs()))
 
-	require.Len(t, sink.AllLogs(), 1)
+	require.Eventually(t, func() bool {
+		return len(sink.AllLogs()) == 1
+	}, time.Second, 10*time.Millisecond)
 	assert.Equal(t, 2, sink.AllLogs()[0].LogRecordCount())
 }
 

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -283,7 +283,7 @@ func TestConsumeLogsWithQueueCompressionAndLogBatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	sink := new(consumertest.LogsSink)
-	logsExporter.loadBalancer.componentFactory = func(_ context.Context, endpoint string) (component.Component, error) {
+	logsExporter.loadBalancer.componentFactory = func(_ context.Context, _ string) (component.Component, error) {
 		return newMockLogsExporter(sink.ConsumeLogs), nil
 	}
 

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -309,9 +309,11 @@ func TestConsumeLogsWithQueueCompressionAndLogBatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, wrappedExporter.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, wrappedExporter.Shutdown(shutdownCtx))
+	})
 	require.NoError(t, wrappedExporter.ConsumeLogs(ctx, simpleLogs()))
 	require.NoError(t, wrappedExporter.ConsumeLogs(ctx, simpleLogs()))
-	require.NoError(t, wrappedExporter.Shutdown(shutdownCtx))
 
 	require.Len(t, sink.AllLogs(), 1)
 	assert.Equal(t, 2, sink.AllLogs()[0].LogRecordCount())

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -309,15 +309,19 @@ func TestConsumeLogsWithQueueCompressionAndLogBatcher(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, wrappedExporter.Start(ctx, componenttest.NewNopHost()))
+	var shutdownOnce sync.Once
+	shutdown := func() {
+		shutdownOnce.Do(func() {
+			require.NoError(t, wrappedExporter.Shutdown(shutdownCtx))
+		})
+	}
 	t.Cleanup(func() {
-		require.NoError(t, wrappedExporter.Shutdown(shutdownCtx))
+		shutdown()
 	})
 	require.NoError(t, wrappedExporter.ConsumeLogs(ctx, simpleLogs()))
 	require.NoError(t, wrappedExporter.ConsumeLogs(ctx, simpleLogs()))
+	shutdown()
 
-	require.Eventually(t, func() bool {
-		return len(sink.AllLogs()) == 1
-	}, time.Second, 10*time.Millisecond)
 	assert.Equal(t, 2, sink.AllLogs()[0].LogRecordCount())
 }
 


### PR DESCRIPTION
## Summary
- restore `sending_queue.compress_in_memory` validation to the `.3` semantics
- add end-to-end coverage for queue compression together with `log_batcher`
- keep the fix branch cleanly based on current `main`

## Validation
- `go test ./...` in `exporter/loadbalancingexporter`

Refs: SAW-6764

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation change in `QueueSettings.Validate()` that may newly reject misconfigured `compress_in_memory` setups, plus added test coverage; no core routing or export logic changes.
> 
> **Overview**
> Restores support for `sending_queue.compress_in_memory` in the loadbalancing exporter by changing validation to allow it only when `sending_queue.enabled=true` and `sending_queue.payload_compression` is set to `snappy` or `zstd` (and emitting clearer configuration errors otherwise).
> 
> Updates unit tests to cover the allowed/forbidden config combinations, and adds an end-to-end logs test that exercises queue payload compression together with the `log_batcher` path and validates flush behavior on shutdown. Adds a user-facing changelog entry for SAW-6764.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1363d09ecd786fbda8b06d49659cccd96911eea7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `.3`-era validation for `sending_queue.compress_in_memory` in `exporter/loadbalancingexporter`, allowing it only when the queue is enabled and payload compression is `snappy` or `zstd`. Adds an end-to-end logs test with `log_batcher` and deterministic shutdown to verify queue compression for SAW-6764.

- **Bug Fixes**
  - `QueueSettings.Validate()` now permits `compress_in_memory` only with `sending_queue.enabled=true` and `sending_queue.payload_compression` set to `snappy` or `zstd`; returns clear errors for a disabled queue or unset/`none`.
  - Tests updated: unit matrix for valid/invalid combos; e2e logs test confirming two inputs batch into one send and flush on shutdown; hardened batching assertion; added changelog entry for SAW-6764.

<sup>Written for commit 1363d09ecd786fbda8b06d49659cccd96911eea7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-memory compression for sending queues is supported when queueing is enabled and payload compression is set to Snappy or Zstd.

* **Bug Fixes**
  * Validation logic and error messages for sending queue configuration updated to enforce the new constraints.

* **Tests**
  * Expanded tests covering queue compression validation and log-batching integration with in-memory compression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->