### PR TITLE
fix(loadbalancingexporter): restore compress_in_memory compatibility

### DIFF
--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -254,9 +254,10 @@ exporters:
     sending_queue:
       enabled: true
       payload_compression: zstd
+      compress_in_memory: true
 ```
 
-`sending_queue.compress_in_memory` is currently not supported by this exporter helper version. If set, config validation fails instead of silently ignoring it.
+`sending_queue.compress_in_memory` enables queue encoding for in-memory queues. It requires `sending_queue.enabled: true` and a non-`none` `sending_queue.payload_compression` value.
 
 Kubernetes resolver example (For a more specific example: [example/k8s-resolver](./example/k8s-resolver/README.md))
 > [!IMPORTANT]

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -129,7 +129,12 @@ func (q QueueSettings) Validate() error {
 	}
 
 	if q.CompressInMemory {
-		return errors.New("sending_queue.compress_in_memory is not supported by this exporter helper version; use sending_queue.payload_compression instead")
+		if !q.Enabled {
+			return errors.New("sending_queue.compress_in_memory requires sending_queue.enabled=true")
+		}
+		if q.PayloadCompression == "" || q.PayloadCompression == QueuePayloadCompressionNone {
+			return errors.New("sending_queue.compress_in_memory requires sending_queue.payload_compression to be set to snappy or zstd")
+		}
 	}
 
 	return nil

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -44,15 +44,18 @@ func TestConfigValidatePayloadCompression(t *testing.T) {
 }
 
 func TestConfigValidateCompressInMemory(t *testing.T) {
-	// compress_in_memory is unsupported; any use must fail immediately regardless of other settings.
 	cfg := createDefaultConfig().(*Config)
 	cfg.QueueSettings.CompressInMemory = true
-	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory is not supported")
+	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory requires sending_queue.enabled=true")
 
-	// Same error even when enabled=true and payload_compression is set.
 	cfg.QueueSettings.Enabled = true
+	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory requires sending_queue.payload_compression")
+
 	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionSnappy
-	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory is not supported")
+	require.NoError(t, cfg.Validate())
+
+	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
+	require.NoError(t, cfg.Validate())
 }
 
 func TestConfigValidateLogBatcher(t *testing.T) {

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -104,6 +104,9 @@ func buildExporterResilienceOptions(
 			}
 		}
 		options = append(options, xexporterhelper.WithQueueBatch(cfg.QueueSettings.QueueBatchConfig, qbs))
+		if cfg.QueueSettings.CompressInMemory {
+			options = append(options, exporterhelper.WithQueueBatchInMemoryEncoding(true))
+		}
 	}
 	if cfg.Enabled {
 		options = append(options, exporterhelper.WithRetry(cfg.BackOffConfig))

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -236,7 +236,7 @@ func TestBuildExporterResilienceOptions(t *testing.T) {
 
 		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodecIfEnabled(cfg), newSettings()), 2)
 	})
-	t.Run("Should have timeout, queue and compression options when compression is enabled", func(t *testing.T) {
+	t.Run("Should have timeout, queue and payload codec options when compression is enabled", func(t *testing.T) {
 		o := []exporterhelper.Option{}
 		cfg := createDefaultConfig().(*Config)
 		cfg.TimeoutSettings = exporterhelper.NewDefaultTimeoutConfig()
@@ -244,6 +244,16 @@ func TestBuildExporterResilienceOptions(t *testing.T) {
 		cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionSnappy
 
 		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression), newSettings()), 2)
+	})
+	t.Run("Should have in-memory encoding option when requested", func(t *testing.T) {
+		o := []exporterhelper.Option{}
+		cfg := createDefaultConfig().(*Config)
+		cfg.TimeoutSettings = exporterhelper.NewDefaultTimeoutConfig()
+		cfg.QueueSettings.QueueBatchConfig = exporterhelper.NewDefaultQueueConfig()
+		cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionSnappy
+		cfg.QueueSettings.CompressInMemory = true
+
+		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression), newSettings()), 3)
 	})
 	t.Run("Should have all resilience options if defined", func(t *testing.T) {
 		o := []exporterhelper.Option{}


### PR DESCRIPTION
Restore the loadbalancing exporter queue-compression compatibility path.

What changed:
- re-enable `sending_queue.compress_in_memory` for in-memory queue encoding
- keep `sending_queue.payload_compression` as the queue payload codec
- require `compress_in_memory` to be used only with `sending_queue.enabled=true` and a non-`none` compression codec
- update tests and docs to match the restored behavior

Verification:
- `go test ./...` in `exporter/loadbalancingexporter`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes queue configuration validation and exporterhelper wiring for `sending_queue.compress_in_memory`, which can affect queuing behavior and payload encoding at runtime. Risk is moderate due to potential performance/compatibility implications for deployments relying on specific queue/compression settings.
> 
> **Overview**
> **Restores `sending_queue.compress_in_memory` behavior** for the loadbalancing exporter: it now enables in-memory queue encoding (via `exporterhelper.WithQueueBatchInMemoryEncoding`) instead of failing validation.
> 
> **Tightens config validation** so `compress_in_memory` is only allowed when `sending_queue.enabled=true` and `sending_queue.payload_compression` is set to `snappy` or `zstd`; tests and README are updated to match this restored/required configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85a5f5035b738b8ebed22fa1300f4958a1a82cc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `sending_queue.compress_in_memory` support in the `loadbalancingexporter`, enabling safe in-memory queue encoding while keeping `sending_queue.payload_compression` as the payload codec. This supports SAW-6849 by ensuring consistent queue behavior during rollout churn.

- **Bug Fixes**
  - Re-enabled `sending_queue.compress_in_memory` for in-memory queue encoding.
  - Added validation: requires `sending_queue.enabled: true` and non-`none` `sending_queue.payload_compression` (`snappy` or `zstd`).
  - Wired `exporterhelper.WithQueueBatchInMemoryEncoding(true)` when enabled.
  - Updated README and tests to reflect the restored behavior.

<sup>Written for commit 85a5f5035b738b8ebed22fa1300f4958a1a82cc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

