### PR TITLE
loadbalancingexporter: disable child OTLP retries for metrics

### DIFF
--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -82,6 +82,16 @@ func buildLogsExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
 	return oCfg
 }
 
+func buildMetricsExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
+	oCfg := buildExporterConfig(cfg, endpoint)
+	if cfg.Enabled {
+		oCfg.QueueConfig.Enabled = false
+		oCfg.RetryConfig.Enabled = false
+	}
+
+	return oCfg
+}
+
 func buildExporterSettings(typ component.Type, params exporter.Settings, endpoint string) exporter.Settings {
 	if name := params.ID.Name(); name != "" {
 		params.ID = component.NewIDWithName(typ, name)

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -170,6 +170,61 @@ func TestBuildLogsExporterConfigPreservesParentQueueCompressionAndBatcherSetting
 	assert.Equal(t, 789*time.Millisecond, cfg.LogBatcher.FlushInterval)
 }
 
+func TestBuildMetricsExporterConfigDisablesChildRetryAndQueueWhenParentRetryOwnsReroute(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Enabled = true
+	cfg.Protocol.OTLP.QueueConfig = exporterhelper.NewDefaultQueueConfig()
+	cfg.Protocol.OTLP.QueueConfig.Enabled = true
+	cfg.Protocol.OTLP.QueueConfig.QueueSize = 321
+	cfg.Protocol.OTLP.RetryConfig = configretry.NewDefaultBackOffConfig()
+	cfg.Protocol.OTLP.RetryConfig.Enabled = true
+	cfg.Protocol.OTLP.RetryConfig.MaxElapsedTime = 42 * time.Second
+
+	exporterCfg := buildMetricsExporterConfig(cfg, "the-endpoint")
+
+	assert.Equal(t, "the-endpoint", exporterCfg.ClientConfig.Endpoint)
+	assert.False(t, exporterCfg.QueueConfig.Enabled)
+	assert.False(t, exporterCfg.RetryConfig.Enabled)
+}
+
+func TestBuildMetricsExporterConfigPreservesChildRetryAndQueueWithoutParentRetry(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Enabled = false
+	cfg.Protocol.OTLP.QueueConfig = exporterhelper.NewDefaultQueueConfig()
+	cfg.Protocol.OTLP.QueueConfig.Enabled = true
+	cfg.Protocol.OTLP.QueueConfig.QueueSize = 321
+	cfg.Protocol.OTLP.RetryConfig = configretry.NewDefaultBackOffConfig()
+	cfg.Protocol.OTLP.RetryConfig.Enabled = true
+	cfg.Protocol.OTLP.RetryConfig.MaxElapsedTime = 42 * time.Second
+
+	exporterCfg := buildMetricsExporterConfig(cfg, "the-endpoint")
+
+	assert.True(t, exporterCfg.QueueConfig.Enabled)
+	assert.EqualValues(t, 321, exporterCfg.QueueConfig.QueueSize)
+	assert.True(t, exporterCfg.RetryConfig.Enabled)
+	assert.Equal(t, 42*time.Second, exporterCfg.RetryConfig.MaxElapsedTime)
+}
+
+func TestBuildMetricsExporterConfigPreservesParentQueueCompression(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.Enabled = true
+	cfg.QueueSettings.QueueBatchConfig = exporterhelper.NewDefaultQueueConfig()
+	cfg.QueueSettings.QueueBatchConfig.Enabled = true
+	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
+	cfg.QueueSettings.CompressInMemory = true
+	cfg.Protocol.OTLP.QueueConfig = exporterhelper.NewDefaultQueueConfig()
+	cfg.Protocol.OTLP.QueueConfig.Enabled = true
+	cfg.Protocol.OTLP.RetryConfig = configretry.NewDefaultBackOffConfig()
+	cfg.Protocol.OTLP.RetryConfig.Enabled = true
+
+	exporterCfg := buildMetricsExporterConfig(cfg, "the-endpoint")
+
+	assert.False(t, exporterCfg.QueueConfig.Enabled)
+	assert.False(t, exporterCfg.RetryConfig.Enabled)
+	assert.Equal(t, QueuePayloadCompressionZstd, cfg.QueueSettings.PayloadCompression)
+	assert.True(t, cfg.QueueSettings.CompressInMemory)
+}
+
 func TestBuildExporterSettings(t *testing.T) {
 	otlpType := otlpexporter.NewFactory().Type()
 

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -155,7 +155,7 @@ func TestBuildLogsExporterConfigPreservesParentQueueCompressionAndBatcherSetting
 	cfg.LogBatcher.MaxBytes = 456
 	cfg.LogBatcher.FlushInterval = 789 * time.Millisecond
 	cfg.QueueSettings.QueueBatchConfig = exporterhelper.NewDefaultQueueConfig()
-	cfg.QueueSettings.QueueBatchConfig.Enabled = true
+	cfg.QueueSettings.Enabled = true
 	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
 	cfg.QueueSettings.CompressInMemory = true
 
@@ -209,7 +209,7 @@ func TestBuildMetricsExporterConfigPreservesParentQueueCompression(t *testing.T)
 	cfg := createDefaultConfig().(*Config)
 	cfg.Enabled = true
 	cfg.QueueSettings.QueueBatchConfig = exporterhelper.NewDefaultQueueConfig()
-	cfg.QueueSettings.QueueBatchConfig.Enabled = true
+	cfg.QueueSettings.Enabled = true
 	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
 	cfg.QueueSettings.CompressInMemory = true
 	cfg.Protocol.OTLP.QueueConfig = exporterhelper.NewDefaultQueueConfig()

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -45,7 +45,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 	}
 	exporterFactory := otlpexporter.NewFactory()
 	cfFunc := func(ctx context.Context, endpoint string) (component.Component, error) {
-		oCfg := buildExporterConfig(cfg.(*Config), endpoint)
+		oCfg := buildMetricsExporterConfig(cfg.(*Config), endpoint)
 		oParams := buildExporterSettings(exporterFactory.Type(), params, endpoint)
 
 		return exporterFactory.CreateMetrics(ctx, oParams, &oCfg)


### PR DESCRIPTION
loadbalancingexporter: Disable child OTLP retries for metrics

Keep metrics on the same retry ownership model as the loadbalancing exporter when parent retry is enabled.

- add a metrics-specific child exporter config path
- disable child OTLP retry and queue when parent loadbalancing retry is enabled
- add regression tests that preserve parent queue compression and non-parent-retry behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry/queue ownership for metrics exports, which can affect delivery semantics and backpressure under failure conditions. Scope is limited to metrics child OTLP config and is covered by new regression tests.
> 
> **Overview**
> Aligns metrics behavior with the loadbalancing exporter’s retry model by adding `buildMetricsExporterConfig` and using it from `metrics_exporter.go`.
> 
> When the parent loadbalancing exporter retry is enabled, the metrics child OTLP exporter now has its `RetryConfig` and `QueueConfig` forcibly disabled to avoid double-retry/queueing; when parent retry is disabled, the child OTLP retry/queue settings are preserved. Tests were updated/added to cover these cases and ensure parent queue compression settings remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff525515682945e15211a7c866d66ab1f7beed6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable child OTLP retry and queue for metrics when the `loadbalancingexporter` owns retries. Aligns metrics with the parent retry model to avoid double retries and improve stability during backend churn (SAW-6849).

- **Bug Fixes**
  - Added `buildMetricsExporterConfig` to disable child `RetryConfig` and `QueueConfig` for metrics when parent LB retry is enabled; preserves settings when it’s not.
  - Updated `metrics_exporter.go` to use the metrics-specific builder; logs path unchanged.
  - Added tests to verify: child retry/queue disabled under parent-retry; behavior preserved without parent-retry; parent queue compression settings remain intact. Minor test config tweak (`QueueSettings.Enabled`) to satisfy exporter lint.

<sup>Written for commit ff525515682945e15211a7c866d66ab1f7beed6d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

