### PR TITLE
feat (lb): implement metric batching in LB

### DIFF
--- a/.chloggen/loadbalancingexporter-metric-batcher-retry-subset.yaml
+++ b/.chloggen/loadbalancingexporter-metric-batcher-retry-subset.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Improve metric batch enqueue retry behavior by avoiding blocking endpoint fanout and returning only failed metric subsets for retries.
+issues: [34]

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -71,10 +71,11 @@ type LogBatcherConfig struct {
 }
 
 type MetricBatcherConfig struct {
-	Enabled       bool          `mapstructure:"enabled"`
-	MaxDataPoints int           `mapstructure:"max_datapoints"`
-	MaxBytes      int           `mapstructure:"max_bytes"`
-	FlushInterval time.Duration `mapstructure:"flush_interval"`
+	Enabled                  bool          `mapstructure:"enabled"`
+	MaxDataPoints            int           `mapstructure:"max_datapoints"`
+	MaxBytes                 int           `mapstructure:"max_bytes"`
+	FlushInterval            time.Duration `mapstructure:"flush_interval"`
+	MaxRetryBufferMultiplier int           `mapstructure:"max_retry_buffer_multiplier"`
 }
 
 func (q *QueueSettings) Unmarshal(conf *confmap.Conf) error {
@@ -203,6 +204,9 @@ func (c MetricBatcherConfig) Validate() error {
 	}
 	if c.FlushInterval <= 0 {
 		return errors.New("metric_batcher.flush_interval must be greater than 0 when metric_batcher.enabled=true")
+	}
+	if c.MaxRetryBufferMultiplier <= 0 {
+		return errors.New("metric_batcher.max_retry_buffer_multiplier must be greater than 0 when metric_batcher.enabled=true")
 	}
 	return nil
 }

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -40,8 +40,9 @@ const (
 type Config struct {
 	TimeoutSettings           exporterhelper.TimeoutConfig `mapstructure:",squash"`
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
-	QueueSettings             QueueSettings    `mapstructure:"sending_queue"`
-	LogBatcher                LogBatcherConfig `mapstructure:"log_batcher"`
+	QueueSettings             QueueSettings       `mapstructure:"sending_queue"`
+	LogBatcher                LogBatcherConfig    `mapstructure:"log_batcher"`
+	MetricBatcher             MetricBatcherConfig `mapstructure:"metric_batcher"`
 
 	Protocol Protocol         `mapstructure:"protocol"`
 	Resolver ResolverSettings `mapstructure:"resolver"`
@@ -65,6 +66,13 @@ type QueueSettings struct {
 type LogBatcherConfig struct {
 	Enabled       bool          `mapstructure:"enabled"`
 	MaxRecords    int           `mapstructure:"max_records"`
+	MaxBytes      int           `mapstructure:"max_bytes"`
+	FlushInterval time.Duration `mapstructure:"flush_interval"`
+}
+
+type MetricBatcherConfig struct {
+	Enabled       bool          `mapstructure:"enabled"`
+	MaxDataPoints int           `mapstructure:"max_datapoints"`
 	MaxBytes      int           `mapstructure:"max_bytes"`
 	FlushInterval time.Duration `mapstructure:"flush_interval"`
 }
@@ -161,7 +169,10 @@ func (cfg *Config) Validate() error {
 	if err := cfg.QueueSettings.Validate(); err != nil {
 		return err
 	}
-	return cfg.LogBatcher.Validate()
+	if err := cfg.LogBatcher.Validate(); err != nil {
+		return err
+	}
+	return cfg.MetricBatcher.Validate()
 }
 
 func (c LogBatcherConfig) Validate() error {
@@ -176,6 +187,22 @@ func (c LogBatcherConfig) Validate() error {
 	}
 	if c.FlushInterval <= 0 {
 		return errors.New("log_batcher.flush_interval must be greater than 0 when log_batcher.enabled=true")
+	}
+	return nil
+}
+
+func (c MetricBatcherConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.MaxDataPoints <= 0 {
+		return errors.New("metric_batcher.max_datapoints must be greater than 0 when metric_batcher.enabled=true")
+	}
+	if c.MaxBytes <= 0 {
+		return errors.New("metric_batcher.max_bytes must be greater than 0 when metric_batcher.enabled=true")
+	}
+	if c.FlushInterval <= 0 {
+		return errors.New("metric_batcher.flush_interval must be greater than 0 when metric_batcher.enabled=true")
 	}
 	return nil
 }

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -90,6 +90,26 @@ func TestConfigValidateLogBatcher(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 }
 
+func TestConfigValidateMetricBatcher(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	require.NoError(t, cfg.Validate())
+
+	cfg.MetricBatcher.Enabled = true
+	cfg.MetricBatcher.MaxDataPoints = 0
+	require.ErrorContains(t, cfg.Validate(), "metric_batcher.max_datapoints")
+
+	cfg.MetricBatcher.MaxDataPoints = 10
+	cfg.MetricBatcher.MaxBytes = 0
+	require.ErrorContains(t, cfg.Validate(), "metric_batcher.max_bytes")
+
+	cfg.MetricBatcher.MaxBytes = 1024
+	cfg.MetricBatcher.FlushInterval = 0
+	require.ErrorContains(t, cfg.Validate(), "metric_batcher.flush_interval")
+
+	cfg.MetricBatcher.FlushInterval = time.Second
+	require.NoError(t, cfg.Validate())
+}
+
 func TestLoadConfigWithQueueCompression(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	conf := confmap.NewFromStringMap(map[string]any{
@@ -152,4 +172,35 @@ func TestLoadConfigWithLogBatcher(t *testing.T) {
 	require.Equal(t, 1024, cfg.LogBatcher.MaxRecords)
 	require.Equal(t, 2097152, cfg.LogBatcher.MaxBytes)
 	require.Equal(t, 250*time.Millisecond, cfg.LogBatcher.FlushInterval)
+}
+
+func TestLoadConfigWithMetricBatcher(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	conf := confmap.NewFromStringMap(map[string]any{
+		"protocol": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "localhost:4317",
+				"tls": map[string]any{
+					"insecure": true,
+				},
+			},
+		},
+		"resolver": map[string]any{
+			"static": map[string]any{
+				"hostnames": []string{"localhost:4317"},
+			},
+		},
+		"metric_batcher": map[string]any{
+			"enabled":        true,
+			"max_datapoints": 4096,
+			"max_bytes":      2097152,
+			"flush_interval": "300ms",
+		},
+	})
+
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.True(t, cfg.MetricBatcher.Enabled)
+	require.Equal(t, 4096, cfg.MetricBatcher.MaxDataPoints)
+	require.Equal(t, 2097152, cfg.MetricBatcher.MaxBytes)
+	require.Equal(t, 300*time.Millisecond, cfg.MetricBatcher.FlushInterval)
 }

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -107,6 +107,10 @@ func TestConfigValidateMetricBatcher(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "metric_batcher.flush_interval")
 
 	cfg.MetricBatcher.FlushInterval = time.Second
+	cfg.MetricBatcher.MaxRetryBufferMultiplier = 0
+	require.ErrorContains(t, cfg.Validate(), "metric_batcher.max_retry_buffer_multiplier")
+
+	cfg.MetricBatcher.MaxRetryBufferMultiplier = 5
 	require.NoError(t, cfg.Validate())
 }
 
@@ -191,10 +195,11 @@ func TestLoadConfigWithMetricBatcher(t *testing.T) {
 			},
 		},
 		"metric_batcher": map[string]any{
-			"enabled":        true,
-			"max_datapoints": 4096,
-			"max_bytes":      2097152,
-			"flush_interval": "300ms",
+			"enabled":                     true,
+			"max_datapoints":              4096,
+			"max_bytes":                   2097152,
+			"flush_interval":              "300ms",
+			"max_retry_buffer_multiplier": 12,
 		},
 	})
 
@@ -203,4 +208,5 @@ func TestLoadConfigWithMetricBatcher(t *testing.T) {
 	require.Equal(t, 4096, cfg.MetricBatcher.MaxDataPoints)
 	require.Equal(t, 2097152, cfg.MetricBatcher.MaxBytes)
 	require.Equal(t, 300*time.Millisecond, cfg.MetricBatcher.FlushInterval)
+	require.Equal(t, 12, cfg.MetricBatcher.MaxRetryBufferMultiplier)
 }

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -62,6 +62,12 @@ func createDefaultConfig() component.Config {
 			MaxBytes:      defaultLogBatchMaxBytes,
 			FlushInterval: defaultLogBatchFlushTimeout,
 		},
+		MetricBatcher: MetricBatcherConfig{
+			Enabled:       false,
+			MaxDataPoints: defaultMetricBatchMaxDataPoints,
+			MaxBytes:      defaultMetricBatchMaxBytes,
+			FlushInterval: defaultMetricBatchFlushTimeout,
+		},
 	}
 }
 

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -63,10 +63,11 @@ func createDefaultConfig() component.Config {
 			FlushInterval: defaultLogBatchFlushTimeout,
 		},
 		MetricBatcher: MetricBatcherConfig{
-			Enabled:       false,
-			MaxDataPoints: defaultMetricBatchMaxDataPoints,
-			MaxBytes:      defaultMetricBatchMaxBytes,
-			FlushInterval: defaultMetricBatchFlushTimeout,
+			Enabled:                  false,
+			MaxDataPoints:            defaultMetricBatchMaxDataPoints,
+			MaxBytes:                 defaultMetricBatchMaxBytes,
+			FlushInterval:            defaultMetricBatchFlushTimeout,
+			MaxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier,
 		},
 	}
 }

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -84,6 +84,15 @@ func TestDefaultLogBatcherConfig(t *testing.T) {
 	assert.Equal(t, defaultLogBatchFlushTimeout, cfg.LogBatcher.FlushInterval)
 }
 
+func TestDefaultMetricBatcherConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+
+	assert.False(t, cfg.MetricBatcher.Enabled)
+	assert.Equal(t, defaultMetricBatchMaxDataPoints, cfg.MetricBatcher.MaxDataPoints)
+	assert.Equal(t, defaultMetricBatchMaxBytes, cfg.MetricBatcher.MaxBytes)
+	assert.Equal(t, defaultMetricBatchFlushTimeout, cfg.MetricBatcher.FlushInterval)
+}
+
 func TestBuildExporterConfig(t *testing.T) {
 	// prepare
 	factories, err := otelcoltest.NopFactories()

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -91,6 +91,7 @@ func TestDefaultMetricBatcherConfig(t *testing.T) {
 	assert.Equal(t, defaultMetricBatchMaxDataPoints, cfg.MetricBatcher.MaxDataPoints)
 	assert.Equal(t, defaultMetricBatchMaxBytes, cfg.MetricBatcher.MaxBytes)
 	assert.Equal(t, defaultMetricBatchFlushTimeout, cfg.MetricBatcher.FlushInterval)
+	assert.Equal(t, defaultMetricBatchRetryBufferMultiplier, cfg.MetricBatcher.MaxRetryBufferMultiplier)
 }
 
 func TestBuildExporterConfig(t *testing.T) {

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -1,0 +1,582 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+	expmetrics "github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics"
+)
+
+const (
+	metricFlushReasonSize           = "size"
+	metricFlushReasonTimeout        = "timeout"
+	metricFlushReasonShutdown       = "shutdown"
+	metricFlushReasonResolverChange = "resolver_change"
+
+	defaultMetricBatchMaxDataPoints = 8192
+	defaultMetricBatchMaxBytes      = 2 << 20
+	defaultMetricBatchFlushTimeout  = 200 * time.Millisecond
+)
+
+var errMetricBatcherExporterStopping = errors.New("metric batcher exporter is stopping")
+
+type metricBatcherSettings struct {
+	maxDataPoints int
+	maxBytes      int
+	flushInterval time.Duration
+}
+
+type metricBatcherSendFunc func(context.Context, *wrappedExporter, pmetric.Metrics, string) error
+
+type metricBatcher struct {
+	logger   *zap.Logger
+	settings metricBatcherSettings
+	send     metricBatcherSendFunc
+
+	telemetry *metricBatcherTelemetry
+
+	mu       sync.RWMutex
+	backends map[string]*backendMetricBatcher
+	stopped  atomic.Bool
+}
+
+type metricBatcherRequest struct {
+	kind   metricBatcherRequestKind
+	md     pmetric.Metrics
+	ctx    context.Context
+	reason string
+	done   chan error
+}
+
+type metricBatcherRequestKind int
+
+const (
+	metricBatcherRequestEnqueue metricBatcherRequestKind = iota
+	metricBatcherRequestFlushAndStop
+)
+
+type backendMetricBatcher struct {
+	endpoint string
+	logger   *zap.Logger
+	settings metricBatcherSettings
+	send     metricBatcherSendFunc
+
+	telemetry *metricBatcherTelemetry
+
+	exporterMu sync.RWMutex
+	exp        *wrappedExporter
+
+	requests chan metricBatcherRequest
+	done     chan struct{}
+	inflight sync.WaitGroup
+
+	pendingDataPoints atomic.Int64
+	pendingBytes      atomic.Int64
+}
+
+type metricBatcherTelemetry struct {
+	logger            *zap.Logger
+	meter             metric.Meter
+	batchDataPoints   metric.Int64Histogram
+	batchBytes        metric.Int64Histogram
+	flushTotal        metric.Int64Counter
+	flushErrors       metric.Int64Counter
+	droppedDataPoints metric.Int64Counter
+	overflowTotal     metric.Int64Counter
+	pendingDataPoints metric.Int64ObservableGauge
+	pendingBytes      metric.Int64ObservableGauge
+
+	mu            sync.Mutex
+	registrations []metric.Registration
+}
+
+func newMetricBatcher(
+	logger *zap.Logger,
+	settings component.TelemetrySettings,
+	cfg metricBatcherSettings,
+	send metricBatcherSendFunc,
+) (*metricBatcher, error) {
+	telemetry, err := newMetricBatcherTelemetry(settings)
+	if err != nil {
+		return nil, err
+	}
+
+	b := &metricBatcher{
+		logger:    logger,
+		settings:  cfg,
+		send:      send,
+		telemetry: telemetry,
+		backends:  make(map[string]*backendMetricBatcher),
+	}
+
+	if err := telemetry.start(b.snapshotPending); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func (b *metricBatcher) Enqueue(ctx context.Context, endpoint string, exp *wrappedExporter, md pmetric.Metrics) error {
+	backend, err := b.acquireBackend(endpoint, exp)
+	if err != nil {
+		return err
+	}
+	defer backend.inflight.Done()
+
+	select {
+	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-backend.done:
+		return errors.New("metric batcher backend is stopped")
+	}
+}
+
+func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pmetric.Metrics) (bool, error) {
+	backend, err := b.acquireBackend(endpoint, exp)
+	if err != nil {
+		return false, err
+	}
+	defer backend.inflight.Done()
+
+	select {
+	case <-backend.done:
+		return false, errors.New("metric batcher backend is stopped")
+	default:
+	}
+
+	select {
+	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md}:
+		return true, nil
+	case <-backend.done:
+		return false, errors.New("metric batcher backend is stopped")
+	default:
+		return false, nil
+	}
+}
+
+func (b *metricBatcher) Remove(ctx context.Context, endpoint string, exp *wrappedExporter) error {
+	b.mu.Lock()
+	backend, ok := b.backends[endpoint]
+	if ok {
+		delete(b.backends, endpoint)
+	}
+	b.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	if exp != nil {
+		backend.setExporter(exp)
+	}
+	if err := waitForInflight(ctx, &backend.inflight); err != nil {
+		b.scheduleBackendCleanup(backend, metricFlushReasonResolverChange)
+		return err
+	}
+	return backend.stopAndFlush(ctx, metricFlushReasonResolverChange)
+}
+
+func (b *metricBatcher) Shutdown(ctx context.Context) error {
+	b.stopped.Store(true)
+
+	b.mu.Lock()
+	backends := make([]*backendMetricBatcher, 0, len(b.backends))
+	for endpoint, backend := range b.backends {
+		backends = append(backends, backend)
+		delete(b.backends, endpoint)
+	}
+	b.mu.Unlock()
+
+	var errs error
+	for _, backend := range backends {
+		if err := waitForInflight(ctx, &backend.inflight); err != nil {
+			b.scheduleBackendCleanup(backend, metricFlushReasonShutdown)
+			errs = errors.Join(errs, err)
+			continue
+		}
+		errs = errors.Join(errs, backend.stopAndFlush(ctx, metricFlushReasonShutdown))
+	}
+	b.telemetry.shutdown()
+	return errs
+}
+
+func (b *metricBatcher) scheduleBackendCleanup(backend *backendMetricBatcher, reason string) {
+	go func() {
+		if err := waitForInflight(context.Background(), &backend.inflight); err != nil {
+			b.logger.Warn("failed waiting for inflight metric batcher requests during background cleanup", zap.String("endpoint", backend.endpoint), zap.Error(err))
+			return
+		}
+		if err := backend.stopAndFlush(context.Background(), reason); err != nil {
+			b.logger.Warn("failed to stop metric batcher backend during background cleanup", zap.String("endpoint", backend.endpoint), zap.String("reason", reason), zap.Error(err))
+		}
+	}()
+}
+
+type metricBatcherPending struct {
+	endpoint   string
+	datapoints int64
+	bytes      int64
+}
+
+func (b *metricBatcher) snapshotPending() []metricBatcherPending {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	pending := make([]metricBatcherPending, 0, len(b.backends))
+	for endpoint, backend := range b.backends {
+		pending = append(pending, metricBatcherPending{
+			endpoint:   endpoint,
+			datapoints: backend.pendingDataPoints.Load(),
+			bytes:      backend.pendingBytes.Load(),
+		})
+	}
+	return pending
+}
+
+func (b *metricBatcher) acquireBackend(endpoint string, exp *wrappedExporter) (*backendMetricBatcher, error) {
+	if b.stopped.Load() {
+		return nil, errMetricBatcherExporterStopping
+	}
+
+	b.mu.RLock()
+	backend, ok := b.backends[endpoint]
+	if ok {
+		if exp != nil && exp.isStopping() {
+			b.mu.RUnlock()
+			return nil, errMetricBatcherExporterStopping
+		}
+		backend.setExporter(exp)
+		backend.inflight.Add(1)
+		b.mu.RUnlock()
+		return backend, nil
+	}
+	b.mu.RUnlock()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.stopped.Load() {
+		return nil, errMetricBatcherExporterStopping
+	}
+	backend, ok = b.backends[endpoint]
+	if ok {
+		if exp != nil && exp.isStopping() {
+			return nil, errMetricBatcherExporterStopping
+		}
+		backend.setExporter(exp)
+		backend.inflight.Add(1)
+		return backend, nil
+	}
+	if exp != nil && exp.isStopping() {
+		return nil, errMetricBatcherExporterStopping
+	}
+
+	backend = newBackendMetricBatcher(endpoint, exp, b.logger, b.settings, b.telemetry, b.send)
+	backend.inflight.Add(1)
+	b.backends[endpoint] = backend
+	return backend, nil
+}
+
+func newBackendMetricBatcher(
+	endpoint string,
+	exp *wrappedExporter,
+	logger *zap.Logger,
+	settings metricBatcherSettings,
+	telemetry *metricBatcherTelemetry,
+	send metricBatcherSendFunc,
+) *backendMetricBatcher {
+	backend := &backendMetricBatcher{
+		endpoint:  endpoint,
+		exp:       exp,
+		logger:    logger.With(zap.String("endpoint", endpoint)),
+		settings:  settings,
+		telemetry: telemetry,
+		send:      send,
+		requests:  make(chan metricBatcherRequest, 16),
+		done:      make(chan struct{}),
+	}
+
+	go backend.run()
+	return backend
+}
+
+func (b *backendMetricBatcher) stopAndFlush(ctx context.Context, reason string) error {
+	done := make(chan error, 1)
+	select {
+	case b.requests <- metricBatcherRequest{kind: metricBatcherRequestFlushAndStop, ctx: ctx, reason: reason, done: done}:
+	case <-b.done:
+		return nil
+	}
+
+	select {
+	case err := <-done:
+		<-b.done
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (b *backendMetricBatcher) setExporter(exp *wrappedExporter) {
+	b.exporterMu.Lock()
+	b.exp = exp
+	b.exporterMu.Unlock()
+}
+
+func (b *backendMetricBatcher) exporter() *wrappedExporter {
+	b.exporterMu.RLock()
+	defer b.exporterMu.RUnlock()
+	return b.exp
+}
+
+func (b *backendMetricBatcher) run() {
+	defer close(b.done)
+
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+
+	pending := pmetric.NewMetrics()
+	pendingBytes := 0
+	pendingDataPoints := 0
+	sizer := &pmetric.ProtoMarshaler{}
+	var nextReq *metricBatcherRequest
+
+	for {
+		if nextReq != nil {
+			req := *nextReq
+			nextReq = nil
+			if b.handleRequest(req, sizer, &pending, &pendingDataPoints, &pendingBytes, &nextReq, timer, &timerC) {
+				return
+			}
+			continue
+		}
+
+		select {
+		case req := <-b.requests:
+			if b.handleRequest(req, sizer, &pending, &pendingDataPoints, &pendingBytes, &nextReq, timer, &timerC) {
+				return
+			}
+		case <-timerC:
+			if err := b.flush(context.Background(), &pending, &pendingDataPoints, &pendingBytes, metricFlushReasonTimeout, timer, &timerC); err != nil {
+				b.logger.Warn("failed to flush metric batch", zap.String("reason", metricFlushReasonTimeout), zap.Error(err))
+			}
+		}
+	}
+}
+
+func (b *backendMetricBatcher) handleRequest(
+	req metricBatcherRequest,
+	sizer *pmetric.ProtoMarshaler,
+	pending *pmetric.Metrics,
+	pendingDataPoints *int,
+	pendingBytes *int,
+	nextReq **metricBatcherRequest,
+	timer *time.Timer,
+	timerC *<-chan time.Time,
+) bool {
+	switch req.kind {
+	case metricBatcherRequestEnqueue:
+		*pendingDataPoints += b.mergeQueuedRequests(pending, req, nextReq)
+		*pendingBytes = sizer.MetricsSize(*pending)
+		b.pendingDataPoints.Store(int64(*pendingDataPoints))
+		b.pendingBytes.Store(int64(*pendingBytes))
+		if *pendingDataPoints > 0 && *timerC == nil {
+			timer.Reset(b.settings.flushInterval)
+			*timerC = timer.C
+		}
+		if *pendingDataPoints >= b.settings.maxDataPoints || *pendingBytes >= b.settings.maxBytes {
+			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
+			b.telemetry.overflowTotal.Add(context.Background(), 1, attrs)
+			if err := b.flush(context.Background(), pending, pendingDataPoints, pendingBytes, metricFlushReasonSize, timer, timerC); err != nil {
+				b.logger.Warn("failed to flush metric batch", zap.String("reason", metricFlushReasonSize), zap.Error(err))
+			}
+		}
+	case metricBatcherRequestFlushAndStop:
+		err := b.flush(req.ctx, pending, pendingDataPoints, pendingBytes, req.reason, timer, timerC)
+		req.done <- err
+		return true
+	}
+	return false
+}
+
+func (b *backendMetricBatcher) mergeQueuedRequests(
+	pending *pmetric.Metrics,
+	first metricBatcherRequest,
+	nextReq **metricBatcherRequest,
+) int {
+	dataPointCount := first.md.DataPointCount()
+	expmetrics.Merge(*pending, first.md)
+
+	for i := 0; i < cap(b.requests); i++ {
+		select {
+		case req := <-b.requests:
+			if req.kind != metricBatcherRequestEnqueue {
+				*nextReq = &req
+				return dataPointCount
+			}
+			dataPointCount += req.md.DataPointCount()
+			expmetrics.Merge(*pending, req.md)
+		default:
+			return dataPointCount
+		}
+	}
+
+	return dataPointCount
+}
+
+func (b *backendMetricBatcher) flush(
+	ctx context.Context,
+	pending *pmetric.Metrics,
+	pendingDataPoints *int,
+	pendingBytes *int,
+	reason string,
+	timer *time.Timer,
+	timerC *<-chan time.Time,
+) error {
+	if !timer.Stop() && *timerC != nil {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	*timerC = nil
+
+	if pending.DataPointCount() == 0 {
+		return nil
+	}
+
+	drained := *pending
+	datapoints := *pendingDataPoints
+	bytes := *pendingBytes
+	*pending = pmetric.NewMetrics()
+	*pendingDataPoints = 0
+	*pendingBytes = 0
+	b.pendingDataPoints.Store(0)
+	b.pendingBytes.Store(0)
+
+	attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
+	b.telemetry.batchDataPoints.Record(ctx, int64(datapoints), attrs)
+	b.telemetry.batchBytes.Record(ctx, int64(bytes), attrs)
+	b.telemetry.flushTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason))))
+
+	err := b.send(ctx, b.exporter(), drained, reason)
+	if err != nil {
+		b.telemetry.flushErrors.Add(ctx, 1, attrs)
+		if reason == metricFlushReasonSize || reason == metricFlushReasonTimeout {
+			*pending = drained
+			*pendingDataPoints = datapoints
+			*pendingBytes = bytes
+			b.pendingDataPoints.Store(int64(datapoints))
+			b.pendingBytes.Store(int64(bytes))
+			if *timerC == nil {
+				timer.Reset(b.settings.flushInterval)
+				*timerC = timer.C
+			}
+		} else {
+			b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
+		}
+	}
+
+	return err
+}
+
+func newMetricBatcherTelemetry(settings component.TelemetrySettings) (*metricBatcherTelemetry, error) {
+	meter := metadata.Meter(settings)
+	var err, errs error
+
+	t := &metricBatcherTelemetry{logger: settings.Logger, meter: meter}
+	t.batchDataPoints, err = meter.Int64Histogram(
+		"otelcol_loadbalancer_metric_batch_size",
+		metric.WithDescription("Number of metric datapoints per flushed backend batch."),
+		metric.WithUnit("{datapoints}"),
+	)
+	errs = errors.Join(errs, err)
+	t.batchBytes, err = meter.Int64Histogram(
+		"otelcol_loadbalancer_metric_batch_bytes",
+		metric.WithDescription("Serialized OTLP bytes per flushed metric backend batch before compression."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	t.flushTotal, err = meter.Int64Counter(
+		"otelcol_loadbalancer_metric_batch_flush_total",
+		metric.WithDescription("Number of metric batch flushes by endpoint and reason."),
+		metric.WithUnit("{flushes}"),
+	)
+	errs = errors.Join(errs, err)
+	t.flushErrors, err = meter.Int64Counter(
+		"otelcol_loadbalancer_metric_batch_flush_errors",
+		metric.WithDescription("Number of metric batch flush errors."),
+		metric.WithUnit("{errors}"),
+	)
+	errs = errors.Join(errs, err)
+	t.droppedDataPoints, err = meter.Int64Counter(
+		"otelcol_loadbalancer_metric_batch_dropped_datapoints",
+		metric.WithDescription("Number of dropped metric datapoints in the internal metric batcher."),
+		metric.WithUnit("{datapoints}"),
+	)
+	errs = errors.Join(errs, err)
+	t.overflowTotal, err = meter.Int64Counter(
+		"otelcol_loadbalancer_metric_batch_overflow_total",
+		metric.WithDescription("Number of times an internal metric batch hit a size bound and was force-flushed."),
+		metric.WithUnit("{overflows}"),
+	)
+	errs = errors.Join(errs, err)
+	t.pendingDataPoints, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_metric_batch_pending_datapoints",
+		metric.WithDescription("Current number of pending metric datapoints per backend batch."),
+		metric.WithUnit("{datapoints}"),
+	)
+	errs = errors.Join(errs, err)
+	t.pendingBytes, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_metric_batch_pending_bytes",
+		metric.WithDescription("Current serialized OTLP bytes per pending metric backend batch before compression."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+
+	return t, errs
+}
+
+func (t *metricBatcherTelemetry) start(snapshot func() []metricBatcherPending) error {
+	reg, err := t.meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+		for _, pending := range snapshot() {
+			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", pending.endpoint)))
+			observer.ObserveInt64(t.pendingDataPoints, pending.datapoints, attrs)
+			observer.ObserveInt64(t.pendingBytes, pending.bytes, attrs)
+		}
+		return nil
+	}, t.pendingDataPoints, t.pendingBytes)
+	if err != nil {
+		return err
+	}
+	t.mu.Lock()
+	t.registrations = append(t.registrations, reg)
+	t.mu.Unlock()
+	return nil
+}
+
+func (t *metricBatcherTelemetry) shutdown() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, reg := range t.registrations {
+		if err := reg.Unregister(); err != nil {
+			t.logger.Warn("failed to unregister metric batcher metric callback", zap.Error(err))
+		}
+	}
+	t.registrations = nil
+}

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -129,23 +129,6 @@ func newMetricBatcher(
 	return b, nil
 }
 
-func (b *metricBatcher) Enqueue(ctx context.Context, endpoint string, exp *wrappedExporter, md pmetric.Metrics) error {
-	backend, err := b.acquireBackend(endpoint, exp)
-	if err != nil {
-		return err
-	}
-	defer backend.inflight.Done()
-
-	select {
-	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md}:
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-backend.done:
-		return errors.New("metric batcher backend is stopped")
-	}
-}
-
 func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pmetric.Metrics) (bool, error) {
 	backend, err := b.acquireBackend(endpoint, exp)
 	if err != nil {

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -39,12 +40,16 @@ type metricBatcherSettings struct {
 	flushInterval time.Duration
 }
 
-type metricBatcherSendFunc func(context.Context, *wrappedExporter, pmetric.Metrics, string) error
+type (
+	metricBatcherSendFunc         func(context.Context, *wrappedExporter, pmetric.Metrics, string) error
+	metricBatcherDrainFailureFunc func(context.Context, pmetric.Metrics, string) error
+)
 
 type metricBatcher struct {
 	logger   *zap.Logger
 	settings metricBatcherSettings
 	send     metricBatcherSendFunc
+	drainErr metricBatcherDrainFailureFunc
 
 	telemetry *metricBatcherTelemetry
 
@@ -73,6 +78,7 @@ type backendMetricBatcher struct {
 	logger   *zap.Logger
 	settings metricBatcherSettings
 	send     metricBatcherSendFunc
+	drainErr metricBatcherDrainFailureFunc
 
 	telemetry *metricBatcherTelemetry
 
@@ -108,6 +114,7 @@ func newMetricBatcher(
 	settings component.TelemetrySettings,
 	cfg metricBatcherSettings,
 	send metricBatcherSendFunc,
+	drainErr metricBatcherDrainFailureFunc,
 ) (*metricBatcher, error) {
 	telemetry, err := newMetricBatcherTelemetry(settings)
 	if err != nil {
@@ -118,6 +125,7 @@ func newMetricBatcher(
 		logger:    logger,
 		settings:  cfg,
 		send:      send,
+		drainErr:  drainErr,
 		telemetry: telemetry,
 		backends:  make(map[string]*backendMetricBatcher),
 	}
@@ -266,7 +274,7 @@ func (b *metricBatcher) acquireBackend(endpoint string, exp *wrappedExporter) (*
 		return nil, errMetricBatcherExporterStopping
 	}
 
-	backend = newBackendMetricBatcher(endpoint, exp, b.logger, b.settings, b.telemetry, b.send)
+	backend = newBackendMetricBatcher(endpoint, exp, b.logger, b.settings, b.telemetry, b.send, b.drainErr)
 	backend.inflight.Add(1)
 	b.backends[endpoint] = backend
 	return backend, nil
@@ -279,6 +287,7 @@ func newBackendMetricBatcher(
 	settings metricBatcherSettings,
 	telemetry *metricBatcherTelemetry,
 	send metricBatcherSendFunc,
+	drainErr metricBatcherDrainFailureFunc,
 ) *backendMetricBatcher {
 	backend := &backendMetricBatcher{
 		endpoint:  endpoint,
@@ -287,6 +296,7 @@ func newBackendMetricBatcher(
 		settings:  settings,
 		telemetry: telemetry,
 		send:      send,
+		drainErr:  drainErr,
 		requests:  make(chan metricBatcherRequest, 16),
 		done:      make(chan struct{}),
 	}
@@ -471,6 +481,18 @@ func (b *backendMetricBatcher) flush(
 				*timerC = timer.C
 			}
 		} else {
+			if b.drainErr != nil && (reason == metricFlushReasonResolverChange || reason == metricFlushReasonShutdown) {
+				rerouteErr := b.drainErr(ctx, drained, reason)
+				if rerouteErr == nil {
+					return nil
+				}
+				var mErr consumererror.Metrics
+				if errors.As(rerouteErr, &mErr) {
+					drained = mErr.Data()
+					datapoints = drained.DataPointCount()
+				}
+				err = errors.Join(err, rerouteErr)
+			}
 			b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
 		}
 	}

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -138,7 +138,7 @@ func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pme
 
 	select {
 	case <-backend.done:
-		return false, errors.New("metric batcher backend is stopped")
+		return false, errMetricBatcherExporterStopping
 	default:
 	}
 
@@ -146,7 +146,7 @@ func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pme
 	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md}:
 		return true, nil
 	case <-backend.done:
-		return false, errors.New("metric batcher backend is stopped")
+		return false, errMetricBatcherExporterStopping
 	default:
 		return false, nil
 	}

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -6,6 +6,7 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 import (
 	"context"
 	"errors"
+	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,19 +28,22 @@ const (
 	metricFlushReasonShutdown       = "shutdown"
 	metricFlushReasonResolverChange = "resolver_change"
 
-	defaultMetricBatchMaxDataPoints = 8192
-	defaultMetricBatchMaxBytes      = 2 << 20
-	defaultMetricBatchFlushTimeout  = 200 * time.Millisecond
-	maxMetricBatchRetryAttempts     = 5
-	maxMetricBatchRetryBackoff      = 5 * time.Second
+	defaultMetricBatchMaxDataPoints         = 8192
+	defaultMetricBatchMaxBytes              = 2 << 20
+	defaultMetricBatchFlushTimeout          = 200 * time.Millisecond
+	defaultMetricBatchRetryBufferMultiplier = 10 // allow retries to grow up to 10x configured batch limits before forced drop
+	maxMetricBatchRetryBackoff              = 5 * time.Second
 )
+
+var metricBatcherMaxRetryAge = 2 * time.Minute
 
 var errMetricBatcherExporterStopping = errors.New("metric batcher exporter is stopping")
 
 type metricBatcherSettings struct {
-	maxDataPoints int
-	maxBytes      int
-	flushInterval time.Duration
+	maxDataPoints            int
+	maxBytes                 int
+	flushInterval            time.Duration
+	maxRetryBufferMultiplier int
 }
 
 type (
@@ -120,6 +124,10 @@ func newMetricBatcher(
 	send metricBatcherSendFunc,
 	drainErr metricBatcherDrainFailureFunc,
 ) (*metricBatcher, error) {
+	if cfg.maxRetryBufferMultiplier <= 0 {
+		cfg.maxRetryBufferMultiplier = defaultMetricBatchRetryBufferMultiplier
+	}
+
 	telemetry, err := newMetricBatcherTelemetry(settings)
 	if err != nil {
 		return nil, err
@@ -346,6 +354,7 @@ func (b *backendMetricBatcher) run() {
 		<-timer.C
 	}
 	var timerC <-chan time.Time
+	retryingSince := time.Time{}
 
 	pending := pmetric.NewMetrics()
 	pendingBytes := 0
@@ -357,7 +366,7 @@ func (b *backendMetricBatcher) run() {
 		if nextReq != nil {
 			req := *nextReq
 			nextReq = nil
-			if b.handleRequest(req, sizer, &pending, &pendingDataPoints, &pendingBytes, &nextReq, timer, &timerC) {
+			if b.handleRequest(req, sizer, &pending, &pendingDataPoints, &pendingBytes, &nextReq, timer, &timerC, &retryingSince) {
 				return
 			}
 			continue
@@ -365,11 +374,11 @@ func (b *backendMetricBatcher) run() {
 
 		select {
 		case req := <-b.requests:
-			if b.handleRequest(req, sizer, &pending, &pendingDataPoints, &pendingBytes, &nextReq, timer, &timerC) {
+			if b.handleRequest(req, sizer, &pending, &pendingDataPoints, &pendingBytes, &nextReq, timer, &timerC, &retryingSince) {
 				return
 			}
 		case <-timerC:
-			if err := b.flush(context.Background(), &pending, &pendingDataPoints, &pendingBytes, metricFlushReasonTimeout, timer, &timerC); err != nil {
+			if err := b.flush(context.Background(), &pending, &pendingDataPoints, &pendingBytes, metricFlushReasonTimeout, timer, &timerC, &retryingSince); err != nil {
 				b.logger.Warn("failed to flush metric batch", zap.String("reason", metricFlushReasonTimeout), zap.Error(err))
 			}
 		}
@@ -385,6 +394,7 @@ func (b *backendMetricBatcher) handleRequest(
 	nextReq **metricBatcherRequest,
 	timer *time.Timer,
 	timerC *<-chan time.Time,
+	retryingSince *time.Time,
 ) bool {
 	switch req.kind {
 	case metricBatcherRequestEnqueue:
@@ -399,12 +409,12 @@ func (b *backendMetricBatcher) handleRequest(
 		if *pendingDataPoints >= b.settings.maxDataPoints || *pendingBytes >= b.settings.maxBytes {
 			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
 			b.telemetry.overflowTotal.Add(context.Background(), 1, attrs)
-			if err := b.flush(context.Background(), pending, pendingDataPoints, pendingBytes, metricFlushReasonSize, timer, timerC); err != nil {
+			if err := b.flush(context.Background(), pending, pendingDataPoints, pendingBytes, metricFlushReasonSize, timer, timerC, retryingSince); err != nil {
 				b.logger.Warn("failed to flush metric batch", zap.String("reason", metricFlushReasonSize), zap.Error(err))
 			}
 		}
 	case metricBatcherRequestFlushAndStop:
-		err := b.flush(req.ctx, pending, pendingDataPoints, pendingBytes, req.reason, timer, timerC)
+		err := b.flush(req.ctx, pending, pendingDataPoints, pendingBytes, req.reason, timer, timerC, retryingSince)
 		req.done <- err
 		return true
 	}
@@ -444,6 +454,7 @@ func (b *backendMetricBatcher) flush(
 	reason string,
 	timer *time.Timer,
 	timerC *<-chan time.Time,
+	retryingSince *time.Time,
 ) error {
 	if !timer.Stop() && *timerC != nil {
 		select {
@@ -475,10 +486,19 @@ func (b *backendMetricBatcher) flush(
 	if err != nil {
 		b.telemetry.flushErrors.Add(ctx, 1, attrs)
 		if reason == metricFlushReasonSize || reason == metricFlushReasonTimeout {
+			now := time.Now()
+			if retryingSince.IsZero() {
+				*retryingSince = now
+			}
+
 			b.flushFailures++
-			if b.flushFailures >= maxMetricBatchRetryAttempts {
-				b.logger.Error("dropping metric batch after repeated flush failures", zap.String("endpoint", b.endpoint), zap.String("reason", reason), zap.Int("failures", b.flushFailures), zap.Error(err))
+			overCap := isBeyondRetryCap(datapoints, b.settings.maxDataPoints, b.settings.maxRetryBufferMultiplier) || isBeyondRetryCap(bytes, b.settings.maxBytes, b.settings.maxRetryBufferMultiplier)
+			overAge := now.Sub(*retryingSince) >= metricBatcherMaxRetryAge
+			if overCap || overAge {
+				b.logger.Error("dropping metric batch after retry limits exceeded", zap.String("endpoint", b.endpoint), zap.String("reason", reason), zap.Int("failures", b.flushFailures), zap.Int("datapoints", datapoints), zap.Int("bytes", bytes), zap.Bool("over_cap", overCap), zap.Bool("over_age", overAge), zap.Duration("retry_age", now.Sub(*retryingSince)), zap.Error(err))
 				b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
+				*retryingSince = time.Time{}
+				b.flushFailures = 0
 				return err
 			}
 			*pending = drained
@@ -488,9 +508,7 @@ func (b *backendMetricBatcher) flush(
 			b.pendingBytes.Store(int64(bytes))
 			if *timerC == nil {
 				delay := b.settings.flushInterval * time.Duration(1<<min(b.flushFailures-1, 4))
-				if delay > maxMetricBatchRetryBackoff {
-					delay = maxMetricBatchRetryBackoff
-				}
+				delay = min(delay, maxMetricBatchRetryBackoff)
 				timer.Reset(delay)
 				*timerC = timer.C
 			}
@@ -512,9 +530,23 @@ func (b *backendMetricBatcher) flush(
 	}
 
 	if err == nil {
+		*retryingSince = time.Time{}
 		b.flushFailures = 0
 	}
 	return err
+}
+
+func isBeyondRetryCap(current, base, multiplier int) bool {
+	if current <= 0 || base <= 0 {
+		return false
+	}
+	if multiplier <= 0 {
+		return false
+	}
+	if base > math.MaxInt/multiplier {
+		return false
+	}
+	return current > base*multiplier
 }
 
 func newMetricBatcherTelemetry(settings component.TelemetrySettings) (*metricBatcherTelemetry, error) {

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -203,7 +203,7 @@ func (b *metricBatcher) scheduleBackendCleanup(backend *backendMetricBatcher, re
 			return
 		}
 		if err := backend.stopAndFlush(context.Background(), reason); err != nil {
-			b.logger.Warn("failed to stop metric batcher backend during background cleanup", zap.String("endpoint", backend.endpoint), zap.String("reason", reason), zap.Error(err))
+			b.logger.Error("failed to stop metric batcher backend during background cleanup", zap.String("endpoint", backend.endpoint), zap.String("reason", reason), zap.Error(err))
 		}
 	}()
 }

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -30,6 +30,8 @@ const (
 	defaultMetricBatchMaxDataPoints = 8192
 	defaultMetricBatchMaxBytes      = 2 << 20
 	defaultMetricBatchFlushTimeout  = 200 * time.Millisecond
+	maxMetricBatchRetryAttempts     = 5
+	maxMetricBatchRetryBackoff      = 5 * time.Second
 )
 
 var errMetricBatcherExporterStopping = errors.New("metric batcher exporter is stopping")
@@ -91,6 +93,8 @@ type backendMetricBatcher struct {
 
 	pendingDataPoints atomic.Int64
 	pendingBytes      atomic.Int64
+
+	flushFailures int
 }
 
 type metricBatcherTelemetry struct {
@@ -471,13 +475,23 @@ func (b *backendMetricBatcher) flush(
 	if err != nil {
 		b.telemetry.flushErrors.Add(ctx, 1, attrs)
 		if reason == metricFlushReasonSize || reason == metricFlushReasonTimeout {
+			b.flushFailures++
+			if b.flushFailures >= maxMetricBatchRetryAttempts {
+				b.logger.Error("dropping metric batch after repeated flush failures", zap.String("endpoint", b.endpoint), zap.String("reason", reason), zap.Int("failures", b.flushFailures), zap.Error(err))
+				b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
+				return err
+			}
 			*pending = drained
 			*pendingDataPoints = datapoints
 			*pendingBytes = bytes
 			b.pendingDataPoints.Store(int64(datapoints))
 			b.pendingBytes.Store(int64(bytes))
 			if *timerC == nil {
-				timer.Reset(b.settings.flushInterval)
+				delay := b.settings.flushInterval * time.Duration(1<<min(b.flushFailures-1, 4))
+				if delay > maxMetricBatchRetryBackoff {
+					delay = maxMetricBatchRetryBackoff
+				}
+				timer.Reset(delay)
 				*timerC = timer.C
 			}
 		} else {
@@ -497,6 +511,9 @@ func (b *backendMetricBatcher) flush(
 		}
 	}
 
+	if err == nil {
+		b.flushFailures = 0
+	}
 	return err
 }
 

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -33,8 +33,8 @@ func TestMetricBatcherFlushesOnMaxDataPoints(t *testing.T) {
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
-	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
-	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
 
 	select {
 	case got := <-flushed:
@@ -63,7 +63,7 @@ func TestMetricBatcherFlushesOnInterval(t *testing.T) {
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
-	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
 
 	select {
 	case got := <-flushed:
@@ -92,7 +92,7 @@ func TestMetricBatcherRemoveFlushesPending(t *testing.T) {
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
-	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
 	require.NoError(t, batcher.Remove(t.Context(), "endpoint-1:4317", exp))
 
 	require.Equal(t, int64(1), flushes.Load())
@@ -116,7 +116,7 @@ func TestMetricBatcherShutdownFlushesPending(t *testing.T) {
 	require.NoError(t, err)
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
-	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
 	require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
 
 	select {
@@ -141,7 +141,7 @@ func TestMetricBatcherRemoveTimeoutSchedulesCleanup(t *testing.T) {
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
-	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
 
 	batcher.mu.RLock()
 	backend := batcher.backends["endpoint-1:4317"]
@@ -187,7 +187,7 @@ func TestMetricBatcherRestoresPendingOnTimeoutFlushFailure(t *testing.T) {
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
-	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
 
 	require.Eventually(t, func() bool {
 		return calls.Load() >= 2
@@ -219,7 +219,7 @@ func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T)
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
-	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
 
 	select {
 	case <-sendStarted:
@@ -247,4 +247,11 @@ func singleDataPointMetric(name string) pmetric.Metrics {
 	g := m.SetEmptyGauge()
 	g.DataPoints().AppendEmpty().SetIntValue(1)
 	return md
+}
+
+func requireMetricBatcherEnqueued(t *testing.T, batcher *metricBatcher, exp *wrappedExporter, md pmetric.Metrics) {
+	t.Helper()
+	enqueued, err := batcher.TryEnqueue("endpoint-1:4317", exp, md)
+	require.NoError(t, err)
+	require.True(t, enqueued)
 }

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -73,6 +73,35 @@ func TestMetricBatcherFlushesOnInterval(t *testing.T) {
 	}
 }
 
+func TestMetricBatcherFlushesOnMaxBytes(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	flushed := make(chan int, 1)
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
+			flushed <- md.DataPointCount()
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
+
+	select {
+	case got := <-flushed:
+		require.Equal(t, 1, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected metric batch flush on max_bytes")
+	}
+}
+
 func TestMetricBatcherRemoveFlushesPending(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	var flushes atomic.Int64

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -26,6 +26,7 @@ func TestMetricBatcherFlushesOnMaxDataPoints(t *testing.T) {
 			flushed <- md.DataPointCount()
 			return nil
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -56,6 +57,7 @@ func TestMetricBatcherFlushesOnInterval(t *testing.T) {
 			flushed <- md.DataPointCount()
 			return nil
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -85,6 +87,7 @@ func TestMetricBatcherFlushesOnMaxBytes(t *testing.T) {
 			flushed <- md.DataPointCount()
 			return nil
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -114,6 +117,7 @@ func TestMetricBatcherRemoveFlushesPending(t *testing.T) {
 			flushes.Add(1)
 			return nil
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -141,6 +145,7 @@ func TestMetricBatcherShutdownFlushesPending(t *testing.T) {
 			}
 			return nil
 		},
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -163,6 +168,7 @@ func TestMetricBatcherRemoveTimeoutSchedulesCleanup(t *testing.T) {
 		ts.TelemetrySettings,
 		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
 		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error { return nil },
+		nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -209,6 +215,7 @@ func TestMetricBatcherRestoresPendingOnTimeoutFlushFailure(t *testing.T) {
 			}
 			return nil
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -240,6 +247,7 @@ func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T)
 			<-blockSend
 			return nil
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -265,6 +273,73 @@ func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T)
 	enqueued, enqueueErr := batcher.TryEnqueue("endpoint-1:4317", exp, singleDataPointMetric("m1"))
 	require.NoError(t, enqueueErr)
 	require.False(t, enqueued)
+}
+
+func TestMetricBatcherRemoveReroutesOnResolverChangeFlushFailure(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	rerouted := make(chan int, 1)
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			return errors.New("flush failed")
+		},
+		func(_ context.Context, md pmetric.Metrics, reason string) error {
+			require.Equal(t, metricFlushReasonResolverChange, reason)
+			rerouted <- md.DataPointCount()
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
+
+	require.NoError(t, batcher.Remove(t.Context(), "endpoint-1:4317", exp))
+
+	select {
+	case got := <-rerouted:
+		require.Equal(t, 1, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected resolver-change drain reroute callback")
+	}
+}
+
+func TestMetricBatcherShutdownReroutesOnShutdownFlushFailure(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	rerouted := make(chan int, 1)
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			return errors.New("flush failed")
+		},
+		func(_ context.Context, md pmetric.Metrics, reason string) error {
+			require.Equal(t, metricFlushReasonShutdown, reason)
+			rerouted <- md.DataPointCount()
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
+
+	require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+
+	select {
+	case got := <-rerouted:
+		require.Equal(t, 1, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected shutdown drain reroute callback")
+	}
 }
 
 func singleDataPointMetric(name string) pmetric.Metrics {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -310,16 +310,60 @@ func TestMetricBatcherRemoveReroutesOnResolverChangeFlushFailure(t *testing.T) {
 	}
 }
 
-func TestMetricBatcherCapsRepeatedFlushFailures(t *testing.T) {
+func TestMetricBatcherDropsPendingWhenRetryBufferCapExceeded(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
-	var sends atomic.Int64
+	var calls atomic.Int64
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1, maxBytes: 1 << 20, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			calls.Add(1)
+			return errors.New("still failing")
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	for range defaultMetricBatchRetryBufferMultiplier + 1 {
+		requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
+	}
+
+	require.Eventually(t, func() bool {
+		return calls.Load() > 0
+	}, 2*time.Second, 20*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		for _, p := range batcher.snapshotPending() {
+			if p.endpoint == "endpoint-1:4317" {
+				return p.datapoints == 0
+			}
+		}
+		return true
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestMetricBatcherDropsPendingWhenRetryAgeExceeded(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	var calls atomic.Int64
+
+	oldRetryAge := metricBatcherMaxRetryAge
+	metricBatcherMaxRetryAge = 30 * time.Millisecond
+	t.Cleanup(func() {
+		metricBatcherMaxRetryAge = oldRetryAge
+	})
+
 	batcher, err := newMetricBatcher(
 		ts.Logger,
 		ts.TelemetrySettings,
 		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: 10 * time.Millisecond},
 		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
-			sends.Add(1)
-			return errors.New("flush failed")
+			calls.Add(1)
+			return errors.New("still failing")
 		},
 		nil,
 	)
@@ -331,18 +375,18 @@ func TestMetricBatcherCapsRepeatedFlushFailures(t *testing.T) {
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
 	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
 
-	deadline := time.After(2 * time.Second)
-	for sends.Load() < maxMetricBatchRetryAttempts {
-		select {
-		case <-deadline:
-			t.Fatalf("expected %d send attempts, got %d", maxMetricBatchRetryAttempts, sends.Load())
-		default:
-			time.Sleep(10 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return calls.Load() >= 2
+	}, 2*time.Second, 20*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		for _, p := range batcher.snapshotPending() {
+			if p.endpoint == "endpoint-1:4317" {
+				return p.datapoints == 0
+			}
 		}
-	}
-	count := sends.Load()
-	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, count, sends.Load())
+		return true
+	}, 2*time.Second, 20*time.Millisecond)
 }
 
 func TestMetricBatcherShutdownReroutesOnShutdownFlushFailure(t *testing.T) {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -310,6 +310,41 @@ func TestMetricBatcherRemoveReroutesOnResolverChangeFlushFailure(t *testing.T) {
 	}
 }
 
+func TestMetricBatcherCapsRepeatedFlushFailures(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	var sends atomic.Int64
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: 10 * time.Millisecond},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			sends.Add(1)
+			return errors.New("flush failed")
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
+
+	deadline := time.After(2 * time.Second)
+	for sends.Load() < maxMetricBatchRetryAttempts {
+		select {
+		case <-deadline:
+			t.Fatalf("expected %d send attempts, got %d", maxMetricBatchRetryAttempts, sends.Load())
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	count := sends.Load()
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, count, sends.Load())
+}
+
 func TestMetricBatcherShutdownReroutesOnShutdownFlushFailure(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	rerouted := make(chan int, 1)

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -1,0 +1,250 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestMetricBatcherFlushesOnMaxDataPoints(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	flushed := make(chan int, 1)
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 2, maxBytes: 1 << 20, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
+			flushed <- md.DataPointCount()
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.Background()))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+
+	select {
+	case got := <-flushed:
+		require.Equal(t, 2, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected metric batch flush on max_datapoints")
+	}
+}
+
+func TestMetricBatcherFlushesOnInterval(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	flushed := make(chan int, 1)
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: 50 * time.Millisecond},
+		func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
+			flushed <- md.DataPointCount()
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.Background()))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+
+	select {
+	case got := <-flushed:
+		require.Equal(t, 1, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected metric batch flush on interval")
+	}
+}
+
+func TestMetricBatcherRemoveFlushesPending(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	var flushes atomic.Int64
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			flushes.Add(1)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.Background()))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	require.NoError(t, batcher.Remove(t.Context(), "endpoint-1:4317", exp))
+
+	require.Equal(t, int64(1), flushes.Load())
+}
+
+func TestMetricBatcherShutdownFlushesPending(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	flushed := make(chan int, 1)
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, reason string) error {
+			if reason == metricFlushReasonShutdown {
+				flushed <- md.DataPointCount()
+			}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+	require.NoError(t, batcher.Shutdown(context.Background()))
+
+	select {
+	case got := <-flushed:
+		require.Equal(t, 1, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected metric batch flush on shutdown")
+	}
+}
+
+func TestMetricBatcherRemoveTimeoutSchedulesCleanup(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error { return nil },
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.Background()))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+
+	batcher.mu.RLock()
+	backend := batcher.backends["endpoint-1:4317"]
+	batcher.mu.RUnlock()
+	require.NotNil(t, backend)
+
+	backend.inflight.Add(1)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	err = batcher.Remove(ctx, "endpoint-1:4317", exp)
+	require.Error(t, err)
+
+	go backend.inflight.Done()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-backend.done:
+			return true
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestMetricBatcherRestoresPendingOnTimeoutFlushFailure(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	var calls atomic.Int64
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: 30 * time.Millisecond},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			if calls.Add(1) == 1 {
+				return errors.New("boom")
+			}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.Background()))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+
+	require.Eventually(t, func() bool {
+		return calls.Load() >= 2
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	sendStarted := make(chan struct{}, 1)
+	blockSend := make(chan struct{})
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1, maxBytes: 1 << 20, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			select {
+			case sendStarted <- struct{}{}:
+			default:
+			}
+			<-blockSend
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		close(blockSend)
+		require.NoError(t, batcher.Shutdown(context.Background()))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
+
+	select {
+	case <-sendStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected backend send to start")
+	}
+
+	for i := 0; i < 16; i++ {
+		enqueued, enqueueErr := batcher.TryEnqueue("endpoint-1:4317", exp, singleDataPointMetric("m1"))
+		require.NoError(t, enqueueErr)
+		require.True(t, enqueued)
+	}
+
+	enqueued, enqueueErr := batcher.TryEnqueue("endpoint-1:4317", exp, singleDataPointMetric("m1"))
+	require.NoError(t, enqueueErr)
+	require.False(t, enqueued)
+}
+
+func singleDataPointMetric(name string) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	m := sm.Metrics().AppendEmpty()
+	m.SetName(name)
+	g := m.SetEmptyGauge()
+	g.DataPoints().AppendEmpty().SetIntValue(1)
+	return md
+}

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -29,7 +29,7 @@ func TestMetricBatcherFlushesOnMaxDataPoints(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, batcher.Shutdown(context.Background()))
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
@@ -59,7 +59,7 @@ func TestMetricBatcherFlushesOnInterval(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, batcher.Shutdown(context.Background()))
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
@@ -88,7 +88,7 @@ func TestMetricBatcherRemoveFlushesPending(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, batcher.Shutdown(context.Background()))
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
@@ -117,7 +117,7 @@ func TestMetricBatcherShutdownFlushesPending(t *testing.T) {
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
 	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, singleDataPointMetric("m1")))
-	require.NoError(t, batcher.Shutdown(context.Background()))
+	require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
 
 	select {
 	case got := <-flushed:
@@ -137,7 +137,7 @@ func TestMetricBatcherRemoveTimeoutSchedulesCleanup(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, batcher.Shutdown(context.Background()))
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
@@ -149,7 +149,7 @@ func TestMetricBatcherRemoveTimeoutSchedulesCleanup(t *testing.T) {
 	require.NotNil(t, backend)
 
 	backend.inflight.Add(1)
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
 	defer cancel()
 	err = batcher.Remove(ctx, "endpoint-1:4317", exp)
 	require.Error(t, err)
@@ -183,7 +183,7 @@ func TestMetricBatcherRestoresPendingOnTimeoutFlushFailure(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, batcher.Shutdown(context.Background()))
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
@@ -215,7 +215,7 @@ func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		close(blockSend)
-		require.NoError(t, batcher.Shutdown(context.Background()))
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
@@ -227,7 +227,7 @@ func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T)
 		t.Fatal("expected backend send to start")
 	}
 
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		enqueued, enqueueErr := batcher.TryEnqueue("endpoint-1:4317", exp, singleDataPointMetric("m1"))
 		require.NoError(t, enqueueErr)
 		require.True(t, enqueued)

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -28,14 +29,16 @@ import (
 
 var _ exporter.Metrics = (*metricExporterImp)(nil)
 
+const metricBatcherEnqueueBackoff = 2 * time.Millisecond
+
 type metricExporterImp struct {
 	loadBalancer *loadBalancer
+	batcher      *metricBatcher
 	routingKey   routingKey
 
-	logger     *zap.Logger
-	stopped    bool
-	shutdownWg sync.WaitGroup
-	telemetry  *metadata.TelemetryBuilder
+	logger    *zap.Logger
+	started   atomic.Bool
+	telemetry *metadata.TelemetryBuilder
 }
 
 func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metricExporterImp, error) {
@@ -76,6 +79,26 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 	default:
 		return nil, fmt.Errorf("unsupported routing_key: %q", cfg.(*Config).RoutingKey)
 	}
+
+	if cfg.(*Config).MetricBatcher.Enabled {
+		metricExporter.batcher, err = newMetricBatcher(
+			params.Logger,
+			params.TelemetrySettings,
+			metricBatcherSettings{
+				maxDataPoints: cfg.(*Config).MetricBatcher.MaxDataPoints,
+				maxBytes:      cfg.(*Config).MetricBatcher.MaxBytes,
+				flushInterval: cfg.(*Config).MetricBatcher.FlushInterval,
+			},
+			metricExporter.consumeBatch,
+		)
+		if err != nil {
+			return nil, err
+		}
+		lb.onExporterRemove = func(ctx context.Context, endpoint string, exp *wrappedExporter) error {
+			return metricExporter.batcher.Remove(ctx, endpoint, exp)
+		}
+	}
+
 	return &metricExporter, nil
 }
 
@@ -84,17 +107,52 @@ func (*metricExporterImp) Capabilities() consumer.Capabilities {
 }
 
 func (e *metricExporterImp) Start(ctx context.Context, host component.Host) error {
-	return e.loadBalancer.Start(ctx, host)
+	if err := e.loadBalancer.Start(ctx, host); err != nil {
+		return err
+	}
+	e.started.Store(true)
+	return nil
 }
 
 func (e *metricExporterImp) Shutdown(ctx context.Context) error {
-	err := e.loadBalancer.Shutdown(ctx)
-	e.stopped = true
-	e.shutdownWg.Wait()
+	if !e.started.Swap(false) {
+		return nil
+	}
+	var err error
+	if e.batcher != nil {
+		err = e.batcher.Shutdown(ctx)
+	}
+	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))
 	return err
 }
 
 func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	if !e.started.Load() {
+		return errExporterIsStopping
+	}
+
+	batches, err := e.splitMetricsByRouting(md)
+	if err != nil {
+		return err
+	}
+
+	if e.batcher != nil {
+		endpointBatches, err := e.groupRoutedMetricsByEndpoint(batches)
+		if err != nil {
+			return err
+		}
+		return e.enqueueEndpointBatches(ctx, endpointBatches, true)
+	}
+
+	return e.consumeMetricsByExporter(ctx, batches)
+}
+
+type endpointMetricsBatch struct {
+	metrics pmetric.Metrics
+	exp     *wrappedExporter
+}
+
+func (e *metricExporterImp) splitMetricsByRouting(md pmetric.Metrics) (map[string]pmetric.Metrics, error) {
 	var batches map[string]pmetric.Metrics
 
 	switch e.routingKey {
@@ -106,7 +164,7 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 				e.logger.Error("failed to export metric", zap.Error(ee))
 			}
 			if len(batches) == 0 {
-				return consumererror.NewPermanent(errors.Join(errs...))
+				return nil, consumererror.NewPermanent(errors.Join(errs...))
 			}
 		}
 	case resourceRouting:
@@ -117,9 +175,139 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 		batches = splitMetricsByStreamID(md)
 	}
 
+	return batches, nil
+}
+
+func (e *metricExporterImp) groupRoutedMetricsByEndpoint(
+	batches map[string]pmetric.Metrics,
+) (map[string]*endpointMetricsBatch, error) {
+	endpointBatches := make(map[string]*endpointMetricsBatch)
+
+	for routingID, mds := range batches {
+		exp, endpoint, err := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
+		if err != nil {
+			return nil, err
+		}
+
+		ep := endpointWithPort(endpoint)
+		batch, ok := endpointBatches[ep]
+		if !ok {
+			batch = &endpointMetricsBatch{metrics: pmetric.NewMetrics(), exp: exp}
+			endpointBatches[ep] = batch
+		}
+		batch.exp = exp
+		metrics.Merge(batch.metrics, mds)
+	}
+
+	return endpointBatches, nil
+}
+
+func (e *metricExporterImp) enqueueEndpointBatches(
+	ctx context.Context,
+	batches map[string]*endpointMetricsBatch,
+	retryOnStopping bool,
+) error {
+	var errs error
+	failed := pmetric.NewMetrics()
+	if len(batches) == 0 {
+		return nil
+	}
+
+	pending := make(map[string]*endpointMetricsBatch, len(batches))
+	for ep, batch := range batches {
+		pending[ep] = batch
+	}
+
+	for len(pending) > 0 {
+		madeProgress := false
+
+		for ep, batch := range pending {
+			// TryEnqueue is non-blocking; false,nil means queue is currently full.
+			enqueued, err := e.batcher.TryEnqueue(ep, batch.exp, batch.metrics)
+
+			if errors.Is(err, errMetricBatcherExporterStopping) && retryOnStopping {
+				// Reroute once when endpoint exporter is stopping.
+				rerouted, rerouteErr := e.splitMetricsByRouting(batch.metrics)
+				errs = multierr.Append(errs, rerouteErr)
+				if rerouteErr != nil {
+					metrics.Merge(failed, batch.metrics)
+				} else {
+					reroutedBatches, groupErr := e.groupRoutedMetricsByEndpoint(rerouted)
+					errs = multierr.Append(errs, groupErr)
+					if groupErr != nil {
+						metrics.Merge(failed, batch.metrics)
+					} else {
+						rerouteErr = e.enqueueEndpointBatches(ctx, reroutedBatches, false)
+						if rerouteErr != nil {
+							var mErr consumererror.Metrics
+							if errors.As(rerouteErr, &mErr) {
+								metrics.Merge(failed, mErr.Data())
+								rerouteErr = errors.Unwrap(mErr)
+							}
+							errs = multierr.Append(errs, rerouteErr)
+						}
+					}
+				}
+				delete(pending, ep)
+				continue
+			}
+			if err != nil {
+				errs = multierr.Append(errs, err)
+				metrics.Merge(failed, batch.metrics)
+				delete(pending, ep)
+				continue
+			}
+			if enqueued {
+				madeProgress = true
+				delete(pending, ep)
+			}
+		}
+
+		if len(pending) == 0 {
+			break
+		}
+
+		if madeProgress {
+			continue
+		}
+
+		// Back off when all pending endpoint queues are currently full.
+		timer := time.NewTimer(metricBatcherEnqueueBackoff)
+		select {
+		case <-ctx.Done():
+			// If context was canceled or timed out we send out failed & pending metrics for a retry
+			for _, batch := range pending {
+				metrics.Merge(failed, batch.metrics)
+			}
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			errs = multierr.Append(errs, ctx.Err())
+			if failed.DataPointCount() > 0 {
+				return consumererror.NewMetrics(errs, failed)
+			}
+			return errs
+		case <-timer.C:
+		}
+	}
+
+	if failed.DataPointCount() > 0 {
+		return consumererror.NewMetrics(errs, failed)
+	}
+
+	return errs
+}
+
+func (e *metricExporterImp) consumeMetricsByExporter(
+	ctx context.Context,
+	batches map[string]pmetric.Metrics,
+) error {
+
 	// Now assign each batch to an exporter, and merge as we go
 	metricsByExporter := map[*wrappedExporter]pmetric.Metrics{}
-	exporterEndpoints := map[*wrappedExporter]string{}
 	needsCleanup := true
 	defer func() {
 		if !needsCleanup {
@@ -131,7 +319,7 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 	}()
 
 	for routingID, mds := range batches {
-		exp, endpoint, err := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
+		exp, _, err := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
 		if err != nil {
 			return err
 		}
@@ -143,31 +331,62 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 			}
 			expMetrics = pmetric.NewMetrics()
 			metricsByExporter[exp] = expMetrics
-			exporterEndpoints[exp] = endpoint
 		}
 
 		metrics.Merge(expMetrics, mds)
 	}
 
 	needsCleanup = false
-	var errs error
+	var (
+		errMu sync.Mutex
+		errs  error
+		wg    sync.WaitGroup
+	)
 	for exp, mds := range metricsByExporter {
-		start := time.Now()
-		err := exp.ConsumeMetrics(ctx, mds)
-		duration := time.Since(start)
+		wg.Add(1)
+		go func(exp *wrappedExporter, mds pmetric.Metrics) {
+			defer wg.Done()
+			start := time.Now()
+			err := exp.ConsumeMetrics(ctx, mds)
+			duration := time.Since(start)
 
-		exp.doneConsume()
-		errs = multierr.Append(errs, err)
-		e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(exp.endpointAttr))
-		if err == nil {
-			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.successAttr))
-		} else {
-			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.failureAttr))
-			e.logger.Debug("failed to export metrics", zap.Error(err))
-		}
+			exp.doneConsume()
+			errMu.Lock()
+			errs = multierr.Append(errs, err)
+			errMu.Unlock()
+			e.recordBackendResult(ctx, exp, duration, err)
+		}(exp, mds)
 	}
+	wg.Wait()
 
 	return errs
+}
+
+func (e *metricExporterImp) consumeBatch(ctx context.Context, we *wrappedExporter, md pmetric.Metrics, reason string) error {
+	if reason == metricFlushReasonResolverChange || reason == metricFlushReasonShutdown {
+		we.forceStartConsume()
+	} else if !we.tryStartConsume() {
+		return errMetricBatcherExporterStopping
+	}
+	defer we.doneConsume()
+
+	start := time.Now()
+	err := we.ConsumeMetrics(ctx, md)
+	duration := time.Since(start)
+	e.recordBackendResult(ctx, we, duration, err)
+
+	return err
+}
+
+func (e *metricExporterImp) recordBackendResult(ctx context.Context, we *wrappedExporter, duration time.Duration, err error) {
+	e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(we.endpointAttr))
+	if err == nil {
+		e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(we.successAttr))
+		return
+	}
+
+	e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(we.failureAttr))
+	e.logger.Debug("failed to export metrics", zap.Error(err))
 }
 
 func splitMetricsByResourceServiceName(md pmetric.Metrics) (map[string]pmetric.Metrics, []error) {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -378,7 +379,24 @@ func (e *metricExporterImp) rerouteDrainBatch(ctx context.Context, md pmetric.Me
 	}
 
 	metricsByExporter := map[*wrappedExporter]pmetric.Metrics{}
-	for routingID, mds := range batches {
+	needsCleanup := true
+	defer func() {
+		if !needsCleanup {
+			return
+		}
+		for exp := range metricsByExporter {
+			exp.doneConsume()
+		}
+	}()
+
+	routingIDs := make([]string, 0, len(batches))
+	for routingID := range batches {
+		routingIDs = append(routingIDs, routingID)
+	}
+	sort.Strings(routingIDs)
+
+	for _, routingID := range routingIDs {
+		mds := batches[routingID]
 		exp, _, lookupErr := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
 		if lookupErr != nil {
 			return consumererror.NewMetrics(lookupErr, md)
@@ -398,6 +416,7 @@ func (e *metricExporterImp) rerouteDrainBatch(ctx context.Context, md pmetric.Me
 
 	failed := pmetric.NewMetrics()
 	var errs error
+	needsCleanup = false
 	for exp, mds := range metricsByExporter {
 		start := time.Now()
 		err = exp.ConsumeMetrics(ctx, mds)

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sync/atomic"
 	"time"
 
@@ -213,9 +214,7 @@ func (e *metricExporterImp) enqueueEndpointBatches(
 	}
 
 	pending := make(map[string]*endpointMetricsBatch, len(batches))
-	for ep, batch := range batches {
-		pending[ep] = batch
-	}
+	maps.Copy(pending, batches)
 
 	for len(pending) > 0 {
 		madeProgress := false
@@ -304,7 +303,6 @@ func (e *metricExporterImp) consumeMetricsByExporter(
 	ctx context.Context,
 	batches map[string]pmetric.Metrics,
 ) error {
-
 	// Now assign each batch to an exporter, and merge as we go
 	metricsByExporter := map[*wrappedExporter]pmetric.Metrics{}
 	needsCleanup := true

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -90,6 +90,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 				flushInterval: cfg.(*Config).MetricBatcher.FlushInterval,
 			},
 			metricExporter.consumeBatch,
+			metricExporter.rerouteDrainBatch,
 		)
 		if err != nil {
 			return nil, err
@@ -368,6 +369,55 @@ func (e *metricExporterImp) consumeBatch(ctx context.Context, we *wrappedExporte
 	e.recordBackendResult(ctx, we, duration, err)
 
 	return err
+}
+
+func (e *metricExporterImp) rerouteDrainBatch(ctx context.Context, md pmetric.Metrics, _ string) error {
+	batches, err := e.splitMetricsByRouting(md)
+	if err != nil {
+		return err
+	}
+
+	metricsByExporter := map[*wrappedExporter]pmetric.Metrics{}
+	for routingID, mds := range batches {
+		exp, _, lookupErr := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
+		if lookupErr != nil {
+			return consumererror.NewMetrics(lookupErr, md)
+		}
+
+		expMetrics, ok := metricsByExporter[exp]
+		if !ok {
+			if !exp.tryStartConsume() {
+				return consumererror.NewMetrics(errExporterIsStopping, md)
+			}
+			expMetrics = pmetric.NewMetrics()
+			metricsByExporter[exp] = expMetrics
+		}
+
+		metrics.Merge(expMetrics, mds)
+	}
+
+	failed := pmetric.NewMetrics()
+	var errs error
+	for exp, mds := range metricsByExporter {
+		start := time.Now()
+		err = exp.ConsumeMetrics(ctx, mds)
+		duration := time.Since(start)
+
+		exp.doneConsume()
+		e.recordBackendResult(ctx, exp, duration, err)
+		if err == nil {
+			continue
+		}
+
+		errs = errors.Join(errs, err)
+		metrics.Merge(failed, mds)
+	}
+
+	if failed.DataPointCount() > 0 {
+		return consumererror.NewMetrics(errs, failed)
+	}
+
+	return errs
 }
 
 func (e *metricExporterImp) recordBackendResult(ctx context.Context, we *wrappedExporter, duration time.Duration, err error) {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -337,27 +336,22 @@ func (e *metricExporterImp) consumeMetricsByExporter(
 	}
 
 	needsCleanup = false
-	var (
-		errMu sync.Mutex
-		errs  error
-		wg    sync.WaitGroup
-	)
+	var errs error
 	for exp, mds := range metricsByExporter {
-		wg.Add(1)
-		go func(exp *wrappedExporter, mds pmetric.Metrics) {
-			defer wg.Done()
-			start := time.Now()
-			err := exp.ConsumeMetrics(ctx, mds)
-			duration := time.Since(start)
+		start := time.Now()
+		err := exp.ConsumeMetrics(ctx, mds)
+		duration := time.Since(start)
 
-			exp.doneConsume()
-			errMu.Lock()
-			errs = multierr.Append(errs, err)
-			errMu.Unlock()
-			e.recordBackendResult(ctx, exp, duration, err)
-		}(exp, mds)
+		exp.doneConsume()
+		errs = multierr.Append(errs, err)
+		e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(exp.endpointAttr))
+		if err == nil {
+			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.successAttr))
+		} else {
+			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.failureAttr))
+			e.logger.Debug("failed to export metrics", zap.Error(err))
+		}
 	}
-	wg.Wait()
 
 	return errs
 }

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -86,9 +86,10 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 			params.Logger,
 			params.TelemetrySettings,
 			metricBatcherSettings{
-				maxDataPoints: cfg.(*Config).MetricBatcher.MaxDataPoints,
-				maxBytes:      cfg.(*Config).MetricBatcher.MaxBytes,
-				flushInterval: cfg.(*Config).MetricBatcher.FlushInterval,
+				maxDataPoints:            cfg.(*Config).MetricBatcher.MaxDataPoints,
+				maxBytes:                 cfg.(*Config).MetricBatcher.MaxBytes,
+				flushInterval:            cfg.(*Config).MetricBatcher.FlushInterval,
+				maxRetryBufferMultiplier: cfg.(*Config).MetricBatcher.MaxRetryBufferMultiplier,
 			},
 			metricExporter.consumeBatch,
 			metricExporter.rerouteDrainBatch,

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -416,7 +416,7 @@ func TestConsumeMetrics_SingleEndpointWithMetricBatcher(t *testing.T) {
 		RoutingKey: metricNameRoutingStr,
 		MetricBatcher: MetricBatcherConfig{
 			Enabled:       true,
-			MaxDataPoints: 1,
+			MaxDataPoints: 2,
 			MaxBytes:      1 << 20,
 			FlushInterval: time.Hour,
 		},
@@ -450,9 +450,15 @@ func TestConsumeMetrics_SingleEndpointWithMetricBatcher(t *testing.T) {
 		require.NoError(t, p.Shutdown(t.Context()))
 	}()
 
-	input := singleDataPointMetric("batcher-metric")
-	input.ResourceMetrics().At(0).Resource().Attributes().PutStr(serviceNameKey, serviceName1)
-	err = p.ConsumeMetrics(t.Context(), input)
+	input1 := singleDataPointMetric("batcher-metric-1")
+	input1.ResourceMetrics().At(0).Resource().Attributes().PutStr(serviceNameKey, serviceName1)
+	err = p.ConsumeMetrics(t.Context(), input1)
+	require.NoError(t, err)
+	require.Empty(t, sink.AllMetrics(), "first call should stay buffered in metric batcher")
+
+	input2 := singleDataPointMetric("batcher-metric-2")
+	input2.ResourceMetrics().At(0).Resource().Attributes().PutStr(serviceNameKey, serviceName1)
+	err = p.ConsumeMetrics(t.Context(), input2)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
@@ -461,14 +467,25 @@ func TestConsumeMetrics_SingleEndpointWithMetricBatcher(t *testing.T) {
 
 	allOutputs := sink.AllMetrics()
 	require.Len(t, allOutputs, 1)
-	require.NoError(t, pmetrictest.CompareMetrics(
-		input,
-		allOutputs[0],
-		pmetrictest.IgnoreResourceMetricsOrder(),
-		pmetrictest.IgnoreScopeMetricsOrder(),
-		pmetrictest.IgnoreMetricsOrder(),
-		pmetrictest.IgnoreMetricDataPointsOrder(),
-	))
+	actual := allOutputs[0]
+	require.Equal(t, 2, actual.DataPointCount())
+
+	names := map[string]struct{}{}
+	resourceMetrics := actual.ResourceMetrics()
+	for i := range resourceMetrics.Len() {
+		scopeMetrics := resourceMetrics.At(i).ScopeMetrics()
+		for j := range scopeMetrics.Len() {
+			metrics := scopeMetrics.At(j).Metrics()
+			for k := range metrics.Len() {
+				names[metrics.At(k).Name()] = struct{}{}
+			}
+		}
+	}
+
+	_, hasMetric1 := names["batcher-metric-1"]
+	_, hasMetric2 := names["batcher-metric-2"]
+	require.True(t, hasMetric1)
+	require.True(t, hasMetric2)
 }
 
 func TestEnqueueEndpointBatchesMakesProgressWhenOneQueueIsFull(t *testing.T) {
@@ -540,11 +557,58 @@ func TestEnqueueEndpointBatchesReturnsFailedSubsetOnBackendError(t *testing.T) {
 
 	var mErr consumererror.Metrics
 	require.ErrorAs(t, err, &mErr)
-	require.ErrorContains(t, err, "metric batcher backend is stopped")
+	require.ErrorIs(t, err, errMetricBatcherExporterStopping)
 	require.Len(t, openBackend.requests, 1)
 	require.NoError(t, pmetrictest.CompareMetrics(
 		singleDataPointMetric("m1"),
 		mErr.Data(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+	))
+}
+
+func TestEnqueueEndpointBatchesReroutesOnExporterStopping(t *testing.T) {
+	stoppedBackend := &backendMetricBatcher{requests: make(chan metricBatcherRequest, 1), done: make(chan struct{})}
+	openBackend := &backendMetricBatcher{requests: make(chan metricBatcherRequest, 1), done: make(chan struct{})}
+
+	openExporter := newWrappedExporter(newNopMockMetricsExporter(), "open:4317")
+
+	p := &metricExporterImp{
+		routingKey: metricNameRouting,
+		loadBalancer: &loadBalancer{
+			ring: newHashRing([]string{"open:4317"}),
+			exporters: map[string]*wrappedExporter{
+				"open:4317": openExporter,
+			},
+		},
+		batcher: &metricBatcher{
+			backends: map[string]*backendMetricBatcher{
+				"stopped:4317": stoppedBackend,
+				"open:4317":    openBackend,
+			},
+		},
+	}
+
+	stoppingExporter := newWrappedExporter(newNopMockMetricsExporter(), "stopped:4317")
+	stoppingExporter.markStopping()
+
+	err := p.enqueueEndpointBatches(t.Context(), map[string]*endpointMetricsBatch{
+		"stopped:4317": {
+			metrics: singleDataPointMetric("reroute-metric"),
+			exp:     stoppingExporter,
+		},
+	}, true)
+	require.NoError(t, err)
+	require.Empty(t, stoppedBackend.requests)
+
+	require.Len(t, openBackend.requests, 1)
+	request := <-openBackend.requests
+	require.Equal(t, metricBatcherRequestEnqueue, request.kind)
+	require.NoError(t, pmetrictest.CompareMetrics(
+		singleDataPointMetric("reroute-metric"),
+		request.md,
 		pmetrictest.IgnoreResourceMetricsOrder(),
 		pmetrictest.IgnoreScopeMetricsOrder(),
 		pmetrictest.IgnoreMetricsOrder(),

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -403,6 +404,152 @@ func TestConsumeMetrics_SingleEndpoint(t *testing.T) {
 			))
 		})
 	}
+}
+
+func TestConsumeMetrics_SingleEndpointWithMetricBatcher(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	config := &Config{
+		Resolver: ResolverSettings{
+			Static: configoptional.Some(StaticResolver{Hostnames: []string{"endpoint-1"}}),
+		},
+		RoutingKey: metricNameRoutingStr,
+		MetricBatcher: MetricBatcherConfig{
+			Enabled:       true,
+			MaxDataPoints: 1,
+			MaxBytes:      1 << 20,
+			FlushInterval: time.Hour,
+		},
+	}
+
+	p, err := newMetricsExporter(ts, config)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	sink := consumertest.MetricsSink{}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newMockMetricsExporter(sink.ConsumeMetrics), nil
+	}
+
+	lb, err := newLoadBalancer(ts.Logger, config, componentFactory, tb)
+	require.NoError(t, err)
+	require.NotNil(t, lb)
+
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1"})
+	lb.res = &mockResolver{
+		triggerCallbacks: true,
+		onResolve: func(_ context.Context) ([]string, error) {
+			return []string{"endpoint-1"}, nil
+		},
+	}
+	p.loadBalancer = lb
+
+	err = p.Start(t.Context(), componenttest.NewNopHost())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	input := singleDataPointMetric("batcher-metric")
+	input.ResourceMetrics().At(0).Resource().Attributes().PutStr(serviceNameKey, serviceName1)
+	err = p.ConsumeMetrics(t.Context(), input)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return len(sink.AllMetrics()) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	allOutputs := sink.AllMetrics()
+	require.Len(t, allOutputs, 1)
+	require.NoError(t, pmetrictest.CompareMetrics(
+		input,
+		allOutputs[0],
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+	))
+}
+
+func TestEnqueueEndpointBatchesMakesProgressWhenOneQueueIsFull(t *testing.T) {
+	fullBackend := &backendMetricBatcher{requests: make(chan metricBatcherRequest, 1), done: make(chan struct{})}
+	openBackend := &backendMetricBatcher{requests: make(chan metricBatcherRequest, 1), done: make(chan struct{})}
+	fullBackend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: singleDataPointMetric("prefilled")}
+
+	p := &metricExporterImp{
+		batcher: &metricBatcher{
+			backends: map[string]*backendMetricBatcher{
+				"full:4317": fullBackend,
+				"open:4317": openBackend,
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := p.enqueueEndpointBatches(ctx, map[string]*endpointMetricsBatch{
+		"full:4317": {
+			metrics: singleDataPointMetric("m1"),
+			exp:     newWrappedExporter(newNopMockMetricsExporter(), "full:4317"),
+		},
+		"open:4317": {
+			metrics: singleDataPointMetric("m2"),
+			exp:     newWrappedExporter(newNopMockMetricsExporter(), "open:4317"),
+		},
+	}, false)
+
+	var mErr consumererror.Metrics
+	require.ErrorAs(t, err, &mErr)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, len(openBackend.requests))
+	require.NoError(t, pmetrictest.CompareMetrics(
+		singleDataPointMetric("m1"),
+		mErr.Data(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+	))
+}
+
+func TestEnqueueEndpointBatchesReturnsFailedSubsetOnBackendError(t *testing.T) {
+	stoppedBackend := &backendMetricBatcher{requests: make(chan metricBatcherRequest, 1), done: make(chan struct{})}
+	close(stoppedBackend.done)
+	openBackend := &backendMetricBatcher{requests: make(chan metricBatcherRequest, 1), done: make(chan struct{})}
+
+	p := &metricExporterImp{
+		batcher: &metricBatcher{
+			backends: map[string]*backendMetricBatcher{
+				"stopped:4317": stoppedBackend,
+				"open:4317":    openBackend,
+			},
+		},
+	}
+
+	err := p.enqueueEndpointBatches(context.Background(), map[string]*endpointMetricsBatch{
+		"stopped:4317": {
+			metrics: singleDataPointMetric("m1"),
+			exp:     newWrappedExporter(newNopMockMetricsExporter(), "stopped:4317"),
+		},
+		"open:4317": {
+			metrics: singleDataPointMetric("m2"),
+			exp:     newWrappedExporter(newNopMockMetricsExporter(), "open:4317"),
+		},
+	}, false)
+
+	var mErr consumererror.Metrics
+	require.ErrorAs(t, err, &mErr)
+	require.ErrorContains(t, err, "metric batcher backend is stopped")
+	require.Equal(t, 1, len(openBackend.requests))
+	require.NoError(t, pmetrictest.CompareMetrics(
+		singleDataPointMetric("m1"),
+		mErr.Data(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+	))
 }
 
 func TestConsumeMetrics_SingleEndpointNoServiceName(t *testing.T) {

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -677,6 +677,68 @@ func TestRerouteDrainBatchReturnsFailedSubsetOnPartialSuccess(t *testing.T) {
 	))
 }
 
+func TestRerouteDrainBatchReleasesStartedConsumesOnEarlyReturn(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	endpointA := "endpoint-a:4317"
+	endpointB := "endpoint-b:4317"
+	lb := &loadBalancer{ring: newHashRing([]string{endpointA, endpointB})}
+
+	routingA := findRoutingIDForEndpoint(t, lb.ring, endpointA)
+	routingB := findRoutingIDForEndpoint(t, lb.ring, endpointB)
+
+	openEndpoint, openRouting := endpointA, routingA
+	stoppingEndpoint, stoppingRouting := endpointB, routingB
+	if routingA > routingB {
+		openEndpoint, openRouting = endpointB, routingB
+		stoppingEndpoint, stoppingRouting = endpointA, routingA
+	}
+
+	openExporter := newWrappedExporter(newNopMockMetricsExporter(), openEndpoint)
+	stoppingExporter := newWrappedExporter(newNopMockMetricsExporter(), stoppingEndpoint)
+	stoppingExporter.markStopping()
+
+	lb.exporters = map[string]*wrappedExporter{
+		openEndpoint:     openExporter,
+		stoppingEndpoint: stoppingExporter,
+	}
+
+	p := &metricExporterImp{
+		routingKey:   metricNameRouting,
+		loadBalancer: lb,
+		telemetry:    tb,
+		logger:       ts.Logger,
+	}
+
+	input := pmetric.NewMetrics()
+	rm := input.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	mOpen := sm.Metrics().AppendEmpty()
+	mOpen.SetName(openRouting)
+	mOpen.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+	mStopping := sm.Metrics().AppendEmpty()
+	mStopping.SetName(stoppingRouting)
+	mStopping.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+
+	err := p.rerouteDrainBatch(t.Context(), input, metricFlushReasonResolverChange)
+	require.Error(t, err)
+
+	var mErr consumererror.Metrics
+	require.ErrorAs(t, err, &mErr)
+
+	shutdownErr := make(chan error, 1)
+	go func() {
+		shutdownErr <- openExporter.Shutdown(t.Context())
+	}()
+
+	select {
+	case shutdown := <-shutdownErr:
+		require.NoError(t, shutdown)
+	case <-time.After(time.Second):
+		t.Fatal("expected started consume slot to be released on reroute early return")
+	}
+}
+
 func TestConsumeMetrics_SingleEndpointNoServiceName(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -485,7 +485,7 @@ func TestEnqueueEndpointBatchesMakesProgressWhenOneQueueIsFull(t *testing.T) {
 		},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer cancel()
 
 	err := p.enqueueEndpointBatches(ctx, map[string]*endpointMetricsBatch{
@@ -502,7 +502,7 @@ func TestEnqueueEndpointBatchesMakesProgressWhenOneQueueIsFull(t *testing.T) {
 	var mErr consumererror.Metrics
 	require.ErrorAs(t, err, &mErr)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
-	require.Equal(t, 1, len(openBackend.requests))
+	require.Len(t, openBackend.requests, 1)
 	require.NoError(t, pmetrictest.CompareMetrics(
 		singleDataPointMetric("m1"),
 		mErr.Data(),
@@ -527,7 +527,7 @@ func TestEnqueueEndpointBatchesReturnsFailedSubsetOnBackendError(t *testing.T) {
 		},
 	}
 
-	err := p.enqueueEndpointBatches(context.Background(), map[string]*endpointMetricsBatch{
+	err := p.enqueueEndpointBatches(t.Context(), map[string]*endpointMetricsBatch{
 		"stopped:4317": {
 			metrics: singleDataPointMetric("m1"),
 			exp:     newWrappedExporter(newNopMockMetricsExporter(), "stopped:4317"),
@@ -541,7 +541,7 @@ func TestEnqueueEndpointBatchesReturnsFailedSubsetOnBackendError(t *testing.T) {
 	var mErr consumererror.Metrics
 	require.ErrorAs(t, err, &mErr)
 	require.ErrorContains(t, err, "metric batcher backend is stopped")
-	require.Equal(t, 1, len(openBackend.requests))
+	require.Len(t, openBackend.requests, 1)
 	require.NoError(t, pmetrictest.CompareMetrics(
 		singleDataPointMetric("m1"),
 		mErr.Data(),

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -616,6 +616,67 @@ func TestEnqueueEndpointBatchesReroutesOnExporterStopping(t *testing.T) {
 	))
 }
 
+func TestRerouteDrainBatchReturnsFailedSubsetOnPartialSuccess(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	lb := &loadBalancer{ring: newHashRing([]string{"ok", "fail"})}
+	metricForOK := findRoutingIDForEndpoint(t, lb.ring, "ok")
+	metricForFail := findRoutingIDForEndpoint(t, lb.ring, "fail")
+
+	consumed := make(chan int, 1)
+	okExporter := newWrappedExporter(newMockMetricsExporter(func(_ context.Context, md pmetric.Metrics) error {
+		consumed <- md.DataPointCount()
+		return nil
+	}), "ok:4317")
+	failExporter := newWrappedExporter(newMockMetricsExporter(func(context.Context, pmetric.Metrics) error {
+		return errors.New("backend failed")
+	}), "fail:4317")
+
+	lb.exporters = map[string]*wrappedExporter{
+		"ok:4317":   okExporter,
+		"fail:4317": failExporter,
+	}
+
+	p := &metricExporterImp{
+		routingKey:   metricNameRouting,
+		loadBalancer: lb,
+		telemetry:    tb,
+		logger:       ts.Logger,
+	}
+
+	input := pmetric.NewMetrics()
+	rm := input.ResourceMetrics().AppendEmpty()
+	sm := rm.ScopeMetrics().AppendEmpty()
+	m1 := sm.Metrics().AppendEmpty()
+	m1.SetName(metricForOK)
+	m1.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+	m2 := sm.Metrics().AppendEmpty()
+	m2.SetName(metricForFail)
+	m2.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(1)
+
+	err := p.rerouteDrainBatch(t.Context(), input, metricFlushReasonResolverChange)
+	require.Error(t, err)
+
+	var mErr consumererror.Metrics
+	require.ErrorAs(t, err, &mErr)
+
+	select {
+	case got := <-consumed:
+		require.Equal(t, 1, got)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected successful reroute send")
+	}
+
+	require.NoError(t, pmetrictest.CompareMetrics(
+		singleDataPointMetric(metricForFail),
+		mErr.Data(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+	))
+}
+
 func TestConsumeMetrics_SingleEndpointNoServiceName(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds metric batching to the `loadbalancingexporter`, grouping metrics by endpoint and sending in parallel to cut request volume and latency. Keeps the original per-exporter path when `metric_batcher.enabled=false`. Implements SAW-6902.

- **New Features**
  - Batch per endpoint and send in parallel; flush on size, interval, resolver change, or shutdown.
  - New `metric_batcher` config: `enabled`, `max_datapoints`, `max_bytes`, `flush_interval`, `max_retry_buffer_multiplier`; validation added; off by default.
  - Non-blocking `TryEnqueue` with brief backoff when all queues are full; reroutes once if an endpoint exporter is stopping; on errors or cancel, return a `consumererror.Metrics` with only the failed subset.
  - Retry policy on flush failures: restore pending and retry with exponential backoff (up to 5s), bounded by `max_retry_buffer_multiplier` and a 2‑minute max retry age; drop with telemetry once limits are exceeded.
  - Drain on shutdown or resolver change: if a flush fails, reroute the batch to healthy backends; partial successes return only the failed subset.
  - Telemetry for batch size/bytes, flushes (with reason), errors, overflows, dropped datapoints, and per-endpoint pending gauges.

- **Bug Fixes**
  - Always release exporter consume slots on early returns during reroute/drain to prevent stuck shutdowns.

<sup>Written for commit 93e173846507792e0593c0194cb5e0392eea42e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable per-endpoint metric batching (enable/disable, max datapoints, max bytes, flush interval) with non-blocking enqueue; retries return only failed metric subsets.

* **Improvements**
  * More robust exporter start/shutdown semantics to avoid duplicate shutdowns and better handling when stopping.

* **Documentation**
  * Added a changelog entry describing the enhancement.

* **Tests**
  * Added extensive tests for batching, flushing, backpressure, enqueue failures, retries, removal, and shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->