### PR TITLE
[codex] loadbalancingexporter: restore compress_in_memory compatibility

### DIFF
--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -254,9 +254,10 @@ exporters:
     sending_queue:
       enabled: true
       payload_compression: zstd
+      compress_in_memory: true
 ```
 
-`sending_queue.compress_in_memory` is currently not supported by this exporter helper version. If set, config validation fails instead of silently ignoring it.
+`sending_queue.compress_in_memory` enables queue encoding for in-memory queues. It requires `sending_queue.enabled: true` and a non-`none` `sending_queue.payload_compression` value.
 
 Kubernetes resolver example (For a more specific example: [example/k8s-resolver](./example/k8s-resolver/README.md))
 > [!IMPORTANT]

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -129,7 +129,12 @@ func (q QueueSettings) Validate() error {
 	}
 
 	if q.CompressInMemory {
-		return errors.New("sending_queue.compress_in_memory is not supported by this exporter helper version; use sending_queue.payload_compression instead")
+		if !q.Enabled {
+			return errors.New("sending_queue.compress_in_memory requires sending_queue.enabled=true")
+		}
+		if q.PayloadCompression == "" || q.PayloadCompression == QueuePayloadCompressionNone {
+			return errors.New("sending_queue.compress_in_memory requires sending_queue.payload_compression to be set to snappy or zstd")
+		}
 	}
 
 	return nil

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -44,15 +44,18 @@ func TestConfigValidatePayloadCompression(t *testing.T) {
 }
 
 func TestConfigValidateCompressInMemory(t *testing.T) {
-	// compress_in_memory is unsupported; any use must fail immediately regardless of other settings.
 	cfg := createDefaultConfig().(*Config)
 	cfg.QueueSettings.CompressInMemory = true
-	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory is not supported")
+	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory requires sending_queue.enabled=true")
 
-	// Same error even when enabled=true and payload_compression is set.
 	cfg.QueueSettings.Enabled = true
+	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory requires sending_queue.payload_compression")
+
 	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionSnappy
-	require.ErrorContains(t, cfg.Validate(), "sending_queue.compress_in_memory is not supported")
+	require.NoError(t, cfg.Validate())
+
+	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
+	require.NoError(t, cfg.Validate())
 }
 
 func TestConfigValidateLogBatcher(t *testing.T) {

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -104,6 +104,9 @@ func buildExporterResilienceOptions(
 			}
 		}
 		options = append(options, xexporterhelper.WithQueueBatch(cfg.QueueSettings.QueueBatchConfig, qbs))
+		if cfg.QueueSettings.CompressInMemory {
+			options = append(options, exporterhelper.WithQueueBatchInMemoryEncoding(true))
+		}
 	}
 	if cfg.Enabled {
 		options = append(options, exporterhelper.WithRetry(cfg.BackOffConfig))

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -236,7 +236,7 @@ func TestBuildExporterResilienceOptions(t *testing.T) {
 
 		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodecIfEnabled(cfg), newSettings()), 2)
 	})
-	t.Run("Should have timeout, queue and compression options when compression is enabled", func(t *testing.T) {
+	t.Run("Should have timeout, queue and payload codec options when compression is enabled", func(t *testing.T) {
 		o := []exporterhelper.Option{}
 		cfg := createDefaultConfig().(*Config)
 		cfg.TimeoutSettings = exporterhelper.NewDefaultTimeoutConfig()
@@ -244,6 +244,16 @@ func TestBuildExporterResilienceOptions(t *testing.T) {
 		cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionSnappy
 
 		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression), newSettings()), 2)
+	})
+	t.Run("Should have in-memory encoding option when requested", func(t *testing.T) {
+		o := []exporterhelper.Option{}
+		cfg := createDefaultConfig().(*Config)
+		cfg.TimeoutSettings = exporterhelper.NewDefaultTimeoutConfig()
+		cfg.QueueSettings.QueueBatchConfig = exporterhelper.NewDefaultQueueConfig()
+		cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionSnappy
+		cfg.QueueSettings.CompressInMemory = true
+
+		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression), newSettings()), 3)
 	})
 	t.Run("Should have all resilience options if defined", func(t *testing.T) {
 		o := []exporterhelper.Option{}


### PR DESCRIPTION
Restores the loadbalancingexporter in-memory queue encoding path so existing Sawmills configs keep starting on the forked exporter branch.

- Re-enable `compress_in_memory` validation and exporterhelper queue encoding.
- Keep the queue compression contract intact with `payload_compression`.
- Add regression coverage for validation and queue-encoding wiring.

SAW-6849.

Checks:
- `go test ./...` in `exporter/loadbalancingexporter`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores in-memory queue encoding for the `loadbalancingexporter` so configs using `sending_queue.compress_in_memory` work again. This keeps existing Sawmills configs starting while addressing SAW-6849 stability work.

- **Bug Fixes**
  - Re-enable `sending_queue.compress_in_memory` with validation: requires `sending_queue.enabled: true` and non-`none` `payload_compression`.
  - Wire in-memory encoding via `exporterhelper.WithQueueBatchInMemoryEncoding(true)` when enabled.
  - Update README to document usage; add tests for validation and option wiring.

<sup>Written for commit 46b4b7e104d204dc30d01ee005b9c4b73ce3a520. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches exporter queuing/encoding behavior and validation, which can affect buffering and payload handling under load. Changes are gated behind `compress_in_memory` and covered by new/updated tests, reducing risk.
> 
> **Overview**
> Re-enables `sending_queue.compress_in_memory` for `loadbalancingexporter`, changing validation from a hard failure to allowing it when `sending_queue.enabled=true` and `sending_queue.payload_compression` is `snappy`/`zstd`.
> 
> When configured, the exporter now passes `exporterhelper.WithQueueBatchInMemoryEncoding(true)` so in-memory queue items are encoded/compressed consistently. README and tests are updated to document the flag and add regression coverage for validation and option wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46b4b7e104d204dc30d01ee005b9c4b73ce3a520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->