### PR TITLE
loadbalancingexporter: reroute removed-backend log batches

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -281,3 +281,4 @@ providers:
 # file before passing it to OCB, to ensure that local versions are used for all
 # Contrib modules.
 replaces:
+  - go.opentelemetry.io/collector/exporter/exporterhelper => github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.140.1-sawmills.1.0.20260304220840-f32306271c14

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -207,7 +207,15 @@ func (b *logBatcher) removeAndReroute(ctx context.Context, endpoint string, back
 		b.scheduleBackendDrain(backend)
 		return err
 	}
-	return b.drainRemovedBackend(ctx, endpoint, backend)
+	if err := b.drainRemovedBackend(ctx, endpoint, backend); err != nil {
+		select {
+		case <-backend.done:
+		default:
+			b.scheduleBackendDrain(backend)
+		}
+		return err
+	}
+	return nil
 }
 
 func (b *logBatcher) Shutdown(ctx context.Context) error {

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -253,7 +253,7 @@ func (b *logBatcher) scheduleBackendDrain(backend *backendLogBatcher) {
 			return
 		}
 		if err := b.drainRemovedBackend(context.Background(), backend.endpoint, backend); err != nil {
-			b.logger.Warn("failed to reroute removed backend log batch", zap.String("removed_endpoint", backend.endpoint), zap.Error(err))
+			b.logger.Error("failed to reroute removed backend log batch", zap.String("removed_endpoint", backend.endpoint), zap.Error(err))
 		}
 	}()
 }

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -41,12 +41,31 @@ type logBatcherSettings struct {
 
 type logBatcherSendFunc func(context.Context, *wrappedExporter, plog.Logs, string) error
 
+type logBatcherOnBackendRemovedFunc func(context.Context, string, plog.Logs, int, int) error
+
+type logBatcherOption interface {
+	apply(*logBatcher)
+}
+
+type logBatcherOptionFunc func(*logBatcher)
+
+func (f logBatcherOptionFunc) apply(b *logBatcher) {
+	f(b)
+}
+
+func withLogBatcherOnBackendRemoved(fn logBatcherOnBackendRemovedFunc) logBatcherOption {
+	return logBatcherOptionFunc(func(b *logBatcher) {
+		b.onBackendRemoved = fn
+	})
+}
+
 type logBatcher struct {
 	logger   *zap.Logger
 	settings logBatcherSettings
 	send     logBatcherSendFunc
 
-	telemetry *logBatcherTelemetry
+	telemetry        *logBatcherTelemetry
+	onBackendRemoved logBatcherOnBackendRemovedFunc
 
 	mu       sync.RWMutex
 	backends map[string]*backendLogBatcher
@@ -59,6 +78,7 @@ type logBatcherRequest struct {
 	ctx    context.Context
 	reason string
 	done   chan error
+	drain  chan logBatcherDrainResult
 }
 
 type logBatcherRequestKind int
@@ -66,7 +86,15 @@ type logBatcherRequestKind int
 const (
 	logBatcherRequestEnqueue logBatcherRequestKind = iota
 	logBatcherRequestFlushAndStop
+	logBatcherRequestDrainAndStop
 )
+
+type logBatcherDrainResult struct {
+	logs    plog.Logs
+	records int
+	bytes   int
+	err     error
+}
 
 type backendLogBatcher struct {
 	endpoint string
@@ -98,6 +126,9 @@ type logBatcherTelemetry struct {
 	overflowTotal  metric.Int64Counter
 	pendingRecords metric.Int64ObservableGauge
 	pendingBytes   metric.Int64ObservableGauge
+	removedTotal   metric.Int64Counter
+	removedRecords metric.Int64Histogram
+	removedBytes   metric.Int64Histogram
 
 	mu            sync.Mutex
 	registrations []metric.Registration
@@ -108,6 +139,7 @@ func newLogBatcher(
 	settings component.TelemetrySettings,
 	cfg logBatcherSettings,
 	send logBatcherSendFunc,
+	options ...logBatcherOption,
 ) (*logBatcher, error) {
 	telemetry, err := newLogBatcherTelemetry(settings)
 	if err != nil {
@@ -120,6 +152,9 @@ func newLogBatcher(
 		send:      send,
 		telemetry: telemetry,
 		backends:  make(map[string]*backendLogBatcher),
+	}
+	for _, option := range options {
+		option.apply(lb)
 	}
 
 	if err := telemetry.start(lb.snapshotPending); err != nil {
@@ -158,11 +193,22 @@ func (b *logBatcher) Remove(ctx context.Context, endpoint string, exp *wrappedEx
 	if exp != nil {
 		backend.setExporter(exp)
 	}
+	if b.onBackendRemoved != nil {
+		return b.removeAndReroute(ctx, endpoint, backend)
+	}
 	if err := waitForInflight(ctx, &backend.inflight); err != nil {
 		b.scheduleBackendCleanup(backend, logFlushReasonResolverChange)
 		return err
 	}
 	return backend.stopAndFlush(ctx, logFlushReasonResolverChange)
+}
+
+func (b *logBatcher) removeAndReroute(ctx context.Context, endpoint string, backend *backendLogBatcher) error {
+	if err := waitForInflight(ctx, &backend.inflight); err != nil {
+		b.scheduleBackendDrain(backend)
+		return err
+	}
+	return b.drainRemovedBackend(ctx, endpoint, backend)
 }
 
 func (b *logBatcher) Shutdown(ctx context.Context) error {
@@ -198,6 +244,37 @@ func (b *logBatcher) scheduleBackendCleanup(backend *backendLogBatcher, reason s
 			b.logger.Warn("failed to stop log batcher backend during background cleanup", zap.String("endpoint", backend.endpoint), zap.String("reason", reason), zap.Error(err))
 		}
 	}()
+}
+
+func (b *logBatcher) scheduleBackendDrain(backend *backendLogBatcher) {
+	go func() {
+		if err := waitForInflight(context.Background(), &backend.inflight); err != nil {
+			b.logger.Warn("failed waiting for inflight log batcher requests during background removed-backend drain", zap.String("endpoint", backend.endpoint), zap.Error(err))
+			return
+		}
+		if err := b.drainRemovedBackend(context.Background(), backend.endpoint, backend); err != nil {
+			b.logger.Warn("failed to reroute removed backend log batch", zap.String("removed_endpoint", backend.endpoint), zap.Error(err))
+		}
+	}()
+}
+
+func (b *logBatcher) drainRemovedBackend(ctx context.Context, endpoint string, backend *backendLogBatcher) error {
+	drained, err := backend.stopAndDrain(ctx)
+	if err != nil {
+		b.recordRemovedBackendOutcome(ctx, endpoint, "failed", 0, 0)
+		return err
+	}
+	if drained.records == 0 {
+		b.recordRemovedBackendOutcome(ctx, endpoint, "empty", 0, 0)
+		return nil
+	}
+	b.recordRemovedBackendSize(ctx, endpoint, drained.records, drained.bytes)
+	if err := b.onBackendRemoved(ctx, endpoint, drained.logs, drained.records, drained.bytes); err != nil {
+		b.recordRemovedBackendOutcome(ctx, endpoint, "failed", drained.records, drained.bytes)
+		return err
+	}
+	b.recordRemovedBackendOutcome(ctx, endpoint, "rerouted", drained.records, drained.bytes)
+	return nil
 }
 
 func (b *logBatcher) snapshotPending() []logBatcherPending {
@@ -299,6 +376,27 @@ func (b *backendLogBatcher) stopAndFlush(ctx context.Context, reason string) err
 	}
 }
 
+func (b *backendLogBatcher) stopAndDrain(ctx context.Context) (logBatcherDrainResult, error) {
+	done := make(chan logBatcherDrainResult, 1)
+	select {
+	case b.requests <- logBatcherRequest{
+		kind:  logBatcherRequestDrainAndStop,
+		ctx:   ctx,
+		drain: done,
+	}:
+	case <-b.done:
+		return logBatcherDrainResult{}, nil
+	}
+
+	select {
+	case result := <-done:
+		<-b.done
+		return result, result.err
+	case <-ctx.Done():
+		return logBatcherDrainResult{}, ctx.Err()
+	}
+}
+
 func (b *backendLogBatcher) setExporter(exp *wrappedExporter) {
 	b.exporterMu.Lock()
 	b.exp = exp
@@ -396,6 +494,9 @@ func (b *backendLogBatcher) handleRequest(
 		err := b.flush(req.ctx, pending, pendingRecords, pendingBytes, req.reason, timer, timerC)
 		req.done <- err
 		return true
+	case logBatcherRequestDrainAndStop:
+		req.drain <- b.drain(pending, pendingRecords, pendingBytes, timer, timerC)
+		return true
 	}
 	return false
 }
@@ -463,6 +564,41 @@ func (b *backendLogBatcher) flush(
 	return err
 }
 
+func (b *backendLogBatcher) drain(
+	pending *plog.Logs,
+	pendingRecords *int,
+	pendingBytes *int,
+	timer *time.Timer,
+	timerC *<-chan time.Time,
+) logBatcherDrainResult {
+	if !timer.Stop() && *timerC != nil {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	*timerC = nil
+
+	if pending.LogRecordCount() == 0 {
+		return logBatcherDrainResult{logs: plog.NewLogs()}
+	}
+
+	drained := *pending
+	records := *pendingRecords
+	bytes := *pendingBytes
+	*pending = plog.NewLogs()
+	*pendingRecords = 0
+	*pendingBytes = 0
+	b.pendingRecords.Store(0)
+	b.pendingBytes.Store(0)
+
+	return logBatcherDrainResult{
+		logs:    drained,
+		records: records,
+		bytes:   bytes,
+	}
+}
+
 type logBatcherPending struct {
 	endpoint string
 	records  int64
@@ -522,8 +658,42 @@ func newLogBatcherTelemetry(settings component.TelemetrySettings) (*logBatcherTe
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
+	t.removedTotal, err = meter.Int64Counter(
+		"otelcol_loadbalancer_log_batch_removed_backend_total",
+		metric.WithDescription("Number of removed backend drain attempts by outcome."),
+		metric.WithUnit("{removals}"),
+	)
+	errs = errors.Join(errs, err)
+	t.removedRecords, err = meter.Int64Histogram(
+		"otelcol_loadbalancer_log_batch_removed_backend_records",
+		metric.WithDescription("Number of log records drained from removed backends before reroute."),
+		metric.WithUnit("{records}"),
+	)
+	errs = errors.Join(errs, err)
+	t.removedBytes, err = meter.Int64Histogram(
+		"otelcol_loadbalancer_log_batch_removed_backend_bytes",
+		metric.WithDescription("Serialized OTLP bytes drained from removed backends before reroute."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
 
 	return t, errs
+}
+
+func (b *logBatcher) recordRemovedBackendOutcome(ctx context.Context, endpoint string, outcome string, records int, bytes int) {
+	b.telemetry.removedTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
+		attribute.String("endpoint", endpoint),
+		attribute.String("outcome", outcome),
+	)))
+}
+
+func (b *logBatcher) recordRemovedBackendSize(ctx context.Context, endpoint string, records int, bytes int) {
+	if records > 0 {
+		b.telemetry.removedRecords.Record(ctx, int64(records), metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", endpoint))))
+	}
+	if bytes > 0 {
+		b.telemetry.removedBytes.Record(ctx, int64(bytes), metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", endpoint))))
+	}
 }
 
 func (t *logBatcherTelemetry) start(snapshot func() []logBatcherPending) error {

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -384,6 +384,8 @@ func (b *backendLogBatcher) stopAndDrain(ctx context.Context) (logBatcherDrainRe
 		ctx:   ctx,
 		drain: done,
 	}:
+	case <-ctx.Done():
+		return logBatcherDrainResult{}, ctx.Err()
 	case <-b.done:
 		return logBatcherDrainResult{}, nil
 	}

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -93,7 +93,6 @@ type logBatcherDrainResult struct {
 	logs    plog.Logs
 	records int
 	bytes   int
-	err     error
 }
 
 type backendLogBatcher struct {
@@ -394,7 +393,7 @@ func (b *backendLogBatcher) stopAndDrain(ctx context.Context) (logBatcherDrainRe
 	select {
 	case result := <-done:
 		<-b.done
-		return result, result.err
+		return result, nil
 	case <-ctx.Done():
 		return logBatcherDrainResult{}, ctx.Err()
 	}

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -33,6 +33,17 @@ const (
 
 var errLogBatcherExporterStopping = errors.New("log batcher exporter is stopping")
 
+var errLogBatcherRemovedBackendPartial = errors.New("removed backend reroute partially dropped records")
+
+const (
+	removedBackendOutcomeEmpty          = "empty"
+	removedBackendOutcomeFailed         = "failed"
+	removedBackendOutcomePartial        = "partial"
+	removedBackendOutcomeRerouted       = "rerouted"
+	removedBackendOutcomeRetryFailed    = "retry_failed"
+	removedBackendOutcomeRetrySucceeded = "retry_succeeded"
+)
+
 type logBatcherSettings struct {
 	maxRecords    int
 	maxBytes      int
@@ -256,7 +267,7 @@ func (b *logBatcher) scheduleBackendCleanup(backend *backendLogBatcher, reason s
 func (b *logBatcher) scheduleBackendDrain(backend *backendLogBatcher) {
 	go func() {
 		if err := waitForInflight(context.Background(), &backend.inflight); err != nil {
-			b.recordRemovedBackendOutcome(context.Background(), backend.endpoint, "failed")
+			b.recordRemovedBackendOutcome(context.Background(), backend.endpoint, removedBackendOutcomeFailed)
 			b.logger.Error("failed waiting for inflight log batcher requests during background removed-backend drain", zap.String("endpoint", backend.endpoint), zap.Error(err))
 			return
 		}
@@ -269,19 +280,23 @@ func (b *logBatcher) scheduleBackendDrain(backend *backendLogBatcher) {
 func (b *logBatcher) drainRemovedBackend(ctx context.Context, endpoint string, backend *backendLogBatcher) error {
 	drained, err := backend.stopAndDrain(ctx)
 	if err != nil {
-		b.recordRemovedBackendOutcome(ctx, endpoint, "failed")
+		b.recordRemovedBackendOutcome(ctx, endpoint, removedBackendOutcomeFailed)
 		return err
 	}
 	if drained.records == 0 {
-		b.recordRemovedBackendOutcome(ctx, endpoint, "empty")
+		b.recordRemovedBackendOutcome(ctx, endpoint, removedBackendOutcomeEmpty)
 		return nil
 	}
 	b.recordRemovedBackendSize(ctx, endpoint, drained.records, drained.bytes)
 	if err := b.onBackendRemoved(ctx, endpoint, drained.logs, drained.records, drained.bytes); err != nil {
-		b.recordRemovedBackendOutcome(ctx, endpoint, "failed")
+		if errors.Is(err, errLogBatcherRemovedBackendPartial) {
+			b.recordRemovedBackendOutcome(ctx, endpoint, removedBackendOutcomePartial)
+			return nil
+		}
+		b.recordRemovedBackendOutcome(ctx, endpoint, removedBackendOutcomeFailed)
 		return err
 	}
-	b.recordRemovedBackendOutcome(ctx, endpoint, "rerouted")
+	b.recordRemovedBackendOutcome(ctx, endpoint, removedBackendOutcomeRerouted)
 	return nil
 }
 

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -249,6 +249,7 @@ func (b *logBatcher) scheduleBackendCleanup(backend *backendLogBatcher, reason s
 func (b *logBatcher) scheduleBackendDrain(backend *backendLogBatcher) {
 	go func() {
 		if err := waitForInflight(context.Background(), &backend.inflight); err != nil {
+			b.recordRemovedBackendOutcome(context.Background(), backend.endpoint, "failed")
 			b.logger.Warn("failed waiting for inflight log batcher requests during background removed-backend drain", zap.String("endpoint", backend.endpoint), zap.Error(err))
 			return
 		}
@@ -261,19 +262,19 @@ func (b *logBatcher) scheduleBackendDrain(backend *backendLogBatcher) {
 func (b *logBatcher) drainRemovedBackend(ctx context.Context, endpoint string, backend *backendLogBatcher) error {
 	drained, err := backend.stopAndDrain(ctx)
 	if err != nil {
-		b.recordRemovedBackendOutcome(ctx, endpoint, "failed", 0, 0)
+		b.recordRemovedBackendOutcome(ctx, endpoint, "failed")
 		return err
 	}
 	if drained.records == 0 {
-		b.recordRemovedBackendOutcome(ctx, endpoint, "empty", 0, 0)
+		b.recordRemovedBackendOutcome(ctx, endpoint, "empty")
 		return nil
 	}
 	b.recordRemovedBackendSize(ctx, endpoint, drained.records, drained.bytes)
 	if err := b.onBackendRemoved(ctx, endpoint, drained.logs, drained.records, drained.bytes); err != nil {
-		b.recordRemovedBackendOutcome(ctx, endpoint, "failed", drained.records, drained.bytes)
+		b.recordRemovedBackendOutcome(ctx, endpoint, "failed")
 		return err
 	}
-	b.recordRemovedBackendOutcome(ctx, endpoint, "rerouted", drained.records, drained.bytes)
+	b.recordRemovedBackendOutcome(ctx, endpoint, "rerouted")
 	return nil
 }
 
@@ -682,14 +683,14 @@ func newLogBatcherTelemetry(settings component.TelemetrySettings) (*logBatcherTe
 	return t, errs
 }
 
-func (b *logBatcher) recordRemovedBackendOutcome(ctx context.Context, endpoint string, outcome string, records int, bytes int) {
+func (b *logBatcher) recordRemovedBackendOutcome(ctx context.Context, endpoint, outcome string) {
 	b.telemetry.removedTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(
 		attribute.String("endpoint", endpoint),
 		attribute.String("outcome", outcome),
 	)))
 }
 
-func (b *logBatcher) recordRemovedBackendSize(ctx context.Context, endpoint string, records int, bytes int) {
+func (b *logBatcher) recordRemovedBackendSize(ctx context.Context, endpoint string, records, bytes int) {
 	if records > 0 {
 		b.telemetry.removedRecords.Record(ctx, int64(records), metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", endpoint))))
 	}

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -257,7 +257,7 @@ func (b *logBatcher) scheduleBackendDrain(backend *backendLogBatcher) {
 	go func() {
 		if err := waitForInflight(context.Background(), &backend.inflight); err != nil {
 			b.recordRemovedBackendOutcome(context.Background(), backend.endpoint, "failed")
-			b.logger.Warn("failed waiting for inflight log batcher requests during background removed-backend drain", zap.String("endpoint", backend.endpoint), zap.Error(err))
+			b.logger.Error("failed waiting for inflight log batcher requests during background removed-backend drain", zap.String("endpoint", backend.endpoint), zap.Error(err))
 			return
 		}
 		if err := b.drainRemovedBackend(context.Background(), backend.endpoint, backend); err != nil {

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -428,6 +428,74 @@ func TestLogBatcherBackgroundRemovalCleanupReroutesPendingLogs(t *testing.T) {
 	require.Zero(t, endpoint1Calls.Load())
 }
 
+func TestLogBatcherRemoveSchedulesBackgroundDrainWhenStopAndDrainCannotEnqueue(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	rerouted := make(chan struct{}, 1)
+	allowDrain := make(chan struct{})
+
+	batcher, err := newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:    100,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, func(context.Context, *wrappedExporter, plog.Logs, string) error {
+		return nil
+	}, withLogBatcherOnBackendRemoved(func(_ context.Context, _ string, logs plog.Logs, _, _ int) error {
+		if logs.LogRecordCount() > 0 {
+			rerouted <- struct{}{}
+		}
+		return nil
+	}))
+	require.NoError(t, err)
+	defer batcher.telemetry.shutdown()
+
+	backend := &backendLogBatcher{
+		endpoint:  "endpoint-1:4317",
+		logger:    ts.Logger,
+		settings:  batcher.settings,
+		telemetry: batcher.telemetry,
+		requests:  make(chan logBatcherRequest, 1),
+		done:      make(chan struct{}),
+	}
+	backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: simpleLogs()}
+
+	batcher.mu.Lock()
+	batcher.backends[backend.endpoint] = backend
+	batcher.mu.Unlock()
+
+	go func() {
+		<-allowDrain
+		<-backend.requests
+		req := <-backend.requests
+		if req.kind == logBatcherRequestDrainAndStop {
+			req.drain <- logBatcherDrainResult{logs: simpleLogs(), records: 1, bytes: 1}
+			close(backend.done)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+
+	err = batcher.Remove(ctx, backend.endpoint, newWrappedExporter(newNopMockLogsExporter(), backend.endpoint))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	close(allowDrain)
+	require.Eventually(t, func() bool {
+		select {
+		case <-backend.done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		select {
+		case <-rerouted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}
+
 func newTestLogsExporter(
 	t *testing.T,
 	ts exporter.Settings,

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -307,7 +307,7 @@ func TestLogBatcherReroutesRemovedBackendFlushToReplacementEndpoint(t *testing.T
 	}, func(ctx context.Context, exp *wrappedExporter, ld plog.Logs, reason string) error {
 		_ = reason
 		return exp.ConsumeLogs(ctx, ld)
-	}, withLogBatcherOnBackendRemoved(func(ctx context.Context, _ string, logs plog.Logs, _ int, _ int) error {
+	}, withLogBatcherOnBackendRemoved(func(ctx context.Context, _ string, logs plog.Logs, _, _ int) error {
 		return endpoint2Exp.ConsumeLogs(ctx, logs)
 	}))
 	require.NoError(t, err)
@@ -353,7 +353,7 @@ func TestLogBatcherRemoveEmitsReroutedMetric(t *testing.T) {
 	}, func(ctx context.Context, exp *wrappedExporter, ld plog.Logs, reason string) error {
 		_ = reason
 		return exp.ConsumeLogs(ctx, ld)
-	}, withLogBatcherOnBackendRemoved(func(ctx context.Context, _ string, logs plog.Logs, _ int, _ int) error {
+	}, withLogBatcherOnBackendRemoved(func(ctx context.Context, _ string, logs plog.Logs, _, _ int) error {
 		return endpoint2Exp.ConsumeLogs(ctx, logs)
 	}))
 	require.NoError(t, err)
@@ -407,7 +407,7 @@ func TestLogBatcherBackgroundRemovalCleanupReroutesPendingLogs(t *testing.T) {
 	}, func(ctx context.Context, exp *wrappedExporter, ld plog.Logs, reason string) error {
 		_ = reason
 		return exp.ConsumeLogs(ctx, ld)
-	}, withLogBatcherOnBackendRemoved(func(ctx context.Context, _ string, logs plog.Logs, _ int, _ int) error {
+	}, withLogBatcherOnBackendRemoved(func(ctx context.Context, _ string, logs plog.Logs, _, _ int) error {
 		return endpoint2Exp.ConsumeLogs(ctx, logs)
 	}))
 	require.NoError(t, err)

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -5,6 +5,7 @@ package loadbalancingexporter
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -13,11 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 )
@@ -267,61 +270,148 @@ func TestLogBatcherRemoveRespectsContextWhileWaitingForInflight(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
-func TestLogBatcherFlushesRemovedBackendToOldExporter(t *testing.T) {
-	ts, tb := getTelemetryAssets(t)
+func TestLogBatcherReroutesRemovedBackendFlushToReplacementEndpoint(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
 	var endpoint1Calls atomic.Int64
 	var endpoint2Calls atomic.Int64
-	endpoints := []string{"endpoint-1"}
 
-	p, lb := newTestLogsExporter(t, ts, tb, &Config{
-		Resolver: ResolverSettings{
-			Static: configoptional.Some(StaticResolver{Hostnames: []string{"endpoint-1"}}),
-		},
-	}, func(_ context.Context, endpoint string) (component.Component, error) {
-		switch endpoint {
-		case "endpoint-1:4317":
-			return newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
-				endpoint1Calls.Add(1)
-				return nil
-			}), nil
-		case "endpoint-2:4317":
-			return newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
-				endpoint2Calls.Add(1)
-				return nil
-			}), nil
-		default:
-			return newNopMockLogsExporter(), nil
-		}
-	})
+	endpoint1Exp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		endpoint1Calls.Add(1)
+		return errors.New(`rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.12.105.114:10418: connect: no route to host"`)
+	}), "endpoint-1:4317")
+	endpoint2Exp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		endpoint2Calls.Add(1)
+		return nil
+	}), "endpoint-2:4317")
 
-	lb.res = &mockResolver{
-		triggerCallbacks: true,
-		onResolve: func(_ context.Context) ([]string, error) {
-			return endpoints, nil
-		},
-	}
-	p.loadBalancer = lb
-	p.batcher, _ = newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+	var batcher *logBatcher
+	var err error
+	batcher, err = newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
 		maxRecords:    100,
 		maxBytes:      1 << 20,
 		flushInterval: time.Hour,
-	}, p.consumeBatch)
-	p.loadBalancer.onExporterRemove = func(ctx context.Context, endpoint string, exp *wrappedExporter) error {
-		return p.batcher.Remove(ctx, endpoint, exp)
-	}
-
-	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
-	defer func() { require.NoError(t, p.Shutdown(t.Context())) }()
-
-	require.NoError(t, p.ConsumeLogs(t.Context(), simpleLogs()))
-	endpoints = []string{"endpoint-2"}
-	_, err := lb.res.resolve(t.Context())
+	}, func(ctx context.Context, exp *wrappedExporter, ld plog.Logs, reason string) error {
+		_ = reason
+		return exp.ConsumeLogs(ctx, ld)
+	}, withLogBatcherOnBackendRemoved(func(ctx context.Context, _ string, logs plog.Logs, _ int, _ int) error {
+		return endpoint2Exp.ConsumeLogs(ctx, logs)
+	}))
 	require.NoError(t, err)
+	defer func() { require.NoError(t, batcher.Shutdown(t.Context())) }()
+
+	backend, err := batcher.acquireBackend("endpoint-1:4317", endpoint1Exp)
+	require.NoError(t, err)
+	backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: simpleLogs()}
+	backend.inflight.Done()
+
+	require.NoError(t, batcher.Remove(t.Context(), "endpoint-1:4317", endpoint1Exp))
+	require.Eventually(t, func() bool {
+		return endpoint2Calls.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, int64(0), endpoint1Calls.Load(), "removed backend drain should not flush against the stale exporter")
+	require.Equal(t, int64(1), endpoint2Calls.Load(), "removed backend drain should reroute pending logs to the replacement endpoint")
+}
+
+func TestLogBatcherRemoveEmitsReroutedMetric(t *testing.T) {
+	ctx := t.Context()
+	shutdownCtx := context.Background() //nolint:usetesting // Context must outlive test for cleanup
+	telemetry := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetry.Shutdown(shutdownCtx))
+	})
+
+	params := exportertest.NewNopSettings(metadata.Type)
+	params.TelemetrySettings = telemetry.NewTelemetrySettings()
+
+	endpoint1Exp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		return errors.New(`rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 10.12.105.114:10418: connect: no route to host"`)
+	}), "endpoint-1:4317")
+	endpoint2Exp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		return nil
+	}), "endpoint-2:4317")
+
+	var batcher *logBatcher
+	var err error
+	batcher, err = newLogBatcher(params.Logger, params.TelemetrySettings, logBatcherSettings{
+		maxRecords:    100,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, func(ctx context.Context, exp *wrappedExporter, ld plog.Logs, reason string) error {
+		_ = reason
+		return exp.ConsumeLogs(ctx, ld)
+	}, withLogBatcherOnBackendRemoved(func(ctx context.Context, _ string, logs plog.Logs, _ int, _ int) error {
+		return endpoint2Exp.ConsumeLogs(ctx, logs)
+	}))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, batcher.Shutdown(ctx)) }()
+
+	backend, err := batcher.acquireBackend("endpoint-1:4317", endpoint1Exp)
+	require.NoError(t, err)
+	backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: simpleLogs()}
+	backend.inflight.Done()
+
+	require.NoError(t, batcher.Remove(ctx, "endpoint-1:4317", endpoint1Exp))
+	require.Eventually(t, func() bool {
+		metric, metricErr := telemetry.GetMetric("otelcol_loadbalancer_log_batch_removed_backend_total")
+		if metricErr != nil {
+			return false
+		}
+		sum, ok := metric.Data.(metricdata.Sum[int64])
+		if !ok {
+			return false
+		}
+		for _, dp := range sum.DataPoints {
+			outcome, ok := dp.Attributes.Value(attribute.Key("outcome"))
+			if ok && outcome.AsString() == "rerouted" && dp.Value == 1 {
+				return true
+			}
+		}
+		return false
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestLogBatcherBackgroundRemovalCleanupReroutesPendingLogs(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	var endpoint1Calls atomic.Int64
+	var endpoint2Calls atomic.Int64
+
+	endpoint1Exp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		endpoint1Calls.Add(1)
+		return nil
+	}), "endpoint-1:4317")
+	endpoint2Exp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+		endpoint2Calls.Add(1)
+		return nil
+	}), "endpoint-2:4317")
+
+	var batcher *logBatcher
+	var err error
+	batcher, err = newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:    100,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, func(ctx context.Context, exp *wrappedExporter, ld plog.Logs, reason string) error {
+		_ = reason
+		return exp.ConsumeLogs(ctx, ld)
+	}, withLogBatcherOnBackendRemoved(func(ctx context.Context, _ string, logs plog.Logs, _ int, _ int) error {
+		return endpoint2Exp.ConsumeLogs(ctx, logs)
+	}))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, batcher.Shutdown(t.Context())) }()
+
+	backend, err := batcher.acquireBackend("endpoint-1:4317", endpoint1Exp)
+	require.NoError(t, err)
+	backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: simpleLogs()}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	require.ErrorIs(t, batcher.Remove(ctx, "endpoint-1:4317", endpoint1Exp), context.Canceled)
+	backend.inflight.Done()
 
 	require.Eventually(t, func() bool {
-		return endpoint1Calls.Load() == 1
+		return endpoint2Calls.Load() == 1
 	}, time.Second, 10*time.Millisecond)
-	assert.Zero(t, endpoint2Calls.Load())
+	require.Zero(t, endpoint1Calls.Load())
 }
 
 func newTestLogsExporter(

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -384,6 +384,57 @@ func TestLogBatcherRemoveEmitsReroutedMetric(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestLogBatcherRemoveEmitsPartialMetric(t *testing.T) {
+	ctx := t.Context()
+	shutdownCtx := context.Background() //nolint:usetesting // Context must outlive test for cleanup
+	telemetry := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetry.Shutdown(shutdownCtx))
+	})
+
+	params := exportertest.NewNopSettings(metadata.Type)
+	params.TelemetrySettings = telemetry.NewTelemetrySettings()
+
+	endpoint1Exp := newWrappedExporter(newNopMockLogsExporter(), "endpoint-1:4317")
+
+	batcher, err := newLogBatcher(params.Logger, params.TelemetrySettings, logBatcherSettings{
+		maxRecords:    100,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, func(ctx context.Context, exp *wrappedExporter, ld plog.Logs, reason string) error {
+		_ = reason
+		return exp.ConsumeLogs(ctx, ld)
+	}, withLogBatcherOnBackendRemoved(func(context.Context, string, plog.Logs, int, int) error {
+		return errLogBatcherRemovedBackendPartial
+	}))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, batcher.Shutdown(ctx)) }()
+
+	backend, err := batcher.acquireBackend("endpoint-1:4317", endpoint1Exp)
+	require.NoError(t, err)
+	backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: simpleLogs()}
+	backend.inflight.Done()
+
+	require.NoError(t, batcher.Remove(ctx, "endpoint-1:4317", endpoint1Exp))
+	require.Eventually(t, func() bool {
+		metric, metricErr := telemetry.GetMetric("otelcol_loadbalancer_log_batch_removed_backend_total")
+		if metricErr != nil {
+			return false
+		}
+		sum, ok := metric.Data.(metricdata.Sum[int64])
+		if !ok {
+			return false
+		}
+		for _, dp := range sum.DataPoints {
+			outcome, ok := dp.Attributes.Value(attribute.Key("outcome"))
+			if ok && outcome.AsString() == removedBackendOutcomePartial && dp.Value == 1 {
+				return true
+			}
+		}
+		return false
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestLogBatcherBackgroundRemovalCleanupReroutesPendingLogs(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	var endpoint1Calls atomic.Int64

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -270,6 +270,20 @@ func TestLogBatcherRemoveRespectsContextWhileWaitingForInflight(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestBackendLogBatcherStopAndDrainRespectsContextWhileQueueIsFull(t *testing.T) {
+	backend := &backendLogBatcher{
+		requests: make(chan logBatcherRequest, 1),
+		done:     make(chan struct{}),
+	}
+	backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: simpleLogs()}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := backend.stopAndDrain(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestLogBatcherReroutesRemovedBackendFlushToReplacementEndpoint(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	var endpoint1Calls atomic.Int64

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"math/rand/v2"
+	"slices"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -68,6 +69,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 				flushInterval: cfg.(*Config).LogBatcher.FlushInterval,
 			},
 			logExporter.consumeBatch,
+			withLogBatcherOnBackendRemoved(logExporter.handleRemovedBackendLogs),
 		)
 		if err != nil {
 			return nil, err
@@ -193,6 +195,45 @@ func (e *logExporterImp) enqueueEndpointBatches(ctx context.Context, batches map
 	return errs
 }
 
+func (e *logExporterImp) handleRemovedBackendLogs(ctx context.Context, removedEndpoint string, drained plog.Logs, records int, bytes int) error {
+	reroutedBatches, groupErr := e.groupLogsByEndpoint(drained)
+	if hasEndpointBatch(reroutedBatches, removedEndpoint) {
+		groupErr = errors.Join(groupErr, errors.New("removed backend reroute did not escape removed endpoint"))
+	}
+	if len(reroutedBatches) == 0 {
+		if groupErr != nil {
+			e.logger.Warn("failed to reroute removed backend batch",
+				zap.String("removed_endpoint", removedEndpoint),
+				zap.Int("records", records),
+				zap.Int("bytes", bytes),
+				zap.Error(groupErr),
+			)
+			return groupErr
+		}
+		return nil
+	}
+
+	err := errors.Join(groupErr, e.enqueueEndpointBatches(ctx, reroutedBatches, true))
+	if err != nil {
+		e.logger.Warn("failed to reroute removed backend batch",
+			zap.String("removed_endpoint", removedEndpoint),
+			zap.Int("records", records),
+			zap.Int("bytes", bytes),
+			zap.Strings("target_endpoints", endpointBatchKeys(reroutedBatches)),
+			zap.Error(err),
+		)
+		return err
+	}
+
+	e.logger.Info("rerouted removed backend batch",
+		zap.String("removed_endpoint", removedEndpoint),
+		zap.Int("records", records),
+		zap.Int("bytes", bytes),
+		zap.Strings("target_endpoints", endpointBatchKeys(reroutedBatches)),
+	)
+	return nil
+}
+
 func (e *logExporterImp) consumeLog(ctx context.Context, ld plog.Logs) error {
 	traceID := traceIDFromLogs(ld)
 	balancingKey := traceID
@@ -271,6 +312,20 @@ func hasAlternativeEndpoint(batches map[string]*endpointBatch, failedEndpoint st
 		}
 	}
 	return false
+}
+
+func hasEndpointBatch(batches map[string]*endpointBatch, endpoint string) bool {
+	_, ok := batches[endpointWithPort(endpoint)]
+	return ok
+}
+
+func endpointBatchKeys(batches map[string]*endpointBatch) []string {
+	keys := make([]string, 0, len(batches))
+	for endpoint := range batches {
+		keys = append(keys, endpoint)
+	}
+	slices.Sort(keys)
+	return keys
 }
 
 // insertLogRecord adds a log record into the destination plog.Logs, reusing

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -202,7 +202,7 @@ func (e *logExporterImp) handleRemovedBackendLogs(ctx context.Context, removedEn
 	}
 	if len(reroutedBatches) == 0 {
 		if groupErr != nil {
-			e.logger.Warn("failed to reroute removed backend batch",
+			e.logger.Error("failed to reroute removed backend batch",
 				zap.String("removed_endpoint", removedEndpoint),
 				zap.Int("records", records),
 				zap.Int("bytes", bytes),
@@ -215,7 +215,7 @@ func (e *logExporterImp) handleRemovedBackendLogs(ctx context.Context, removedEn
 
 	err := errors.Join(groupErr, e.enqueueEndpointBatches(ctx, reroutedBatches, true))
 	if err != nil {
-		e.logger.Warn("failed to reroute removed backend batch",
+		e.logger.Error("failed to reroute removed backend batch",
 			zap.String("removed_endpoint", removedEndpoint),
 			zap.Int("records", records),
 			zap.Int("bytes", bytes),

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -199,6 +199,7 @@ func (e *logExporterImp) handleRemovedBackendLogs(ctx context.Context, removedEn
 	reroutedBatches, groupErr := e.groupLogsByEndpoint(drained)
 	if hasEndpointBatch(reroutedBatches, removedEndpoint) {
 		groupErr = errors.Join(groupErr, errors.New("removed backend reroute did not escape removed endpoint"))
+		delete(reroutedBatches, removedEndpoint)
 	}
 	if len(reroutedBatches) == 0 {
 		if groupErr != nil {

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -214,6 +214,9 @@ func (e *logExporterImp) retryRemovedBackendBatches(removedEndpoint string, batc
 	go func() {
 		err := e.enqueueEndpointBatches(context.Background(), retryBatches)
 		if err != nil {
+			if e.batcher != nil {
+				e.batcher.recordRemovedBackendOutcome(context.Background(), removedEndpoint, removedBackendOutcomeRetryFailed)
+			}
 			e.logger.Error("failed background retry for removed backend batch",
 				zap.String("removed_endpoint", removedEndpoint),
 				zap.Int("records", records),
@@ -224,6 +227,9 @@ func (e *logExporterImp) retryRemovedBackendBatches(removedEndpoint string, batc
 			return
 		}
 
+		if e.batcher != nil {
+			e.batcher.recordRemovedBackendOutcome(context.Background(), removedEndpoint, removedBackendOutcomeRetrySucceeded)
+		}
 		e.logger.Info("retried removed backend batch",
 			zap.String("removed_endpoint", removedEndpoint),
 			zap.Int("records", records),
@@ -285,14 +291,15 @@ func (e *logExporterImp) finishRemovedBackendReroute(ctx context.Context, remove
 	}
 
 	if removedEndpointErr != nil {
-		e.logger.Warn("partially rerouted removed backend batch",
+		err = errors.Join(errLogBatcherRemovedBackendPartial, removedEndpointErr)
+		e.logger.Error("partially rerouted removed backend batch",
 			zap.String("removed_endpoint", removedEndpoint),
 			zap.Int("records", records),
 			zap.Int("bytes", bytes),
 			zap.Strings("target_endpoints", endpointBatchKeys(reroutedBatches)),
-			zap.Error(removedEndpointErr),
+			zap.Error(err),
 		)
-		return nil
+		return err
 	}
 
 	e.logger.Info("rerouted removed backend batch",

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -196,10 +196,11 @@ func (e *logExporterImp) enqueueEndpointBatches(ctx context.Context, batches map
 }
 
 func (e *logExporterImp) handleRemovedBackendLogs(ctx context.Context, removedEndpoint string, drained plog.Logs, records, bytes int) error {
+	normalizedRemovedEndpoint := endpointWithPort(removedEndpoint)
 	reroutedBatches, groupErr := e.groupLogsByEndpoint(drained)
-	if hasEndpointBatch(reroutedBatches, removedEndpoint) {
+	if hasEndpointBatch(reroutedBatches, normalizedRemovedEndpoint) {
 		groupErr = errors.Join(groupErr, errors.New("removed backend reroute did not escape removed endpoint"))
-		delete(reroutedBatches, removedEndpoint)
+		delete(reroutedBatches, normalizedRemovedEndpoint)
 	}
 	if len(reroutedBatches) == 0 {
 		if groupErr != nil {

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -195,7 +195,7 @@ func (e *logExporterImp) enqueueEndpointBatches(ctx context.Context, batches map
 	return errs
 }
 
-func (e *logExporterImp) handleRemovedBackendLogs(ctx context.Context, removedEndpoint string, drained plog.Logs, records int, bytes int) error {
+func (e *logExporterImp) handleRemovedBackendLogs(ctx context.Context, removedEndpoint string, drained plog.Logs, records, bytes int) error {
 	reroutedBatches, groupErr := e.groupLogsByEndpoint(drained)
 	if hasEndpointBatch(reroutedBatches, removedEndpoint) {
 		groupErr = errors.Join(groupErr, errors.New("removed backend reroute did not escape removed endpoint"))

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -6,6 +6,7 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 import (
 	"context"
 	"errors"
+	"maps"
 	"math/rand/v2"
 	"slices"
 	"time"
@@ -130,7 +131,7 @@ type endpointBatch struct {
 // duplication that per-record wrapping would cause in the batcher.
 func (e *logExporterImp) consumeLogsBatched(ctx context.Context, ld plog.Logs) error {
 	batches, errs := e.groupLogsByEndpoint(ld)
-	return multierr.Append(errs, e.enqueueEndpointBatches(ctx, batches, true))
+	return multierr.Append(errs, e.enqueueEndpointBatches(ctx, batches))
 }
 
 func (e *logExporterImp) groupLogsByEndpoint(ld plog.Logs) (map[string]*endpointBatch, error) {
@@ -176,46 +177,102 @@ func (e *logExporterImp) groupLogsByEndpoint(ld plog.Logs) (map[string]*endpoint
 	return batches, errs
 }
 
-func (e *logExporterImp) enqueueEndpointBatches(ctx context.Context, batches map[string]*endpointBatch, retryOnStopping bool) error {
+func (e *logExporterImp) enqueueEndpointBatches(ctx context.Context, batches map[string]*endpointBatch) error {
+	_, err := e.enqueueEndpointBatchesDetailed(ctx, batches, true)
+	return err
+}
+
+func (e *logExporterImp) enqueueEndpointBatchesDetailed(ctx context.Context, batches map[string]*endpointBatch, retryOnStopping bool) (map[string]*endpointBatch, error) {
 	var errs error
+	failed := make(map[string]*endpointBatch)
 
 	for ep, batch := range batches {
 		err := e.batcher.Enqueue(ctx, ep, batch.exp, batch.logs)
 		if errors.Is(err, errLogBatcherExporterStopping) && retryOnStopping {
 			reroutedBatches, rerouteErr := e.groupLogsByEndpoint(batch.logs)
 			errs = multierr.Append(errs, rerouteErr)
-			errs = multierr.Append(errs, e.enqueueEndpointBatches(ctx, reroutedBatches, false))
+			rerouteFailed, rerouteEnqueueErr := e.enqueueEndpointBatchesDetailed(ctx, reroutedBatches, false)
+			maps.Copy(failed, rerouteFailed)
+			errs = multierr.Append(errs, rerouteEnqueueErr)
 			continue
 		}
 		if err != nil {
+			failed[ep] = batch
 			errs = multierr.Append(errs, err)
 		}
 	}
 
-	return errs
+	if len(failed) == 0 {
+		return nil, errs
+	}
+
+	return failed, errs
+}
+
+func (e *logExporterImp) retryRemovedBackendBatches(removedEndpoint string, batches map[string]*endpointBatch, records, bytes int) {
+	retryBatches := maps.Clone(batches)
+	go func() {
+		err := e.enqueueEndpointBatches(context.Background(), retryBatches)
+		if err != nil {
+			e.logger.Error("failed background retry for removed backend batch",
+				zap.String("removed_endpoint", removedEndpoint),
+				zap.Int("records", records),
+				zap.Int("bytes", bytes),
+				zap.Strings("target_endpoints", endpointBatchKeys(retryBatches)),
+				zap.Error(err),
+			)
+			return
+		}
+
+		e.logger.Info("retried removed backend batch",
+			zap.String("removed_endpoint", removedEndpoint),
+			zap.Int("records", records),
+			zap.Int("bytes", bytes),
+			zap.Strings("target_endpoints", endpointBatchKeys(retryBatches)),
+		)
+	}()
 }
 
 func (e *logExporterImp) handleRemovedBackendLogs(ctx context.Context, removedEndpoint string, drained plog.Logs, records, bytes int) error {
-	normalizedRemovedEndpoint := endpointWithPort(removedEndpoint)
 	reroutedBatches, groupErr := e.groupLogsByEndpoint(drained)
+	return e.finishRemovedBackendReroute(ctx, removedEndpoint, reroutedBatches, records, bytes, groupErr)
+}
+
+func (e *logExporterImp) finishRemovedBackendReroute(ctx context.Context, removedEndpoint string, reroutedBatches map[string]*endpointBatch, records, bytes int, groupErr error) error {
+	normalizedRemovedEndpoint := endpointWithPort(removedEndpoint)
+	var removedEndpointErr error
 	if hasEndpointBatch(reroutedBatches, normalizedRemovedEndpoint) {
-		groupErr = errors.Join(groupErr, errors.New("removed backend reroute did not escape removed endpoint"))
+		removedEndpointErr = errors.New("removed backend reroute did not escape removed endpoint")
 		delete(reroutedBatches, normalizedRemovedEndpoint)
 	}
 	if len(reroutedBatches) == 0 {
-		if groupErr != nil {
+		err := errors.Join(groupErr, removedEndpointErr)
+		if err != nil {
 			e.logger.Error("failed to reroute removed backend batch",
 				zap.String("removed_endpoint", removedEndpoint),
 				zap.Int("records", records),
 				zap.Int("bytes", bytes),
-				zap.Error(groupErr),
+				zap.Error(err),
 			)
-			return groupErr
+			return err
 		}
 		return nil
 	}
 
-	err := errors.Join(groupErr, e.enqueueEndpointBatches(ctx, reroutedBatches, true))
+	failedBatches, enqueueErr := e.enqueueEndpointBatchesDetailed(ctx, reroutedBatches, true)
+	if len(failedBatches) > 0 {
+		e.retryRemovedBackendBatches(removedEndpoint, failedBatches, records, bytes)
+		e.logger.Warn("scheduled background retry for removed backend batch",
+			zap.String("removed_endpoint", removedEndpoint),
+			zap.Int("records", records),
+			zap.Int("bytes", bytes),
+			zap.Strings("target_endpoints", endpointBatchKeys(failedBatches)),
+			zap.Error(enqueueErr),
+		)
+		enqueueErr = nil
+	}
+
+	err := errors.Join(groupErr, enqueueErr)
 	if err != nil {
 		e.logger.Error("failed to reroute removed backend batch",
 			zap.String("removed_endpoint", removedEndpoint),
@@ -225,6 +282,17 @@ func (e *logExporterImp) handleRemovedBackendLogs(ctx context.Context, removedEn
 			zap.Error(err),
 		)
 		return err
+	}
+
+	if removedEndpointErr != nil {
+		e.logger.Warn("partially rerouted removed backend batch",
+			zap.String("removed_endpoint", removedEndpoint),
+			zap.Int("records", records),
+			zap.Int("bytes", bytes),
+			zap.Strings("target_endpoints", endpointBatchKeys(reroutedBatches)),
+			zap.Error(removedEndpointErr),
+		)
+		return nil
 	}
 
 	e.logger.Info("rerouted removed backend batch",

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -191,7 +191,7 @@ func TestConsumeLogsEmitsOnlyParentExporterMetrics(t *testing.T) {
 		maxRecords:    1,
 		maxBytes:      1 << 20,
 		flushInterval: time.Hour,
-	}, logsExporter.consumeBatch)
+	}, logsExporter.consumeBatch, withLogBatcherOnBackendRemoved(logsExporter.handleRemovedBackendLogs))
 	require.NoError(t, err)
 	logsExporter.loadBalancer.onExporterRemove = func(ctx context.Context, endpoint string, exp *wrappedExporter) error {
 		return logsExporter.batcher.Remove(ctx, endpoint, exp)
@@ -474,7 +474,7 @@ func TestEnqueueEndpointBatchesReroutesStoppingExporterOnce(t *testing.T) {
 		maxRecords:    1,
 		maxBytes:      1 << 20,
 		flushInterval: time.Hour,
-	}, p.consumeBatch)
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, p.batcher.Shutdown(t.Context()))
@@ -514,7 +514,7 @@ func TestEnqueueEndpointBatchesReturnsStoppingErrorAfterSecondCollision(t *testi
 		maxRecords:    1,
 		maxBytes:      1 << 20,
 		flushInterval: time.Hour,
-	}, p.consumeBatch)
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, p.batcher.Shutdown(t.Context()))
@@ -556,7 +556,7 @@ func TestConsumeBatchReroutesTransportFailureToHealthyEndpoint(t *testing.T) {
 		maxRecords:    1,
 		maxBytes:      1 << 20,
 		flushInterval: time.Hour,
-	}, p.consumeBatch)
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, p.batcher.Shutdown(t.Context()))
@@ -627,6 +627,42 @@ func TestFinishTransportFailedReroutePreservesRecoverableLogsOnPartialGroupingEr
 	require.Equal(t, int64(1), logsConsumed.Load())
 }
 
+func TestHandleRemovedBackendLogsReroutesToCurrentEndpoints(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	logsConsumed := atomic.Int64{}
+	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), nil, tb)
+	require.NoError(t, err)
+
+	liveExp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+		logsConsumed.Add(int64(ld.LogRecordCount()))
+		return nil
+	}), "endpoint-2:4317")
+
+	lb.ring = newHashRing([]string{"endpoint-2"})
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-2:4317": liveExp,
+	}
+
+	p, err := newLogsExporter(ts, simpleConfig())
+	require.NoError(t, err)
+	p.loadBalancer = lb
+	p.batcher, err = newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:    1,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.batcher.Shutdown(t.Context()))
+	}()
+
+	err = p.handleRemovedBackendLogs(t.Context(), "endpoint-1:4317", simpleLogs(), 1, 1)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return logsConsumed.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestInsertLogRecordKeepsDistinctDroppedAttributeCounts(t *testing.T) {
 	dest := plog.NewLogs()
 
@@ -688,7 +724,7 @@ func TestConsumeLogs_ConcurrentResolverChange(t *testing.T) {
 		maxRecords:    1,
 		maxBytes:      1 << 20,
 		flushInterval: time.Hour,
-	}, p.consumeBatch)
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
 	require.NoError(t, err)
 	p.loadBalancer.onExporterRemove = func(ctx context.Context, endpoint string, exp *wrappedExporter) error {
 		return p.batcher.Remove(ctx, endpoint, exp)
@@ -777,7 +813,7 @@ func TestRollingUpdatesWhenConsumeLogs(t *testing.T) {
 		maxRecords:    1,
 		maxBytes:      1 << 20,
 		flushInterval: time.Hour,
-	}, p.consumeBatch)
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
 	require.NoError(t, err)
 	p.loadBalancer.onExporterRemove = func(ctx context.Context, endpoint string, exp *wrappedExporter) error {
 		return p.batcher.Remove(ctx, endpoint, exp)

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -692,7 +692,7 @@ func TestHandleRemovedBackendLogsNeverReenqueuesRemovedEndpoint(t *testing.T) {
 		require.NoError(t, p.batcher.Shutdown(t.Context()))
 	}()
 
-	err = p.handleRemovedBackendLogs(t.Context(), "endpoint-1:4317", simpleLogs(), 1, 1)
+	err = p.handleRemovedBackendLogs(t.Context(), "endpoint-1", simpleLogs(), 1, 1)
 	require.ErrorContains(t, err, "removed backend reroute did not escape removed endpoint")
 	require.Never(t, func() bool {
 		return logsConsumed.Load() > 0

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -485,7 +485,7 @@ func TestEnqueueEndpointBatchesReroutesStoppingExporterOnce(t *testing.T) {
 			logs: simpleLogs(),
 			exp:  stoppingExp,
 		},
-	}, true)
+	})
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		return logsConsumed.Load() == 1
@@ -525,7 +525,7 @@ func TestEnqueueEndpointBatchesReturnsStoppingErrorAfterSecondCollision(t *testi
 			logs: simpleLogs(),
 			exp:  initialExp,
 		},
-	}, true)
+	})
 	require.ErrorIs(t, err, errLogBatcherExporterStopping)
 }
 
@@ -567,7 +567,7 @@ func TestConsumeBatchReroutesTransportFailureToHealthyEndpoint(t *testing.T) {
 			logs: simpleLogWithID(findTraceIDForEndpoint(t, lb.ring, "endpoint-1")),
 			exp:  failingExp,
 		},
-	}, true)
+	})
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		return logsConsumed.Load() == 1
@@ -697,6 +697,87 @@ func TestHandleRemovedBackendLogsNeverReenqueuesRemovedEndpoint(t *testing.T) {
 	require.Never(t, func() bool {
 		return logsConsumed.Load() > 0
 	}, 200*time.Millisecond, 10*time.Millisecond, "removed backend guard must drop the self-rerouted batch")
+}
+
+func TestHandleRemovedBackendLogsDoesNotFailAfterDroppingRemovedEndpointBatch(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	logsConsumed := atomic.Int64{}
+
+	removedExp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+		logsConsumed.Add(int64(ld.LogRecordCount()) * 10)
+		return nil
+	}), "endpoint-1:4317")
+	liveExp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+		logsConsumed.Add(int64(ld.LogRecordCount()))
+		return nil
+	}), "endpoint-2:4317")
+
+	p, err := newLogsExporter(ts, simpleConfig())
+	require.NoError(t, err)
+	p.batcher, err = newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:    1,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.batcher.Shutdown(t.Context()))
+	}()
+
+	err = p.finishRemovedBackendReroute(t.Context(), "endpoint-1:4317", map[string]*endpointBatch{
+		"endpoint-1:4317": {
+			logs: simpleLogs(),
+			exp:  removedExp,
+		},
+		"endpoint-2:4317": {
+			logs: simpleLogs(),
+			exp:  liveExp,
+		},
+	}, 2, 2, nil)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return logsConsumed.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Equal(t, int64(1), logsConsumed.Load(), "only the live-endpoint record should be rerouted")
+}
+
+func TestHandleRemovedBackendLogsRetriesCanceledEnqueueInBackground(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	logsConsumed := atomic.Int64{}
+	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), nil, tb)
+	require.NoError(t, err)
+
+	liveExp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+		logsConsumed.Add(int64(ld.LogRecordCount()))
+		return nil
+	}), "endpoint-2:4317")
+
+	lb.ring = newHashRing([]string{"endpoint-2"})
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-2:4317": liveExp,
+	}
+
+	p, err := newLogsExporter(ts, simpleConfig())
+	require.NoError(t, err)
+	p.loadBalancer = lb
+	p.batcher, err = newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:    1,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.batcher.Shutdown(t.Context()))
+	}()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err = p.handleRemovedBackendLogs(ctx, "endpoint-1:4317", simpleLogs(), 1, 1)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return logsConsumed.Load() == 1
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestInsertLogRecordKeepsDistinctDroppedAttributeCounts(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -699,7 +699,7 @@ func TestHandleRemovedBackendLogsNeverReenqueuesRemovedEndpoint(t *testing.T) {
 	}, 200*time.Millisecond, 10*time.Millisecond, "removed backend guard must drop the self-rerouted batch")
 }
 
-func TestHandleRemovedBackendLogsDoesNotFailAfterDroppingRemovedEndpointBatch(t *testing.T) {
+func TestHandleRemovedBackendLogsReturnsPartialErrorAfterDroppingRemovedEndpointBatch(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	logsConsumed := atomic.Int64{}
 
@@ -734,7 +734,7 @@ func TestHandleRemovedBackendLogsDoesNotFailAfterDroppingRemovedEndpointBatch(t 
 			exp:  liveExp,
 		},
 	}, 2, 2, nil)
-	require.NoError(t, err)
+	require.ErrorIs(t, err, errLogBatcherRemovedBackendPartial)
 	require.Eventually(t, func() bool {
 		return logsConsumed.Load() == 1
 	}, time.Second, 10*time.Millisecond)
@@ -778,6 +778,75 @@ func TestHandleRemovedBackendLogsRetriesCanceledEnqueueInBackground(t *testing.T
 	require.Eventually(t, func() bool {
 		return logsConsumed.Load() == 1
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestRetryRemovedBackendBatchesRecordsRetrySucceededMetric(t *testing.T) {
+	ctx := t.Context()
+	shutdownCtx := context.Background() //nolint:usetesting // Context must outlive test for cleanup
+	telemetry := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetry.Shutdown(shutdownCtx))
+	})
+
+	params := exportertest.NewNopSettings(metadata.Type)
+	params.TelemetrySettings = telemetry.NewTelemetrySettings()
+	tb, err := metadata.NewTelemetryBuilder(params.TelemetrySettings)
+	require.NoError(t, err)
+
+	logsConsumed := atomic.Int64{}
+	lb, err := newLoadBalancer(params.Logger, simpleConfig(), nil, tb)
+	require.NoError(t, err)
+
+	liveExp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+		logsConsumed.Add(int64(ld.LogRecordCount()))
+		return nil
+	}), "endpoint-2:4317")
+
+	lb.ring = newHashRing([]string{"endpoint-2"})
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-2:4317": liveExp,
+	}
+
+	p, err := newLogsExporter(params, simpleConfig())
+	require.NoError(t, err)
+	p.loadBalancer = lb
+	p.batcher, err = newLogBatcher(params.Logger, params.TelemetrySettings, logBatcherSettings{
+		maxRecords:    1,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.batcher.Shutdown(ctx))
+	}()
+
+	p.retryRemovedBackendBatches("endpoint-1:4317", map[string]*endpointBatch{
+		"endpoint-2:4317": {
+			logs: simpleLogs(),
+			exp:  liveExp,
+		},
+	}, 1, 1)
+
+	require.Eventually(t, func() bool {
+		return logsConsumed.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		metric, metricErr := telemetry.GetMetric("otelcol_loadbalancer_log_batch_removed_backend_total")
+		if metricErr != nil {
+			return false
+		}
+		sum, ok := metric.Data.(metricdata.Sum[int64])
+		if !ok {
+			return false
+		}
+		for _, dp := range sum.DataPoints {
+			outcome, ok := dp.Attributes.Value(attribute.Key("outcome"))
+			if ok && outcome.AsString() == removedBackendOutcomeRetrySucceeded && dp.Value == 1 {
+				return true
+			}
+		}
+		return false
+	}, 3*time.Second, 20*time.Millisecond)
 }
 
 func TestInsertLogRecordKeepsDistinctDroppedAttributeCounts(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -663,6 +663,42 @@ func TestHandleRemovedBackendLogsReroutesToCurrentEndpoints(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestHandleRemovedBackendLogsNeverReenqueuesRemovedEndpoint(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	logsConsumed := atomic.Int64{}
+	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), nil, tb)
+	require.NoError(t, err)
+
+	removedExp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+		logsConsumed.Add(int64(ld.LogRecordCount()))
+		return nil
+	}), "endpoint-1:4317")
+
+	lb.ring = newHashRing([]string{"endpoint-1"})
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-1:4317": removedExp,
+	}
+
+	p, err := newLogsExporter(ts, simpleConfig())
+	require.NoError(t, err)
+	p.loadBalancer = lb
+	p.batcher, err = newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:    1,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, p.consumeBatch, withLogBatcherOnBackendRemoved(p.handleRemovedBackendLogs))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.batcher.Shutdown(t.Context()))
+	}()
+
+	err = p.handleRemovedBackendLogs(t.Context(), "endpoint-1:4317", simpleLogs(), 1, 1)
+	require.ErrorContains(t, err, "removed backend reroute did not escape removed endpoint")
+	require.Never(t, func() bool {
+		return logsConsumed.Load() > 0
+	}, 200*time.Millisecond, 10*time.Millisecond, "removed backend guard must drop the self-rerouted batch")
+}
+
 func TestInsertLogRecordKeepsDistinctDroppedAttributeCounts(t *testing.T) {
 	dest := plog.NewLogs()
 


### PR DESCRIPTION
loadbalancingexporter: reroute removed-backend log batches

Reroutes pending log batches away from removed backends before the stale exporter is drained. Adds direct and async regression coverage plus removed-backend telemetry.

Description
- replace resolver-change removal flushes with a drain-and-reroute callback path
- re-enqueue removed-backend logs through the current ring instead of the stale exporter
- add direct, async-cleanup, regroup, and metric regression tests

Refs: SAW-6849

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes log-batcher removal behavior to drain and reroute buffered logs instead of flushing to a stale exporter, adding background retries and new metrics; this affects log delivery during backend churn and introduces new async paths that could impact correctness under load.
> 
> **Overview**
> Prevents `loadbalancingexporter` from flushing pending log batches to a backend that has been removed from the resolver/ring by adding a *drain-and-reroute* path on backend removal.
> 
> `logBatcher` now supports an `onBackendRemoved` callback (via `withLogBatcherOnBackendRemoved`) that drains buffered logs (`DrainAndStop`) and hands them back to the exporter to be regrouped and re-enqueued against the *current* endpoints; if removal/drain can’t complete in-time, it schedules background draining.
> 
> Adds removed-backend telemetry (`otelcol_loadbalancer_log_batch_removed_backend_*`) including outcome, drained records, and bytes, plus regression tests covering direct removal reroute, context/queue edge cases, partial reroutes (dropping self-rerouted records), and background retry success/failure. Also updates the local `otelcontribcol` builder `replaces` to pin `exporterhelper` to a Sawmills fork.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9363080a3c0766af26443691661be36d4836c291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reroutes pending log batches away from removed backends in `loadbalancingexporter` before exporter removal, with background retry and accurate “partial” outcome handling to avoid flushing to stale endpoints. Part of SAW-6849 to harden rollout‑time backend churn handling.

- **Bug Fixes**
  - Replace resolver-change “flush to old exporter” with a drain‑and‑reroute path; simplify the drain result type.
  - Never send drained logs to the removed endpoint; if regrouping maps back, drop those records and flag a `partial` outcome (error‑level log), while keeping other reroutes.
  - Honor stop‑and‑drain context cancellation; if stop/enqueue can’t proceed, schedule a background drain and later retry only the failed subset, recording `retry_succeeded`/`retry_failed`.
  - Harden guards around inflight waits and channel races during background cleanup.
  - Log reroute failures and partials at error level with removed endpoint and record/byte counts.

- **New Features**
  - Hook `withLogBatcherOnBackendRemoved` with `handleRemovedBackendLogs` to regroup and enqueue drained logs via the current ring; never re‑enqueue the removed endpoint.
  - Telemetry for removed‑backend drains: `otelcol_loadbalancer_log_batch_removed_backend_total` (by outcome), `..._records`, `..._bytes`.
  - Tests for direct removal, async/background cleanup and retry, regrouping, partial‑reroute reporting, metric emission, reroute to current endpoints, and “never re‑enqueue removed endpoint.”
  - Wire `go.opentelemetry.io/collector/exporter/exporterhelper` to `github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper` in `otelcontribcol` build.

<sup>Written for commit 9363080a3c0766af26443691661be36d4836c291. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

