### PR TITLE
fix(loadbalancingexporter): restore in-memory queue compression

### DIFF
--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -135,9 +135,6 @@ const (
 func (q QueueSettings) Validate() error {
 	if q.QueueConfig.HasValue() {
 		queueCfg := *q.QueueConfig.Get()
-		if q.CompressInMemory && queueCfg.StorageID == nil {
-			queueCfg.StorageID = &inMemoryQueueStorageID
-		}
 		if err := queueCfg.Validate(); err != nil {
 			return err
 		}

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -67,7 +67,7 @@ func TestConfigValidateCompressInMemory(t *testing.T) {
 	queueCfg.WaitForResult = true
 	cfg.QueueSettings.QueueConfig = configoptional.Some(queueCfg)
 	cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionSnappy
-	require.ErrorContains(t, cfg.Validate(), "`wait_for_result` is not supported with a persistent queue configured with `storage`")
+	require.NoError(t, cfg.Validate())
 }
 
 func TestConfigValidateLogBatcher(t *testing.T) {
@@ -119,6 +119,40 @@ func TestLoadConfigWithQueueCompression(t *testing.T) {
 	require.True(t, cfg.QueueSettings.QueueConfig.HasValue())
 	require.Equal(t, int64(1000), cfg.QueueSettings.QueueConfig.Get().QueueSize)
 	require.Equal(t, 2, cfg.QueueSettings.QueueConfig.Get().NumConsumers)
+	require.Equal(t, QueuePayloadCompressionZstd, cfg.QueueSettings.PayloadCompression)
+	require.True(t, cfg.QueueSettings.CompressInMemory)
+	require.Nil(t, cfg.QueueSettings.QueueConfig.Get().StorageID)
+}
+
+func TestLoadConfigWithQueueCompressionAndExplicitNullStorage(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	conf := confmap.NewFromStringMap(map[string]any{
+		"protocol": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "localhost:4317",
+				"tls": map[string]any{
+					"insecure": true,
+				},
+			},
+		},
+		"resolver": map[string]any{
+			"static": map[string]any{
+				"hostnames": []string{"localhost:4317"},
+			},
+		},
+		"sending_queue": map[string]any{
+			"enabled":             true,
+			"queue_size":          1000,
+			"num_consumers":       2,
+			"payload_compression": "zstd",
+			"compress_in_memory":  true,
+			"storage":             nil,
+		},
+	})
+
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.True(t, cfg.QueueSettings.QueueConfig.HasValue())
+	require.Nil(t, cfg.QueueSettings.QueueConfig.Get().StorageID)
 	require.Equal(t, QueuePayloadCompressionZstd, cfg.QueueSettings.PayloadCompression)
 	require.True(t, cfg.QueueSettings.CompressInMemory)
 }

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -21,14 +21,11 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/inmemorystorage"
 )
 
 const (
 	zapEndpointKey = "endpoint"
 )
-
-var inMemoryQueueStorageID = component.NewID(inmemorystorage.Type)
 
 // NewFactory creates a factory for the exporter.
 func NewFactory() exporter.Factory {
@@ -102,6 +99,9 @@ func buildExporterResilienceOptions(
 				encoding: qbs.Encoding,
 				codec:    payloadCodec,
 			}
+		}
+		if cfg.QueueSettings.CompressInMemory {
+			options = append(options, exporterhelper.WithQueueBatchInMemoryEncoding(true))
 		}
 		options = append(options, xexporterhelper.WithQueueBatch(queueCfg, qbs))
 	}
@@ -210,9 +210,6 @@ func queueConfigForExport(cfg *Config) (configoptional.Optional[exporterhelper.Q
 	}
 
 	queueCfg := *cfg.QueueSettings.QueueConfig.Get()
-	if cfg.QueueSettings.CompressInMemory && queueCfg.StorageID == nil {
-		queueCfg.StorageID = &inMemoryQueueStorageID
-	}
 
 	return configoptional.Some(queueCfg), true
 }

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -63,6 +63,33 @@ func TestLogExporterGetsCreatedWithValidConfiguration(t *testing.T) {
 	assert.NotNil(t, exp)
 }
 
+func TestLogExporterWithCompressedInMemoryQueueStartsWithoutStorageExtension(t *testing.T) {
+	factory := NewFactory()
+	creationParams := exportertest.NewNopSettings(metadata.Type)
+	queueCfg := exporterhelper.NewDefaultQueueConfig()
+	queueCfg.NumConsumers = 2
+	queueCfg.QueueSize = 1000
+	cfg := &Config{
+		Resolver: ResolverSettings{
+			Static: configoptional.Some(StaticResolver{Hostnames: []string{"endpoint-1"}}),
+		},
+		QueueSettings: QueueSettings{
+			QueueConfig: configoptional.Some(queueCfg),
+			PayloadCompression: QueuePayloadCompressionZstd,
+			CompressInMemory:   true,
+		},
+	}
+
+	exp, err := factory.CreateLogs(t.Context(), creationParams, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, exp)
+
+	require.NoError(t, exp.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, exp.Shutdown(t.Context()))
+	})
+}
+
 func TestOTLPConfigIsValid(t *testing.T) {
 	// prepare
 	factory := NewFactory()
@@ -270,7 +297,7 @@ func TestNewQueuePayloadCodecIfEnabled(t *testing.T) {
 	})
 }
 
-func TestQueueConfigForExportUsesInMemoryStorageWhenRequested(t *testing.T) {
+func TestQueueConfigForExportKeepsMemoryQueueWhenRequested(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.QueueSettings.QueueConfig = configoptional.Some(exporterhelper.NewDefaultQueueConfig())
 	cfg.QueueSettings.CompressInMemory = true
@@ -278,6 +305,5 @@ func TestQueueConfigForExportUsesInMemoryStorageWhenRequested(t *testing.T) {
 	queueCfg, ok := queueConfigForExport(cfg)
 	require.True(t, ok)
 	require.True(t, queueCfg.HasValue())
-	require.NotNil(t, queueCfg.Get().StorageID)
-	assert.Equal(t, inMemoryQueueStorageID, *queueCfg.Get().StorageID)
+	require.Nil(t, queueCfg.Get().StorageID)
 }

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/goccy/go-json v0.10.5
 	github.com/golang/snappy v1.0.0
 	github.com/klauspost/compress v1.18.5
-	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/inmemorystorage v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.148.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.149.0
@@ -28,7 +27,6 @@ require (
 	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.1-0.20260402195938-76ede073ee8e
 	go.opentelemetry.io/collector/exporter/exportertest v0.149.1-0.20260402195938-76ede073ee8e
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.149.1-0.20260402195938-76ede073ee8e
-	go.opentelemetry.io/collector/extension v1.55.1-0.20260402195938-76ede073ee8e
 	go.opentelemetry.io/collector/otelcol/otelcoltest v0.149.1-0.20260402195938-76ede073ee8e
 	go.opentelemetry.io/collector/pdata v1.55.1-0.20260402195938-76ede073ee8e
 	go.opentelemetry.io/otel v1.42.0
@@ -135,7 +133,6 @@ require (
 	go.opentelemetry.io/collector/connector/xconnector v0.149.1-0.20260402195938-76ede073ee8e // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.149.1-0.20260402195938-76ede073ee8e // indirect
 	go.opentelemetry.io/collector/consumer/xconsumer v0.149.1-0.20260402195938-76ede073ee8e // indirect
-	go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.1-0.20260402195938-76ede073ee8e // indirect
 	go.opentelemetry.io/collector/exporter/xexporter v0.149.1-0.20260402195938-76ede073ee8e // indirect
 	go.opentelemetry.io/collector/extension v1.55.1-0.20260402195938-76ede073ee8e // indirect
 	go.opentelemetry.io/collector/extension/extensionauth v1.55.1-0.20260402195938-76ede073ee8e // indirect
@@ -220,3 +217,7 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics => ../../internal/exp/metrics
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/inmemorystorage => ../../extension/storage/inmemorystorage
+
+replace go.opentelemetry.io/collector/exporter/exporterhelper => github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.1
+
+replace go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper => github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.1

--- a/exporter/loadbalancingexporter/go.sum
+++ b/exporter/loadbalancingexporter/go.sum
@@ -1,5 +1,9 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.1 h1:9SZhwUGER1B/naxD+gAxazKn2Sq/w/vxLe/jbrG8KWg=
+github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.1/go.mod h1:vrebAHP8yYENZwHrOhfYqXDOlkqzB3pIOydIlbH/zoc=
+github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.1 h1:qaa2zAfOIKMpV4Z4OGBlQ0jVLh7LWphKZKWwYg6gzrM=
+github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.1/go.mod h1:rgd0kMwhRYZlCmQTau1zO/OI3tMcQqiFTYGooQ3RV5U=
 github.com/aws/aws-sdk-go-v2 v1.41.3 h1:4kQ/fa22KjDt13QCy1+bYADvdgcxpfH18f0zP542kZA=
 github.com/aws/aws-sdk-go-v2 v1.41.3/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/config v1.32.11 h1:ftxI5sgz8jZkckuUHXfC/wMUc8u3fG1vQS0plr2F2Zs=
@@ -261,10 +265,6 @@ go.opentelemetry.io/collector/consumer/xconsumer v0.149.1-0.20260402195938-76ede
 go.opentelemetry.io/collector/consumer/xconsumer v0.149.1-0.20260402195938-76ede073ee8e/go.mod h1:/6GxiFXbETTbPmdyyCcLjzF6cJg2AQ+CLF3yrjecL20=
 go.opentelemetry.io/collector/exporter v1.55.1-0.20260402195938-76ede073ee8e h1:EAcrFOISLJd/mOOeHlYGET7hFsWq/Y9t9xoAXJBFJ4c=
 go.opentelemetry.io/collector/exporter v1.55.1-0.20260402195938-76ede073ee8e/go.mod h1:CT1a6LcOvSq1+e8JtB8TOeokO7NvbA3GPapyPYQg4/0=
-go.opentelemetry.io/collector/exporter/exporterhelper v0.149.1-0.20260402195938-76ede073ee8e h1:KWSyQGSZBldbG1C6ly+F50myVhIty34nLqqSFNGgbJI=
-go.opentelemetry.io/collector/exporter/exporterhelper v0.149.1-0.20260402195938-76ede073ee8e/go.mod h1:mkCJzZNAUyO0PPXtOWyxRXOEIrsstwBaj0FHanzwXNU=
-go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.1-0.20260402195938-76ede073ee8e h1:f2wMIWld0vfso0rE7ppW8fUSBTXfpoBB+Od6BiC+Gj0=
-go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.1-0.20260402195938-76ede073ee8e/go.mod h1:rgd0kMwhRYZlCmQTau1zO/OI3tMcQqiFTYGooQ3RV5U=
 go.opentelemetry.io/collector/exporter/exportertest v0.149.1-0.20260402195938-76ede073ee8e h1:VaoNlT5JOq2ypGlpKGR7gXtw5Bs/YNRsJGoGvhWRkyc=
 go.opentelemetry.io/collector/exporter/exportertest v0.149.1-0.20260402195938-76ede073ee8e/go.mod h1:WbCmeP0j2EfCiM8FkrNrebht1pzfz5tU76fV9t3tKTc=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.149.1-0.20260402195938-76ede073ee8e h1:eb9rbBrIP6xvY1alOIDWInu+hzRoyqDOcSdqmMOM6Cc=

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -25,7 +25,6 @@ import (
 	"go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	collectorextension "go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/otel/attribute"
@@ -35,7 +34,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/inmemorystorage"
 )
 
 func TestNewLogsExporter(t *testing.T) {
@@ -266,7 +264,7 @@ func TestConsumeLogsEmitsOnlyParentExporterMetrics(t *testing.T) {
 	assert.IsType(t, tracenoop.NewTracerProvider(), childSettings[0].TracerProvider)
 }
 
-func TestConsumeLogsWithQueueCompressionAndInMemoryStorage(t *testing.T) {
+func TestConsumeLogsWithQueueCompressionAndInMemoryQueue(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	sink := new(consumertest.LogsSink)
 
@@ -304,19 +302,7 @@ func TestConsumeLogsWithQueueCompressionAndInMemoryStorage(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	storageExt, err := inmemorystorage.NewFactory().Create(
-		t.Context(),
-		collectorextension.Settings{ID: component.NewID(inmemorystorage.Type)},
-		&inmemorystorage.Config{},
-	)
-	require.NoError(t, err)
-
-	host := testStorageHost{
-		extensions: map[component.ID]component.Component{
-			inMemoryQueueStorageID: storageExt,
-		},
-	}
-	require.NoError(t, wrapped.Start(t.Context(), host))
+	require.NoError(t, wrapped.Start(t.Context(), componenttest.NewNopHost()))
 	t.Cleanup(func() {
 		require.NoError(t, wrapped.Shutdown(t.Context()))
 	})


### PR DESCRIPTION
## Summary
- restore real in-memory queue compression for `loadbalancingexporter`
- stop forcing the in-memory compression path through storage-backed queue semantics
- keep queue batching and consumer behavior unchanged while preserving `compress_in_memory`

## Validation
- `cd exporter/loadbalancingexporter && GOWORK=off go test ./...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `compress_in_memory` is implemented for the sending queue, affecting exporter queuing semantics at runtime. Also swaps `exporterhelper`/`xexporterhelper` via `replace`, which could introduce behavioral differences from upstream.
> 
> **Overview**
> Restores *true in-memory queue compression* for `loadbalancingexporter` by no longer forcing `CompressInMemory` to use a storage-backed queue (`StorageID` injection is removed) and instead enabling `exporterhelper.WithQueueBatchInMemoryEncoding(true)` when requested.
> 
> Updates validation and tests to reflect the new behavior: configs with `compress_in_memory` + compression no longer require/assume a storage extension, explicit `storage: null` is handled, and queue configs keep `StorageID` unset while still allowing `wait_for_result`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921f389bfd73db6bc0065c2900002fcf8041eaeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores real in-memory queue compression in `loadbalancingexporter`, fixing a regression where `compress_in_memory` forced persistent storage. Exporters now compress queue batches in memory without requiring a storage extension, while batching and consumer behavior stay the same.

- **Bug Fixes**
  - Stop forcing `storage` for `compress_in_memory`; leave `StorageID` nil to keep the queue in memory.
  - Enable in-memory batch encoding via `exporterhelper.WithQueueBatchInMemoryEncoding(true)` when `compress_in_memory` is set.
  - Validation no longer treats in-memory compression as persistent, so `wait_for_result` is allowed in this mode.
  - Tests cover explicit null `storage` and starting without a storage extension.

- **Dependencies**
  - Removed `github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/inmemorystorage`.
  - Added replaces for `go.opentelemetry.io/collector/exporter/exporterhelper` and `xexporterhelper` to `github.com/Sawmills/opentelemetry-collector/... v0.149.0-sawmills.1`.

<sup>Written for commit 921f389bfd73db6bc0065c2900002fcf8041eaeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed in-memory queue compression to work without requiring an external storage extension configuration.

* **Refactor**
  * Simplified in-memory queue compression handling to function independently, improving reliability and reducing configuration complexity for users enabling payload compression with in-memory queuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->