### PR TITLE
loadbalancingexporter: disable child OTLP retries for log batcher

### DIFF
--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -72,6 +72,16 @@ func buildExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
 	return oCfg
 }
 
+func buildLogsExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
+	oCfg := buildExporterConfig(cfg, endpoint)
+	if cfg.LogBatcher.Enabled {
+		oCfg.QueueConfig.Enabled = false
+		oCfg.RetryConfig.Enabled = false
+	}
+
+	return oCfg
+}
+
 func buildExporterSettings(typ component.Type, params exporter.Settings, endpoint string) exporter.Settings {
 	if name := params.ID.Name(); name != "" {
 		params.ID = component.NewIDWithName(typ, name)

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,6 +112,62 @@ func TestBuildExporterConfig(t *testing.T) {
 	assert.Equal(t, defaultCfg.TimeoutConfig, exporterCfg.TimeoutConfig)
 	assert.Equal(t, defaultCfg.QueueConfig, exporterCfg.QueueConfig)
 	assert.Equal(t, defaultCfg.RetryConfig, exporterCfg.RetryConfig)
+}
+
+func TestBuildLogsExporterConfigDisablesChildRetryAndQueueWhenLogBatcherOwnsReroute(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.LogBatcher.Enabled = true
+	cfg.Protocol.OTLP.QueueConfig = exporterhelper.NewDefaultQueueConfig()
+	cfg.Protocol.OTLP.QueueConfig.Enabled = true
+	cfg.Protocol.OTLP.QueueConfig.QueueSize = 321
+	cfg.Protocol.OTLP.RetryConfig = configretry.NewDefaultBackOffConfig()
+	cfg.Protocol.OTLP.RetryConfig.Enabled = true
+	cfg.Protocol.OTLP.RetryConfig.MaxElapsedTime = 42 * time.Second
+
+	exporterCfg := buildLogsExporterConfig(cfg, "the-endpoint")
+
+	assert.Equal(t, "the-endpoint", exporterCfg.ClientConfig.Endpoint)
+	assert.False(t, exporterCfg.QueueConfig.Enabled)
+	assert.False(t, exporterCfg.RetryConfig.Enabled)
+}
+
+func TestBuildLogsExporterConfigPreservesChildRetryAndQueueWithoutLogBatcher(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Protocol.OTLP.QueueConfig = exporterhelper.NewDefaultQueueConfig()
+	cfg.Protocol.OTLP.QueueConfig.Enabled = true
+	cfg.Protocol.OTLP.QueueConfig.QueueSize = 321
+	cfg.Protocol.OTLP.RetryConfig = configretry.NewDefaultBackOffConfig()
+	cfg.Protocol.OTLP.RetryConfig.Enabled = true
+	cfg.Protocol.OTLP.RetryConfig.MaxElapsedTime = 42 * time.Second
+
+	exporterCfg := buildLogsExporterConfig(cfg, "the-endpoint")
+
+	assert.True(t, exporterCfg.QueueConfig.Enabled)
+	assert.EqualValues(t, 321, exporterCfg.QueueConfig.QueueSize)
+	assert.True(t, exporterCfg.RetryConfig.Enabled)
+	assert.Equal(t, 42*time.Second, exporterCfg.RetryConfig.MaxElapsedTime)
+}
+
+func TestBuildLogsExporterConfigPreservesParentQueueCompressionAndBatcherSettings(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.LogBatcher.Enabled = true
+	cfg.LogBatcher.MaxRecords = 123
+	cfg.LogBatcher.MaxBytes = 456
+	cfg.LogBatcher.FlushInterval = 789 * time.Millisecond
+	cfg.QueueSettings.QueueBatchConfig = exporterhelper.NewDefaultQueueConfig()
+	cfg.QueueSettings.QueueBatchConfig.Enabled = true
+	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
+	cfg.QueueSettings.CompressInMemory = true
+
+	exporterCfg := buildLogsExporterConfig(cfg, "the-endpoint")
+
+	assert.False(t, exporterCfg.QueueConfig.Enabled)
+	assert.Equal(t, QueuePayloadCompressionZstd, cfg.QueueSettings.PayloadCompression)
+	assert.True(t, cfg.QueueSettings.CompressInMemory)
+	assert.True(t, cfg.LogBatcher.Enabled)
+	assert.Equal(t, 123, cfg.LogBatcher.MaxRecords)
+	assert.Equal(t, 456, cfg.LogBatcher.MaxBytes)
+	assert.Equal(t, 789*time.Millisecond, cfg.LogBatcher.FlushInterval)
 }
 
 func TestBuildExporterSettings(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -44,7 +44,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 	}
 	exporterFactory := otlpexporter.NewFactory()
 	cfFunc := func(ctx context.Context, endpoint string) (component.Component, error) {
-		oCfg := buildExporterConfig(cfg.(*Config), endpoint)
+		oCfg := buildLogsExporterConfig(cfg.(*Config), endpoint)
 		oParams := buildExporterSettings(exporterFactory.Type(), params, endpoint)
 
 		return exporterFactory.CreateLogs(ctx, oParams, &oCfg)


### PR DESCRIPTION
loadbalancingexporter: Disable child OTLP retries for log batcher

Keeps retries and queueing at the loadbalancing exporter layer when log batching is enabled, so removed or unhealthy backends can be rerouted instead of retried by sticky child exporters.

- disable child OTLP retry and queue only for logs when `log_batcher` is enabled
- preserve parent queue compression and log batcher settings
- add regression coverage for the logs-only child exporter config path

Testing:
- go test ./...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes logs export behavior by disabling per-backend OTLP retry/queueing when `log_batcher.enabled=true`, which could affect delivery guarantees and backpressure behavior in log pipelines. Scope is limited to logs and is covered by new unit tests.
> 
> **Overview**
> When `log_batcher.enabled` is turned on, the logs path now builds a dedicated child OTLP exporter config that **disables the child exporter’s `sending_queue` and `retry_on_failure`**, keeping resilience/reroute decisions at the loadbalancing exporter layer.
> 
> Updates the logs exporter creation to use this new config builder, and adds regression tests to ensure child retry/queue are disabled only for logs with batching enabled while preserving parent queue compression and log batcher settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73fa451e3e8b139c6539cb2a9e7c1ddf7e80000c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable child OTLP retry and queue for logs when `log_batcher` is enabled in the `loadbalancingexporter`. This keeps retries/rerouting at the LB layer to avoid sticky child retries during backend churn (SAW-6849).

- **Bug Fixes**
  - For logs, build child `otlpexporter` with `RetryConfig.Enabled=false` and `QueueConfig.Enabled=false` when `log_batcher` is on.
  - Preserve parent queue compression and log batcher settings; behavior unchanged when `log_batcher` is off.
  - Add tests for disabled child retry/queue and preservation paths; traces/metrics unaffected.

<sup>Written for commit 73fa451e3e8b139c6539cb2a9e7c1ddf7e80000c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

