### PR TITLE
fix(awss3exporter): add Sprig template funcs to legacy key parser

### DIFF
--- a/.chloggen/awss3-dateInZone-template-funcs.yaml
+++ b/.chloggen/awss3-dateInZone-template-funcs.yaml
@@ -4,7 +4,7 @@
 change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
-component: exporter/awss3exporter
+component: exporter/awss3
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: Add dateInZone, now, and randAlpha template functions to the legacy S3 key template parser, fixing crash on startup when using datadog marshaler.

--- a/.chloggen/awss3-dateInZone-template-funcs.yaml
+++ b/.chloggen/awss3-dateInZone-template-funcs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. receiver/filelog)
+component: exporter/awss3exporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add dateInZone, now, and randAlpha template functions to the legacy S3 key template parser, fixing crash on startup when using datadog marshaler.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [39]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awss3exporter/internal/upload/partition.go
+++ b/exporter/awss3exporter/internal/upload/partition.go
@@ -19,6 +19,27 @@ import (
 	"go.opentelemetry.io/collector/config/configcompression"
 )
 
+// legacyTemplateFuncs provides the Sprig-compatible template functions
+// used by generated configs (dateInZone, now, randAlpha).
+var legacyTemplateFuncs = template.FuncMap{
+	"now": func() time.Time { return time.Now() },
+	"dateInZone": func(layout string, t time.Time, zone string) string {
+		loc, err := time.LoadLocation(zone)
+		if err != nil {
+			loc = time.UTC
+		}
+		return t.In(loc).Format(layout)
+	},
+	"randAlpha": func(n int) string {
+		const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = letters[rand.IntN(len(letters))]
+		}
+		return string(b)
+	},
+}
+
 var compressionFileExtensions = map[configcompression.Type]string{
 	configcompression.TypeGzip: ".gz",
 	configcompression.TypeZstd: ".zst",
@@ -104,7 +125,7 @@ func buildLegacyTemplateKey(prefix string, tmpl *template.Template, ts time.Time
 }
 
 func parseLegacyTemplate(templateText string) (*template.Template, error) {
-	return template.New("legacy-s3-key").Option("missingkey=error").Parse(templateText)
+	return template.New("legacy-s3-key").Funcs(legacyTemplateFuncs).Option("missingkey=error").Parse(templateText)
 }
 
 func ParseLegacyTemplateForValidation(templateText string) (*template.Template, error) {

--- a/exporter/awss3exporter/internal/upload/partition_test.go
+++ b/exporter/awss3exporter/internal/upload/partition_test.go
@@ -330,6 +330,73 @@ func TestPartitionKeyInputsFilename(t *testing.T) {
 	}
 }
 
+func TestParseLegacyTemplate_DatadogKeyTemplate(t *testing.T) {
+	t.Parallel()
+
+	// Regression test: the datadog marshaler config generator emits an
+	// s3_key_template using dateInZone, now, and randAlpha. The template
+	// parser must support these functions or the collector will crash on
+	// startup with "function dateInZone not defined".
+	const datadogTemplate = `dt={{ dateInZone "20060102" (now) "UTC" }}/hour={{ dateInZone "15" (now) "UTC" }}/archive_{{ dateInZone "150405.0000" (now) "UTC" }}.{{ randAlpha 22 }}.json.gz`
+
+	tmpl, err := parseLegacyTemplate(datadogTemplate)
+	assert.NoError(t, err, "parseLegacyTemplate must accept dateInZone/now/randAlpha")
+	assert.NotNil(t, tmpl)
+
+	// Execute with real data to verify the functions produce valid output.
+	key := buildLegacyTemplateKey("", tmpl, time.Date(2025, 9, 4, 18, 30, 45, 0, time.UTC))
+	assert.Regexp(t, `^dt=\d{8}/hour=\d{2}/archive_\d{6}\.\d{4}\.[a-zA-Z]{22}\.json\.gz$`, key)
+}
+
+func TestParseLegacyTemplate_SprigFunctionsAvailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template string
+		pattern  string
+	}{
+		{
+			name:     "dateInZone formats time in UTC",
+			template: `{{ dateInZone "2006-01-02" (now) "UTC" }}`,
+			pattern:  `^\d{4}-\d{2}-\d{2}$`,
+		},
+		{
+			name:     "randAlpha generates alphabetic string",
+			template: `{{ randAlpha 10 }}`,
+			pattern:  `^[a-zA-Z]{10}$`,
+		},
+		{
+			name:     "now returns current time",
+			template: `{{ dateInZone "15" (now) "UTC" }}`,
+			pattern:  `^\d{2}$`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpl, err := parseLegacyTemplate(tc.template)
+			assert.NoError(t, err)
+
+			key := buildLegacyTemplateKey("", tmpl, time.Now())
+			assert.Regexp(t, tc.pattern, key)
+		})
+	}
+}
+
+func TestValidateLegacyTemplate_DatadogKeyTemplate(t *testing.T) {
+	t.Parallel()
+
+	// Regression: config validation must not reject the datadog template.
+	const datadogTemplate = `dt={{ dateInZone "20060102" (now) "UTC" }}/hour={{ dateInZone "15" (now) "UTC" }}/archive_{{ dateInZone "150405.0000" (now) "UTC" }}.{{ randAlpha 22 }}.json.gz`
+
+	tmpl, err := ParseLegacyTemplateForValidation(datadogTemplate)
+	assert.NoError(t, err)
+	assert.NoError(t, ValidateLegacyTemplateForValidation(tmpl))
+}
+
 func TestPartitionKeyInputsUniqueKey(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- The config generator emits `s3_key_template` using `dateInZone`, `now`, and `randAlpha` (Sprig functions) for the `datadog` marshaler
- `parseLegacyTemplate` used plain `text/template` with no custom funcmap, causing collectors to crash on startup: `function "dateInZone" not defined`
- Adds a minimal funcmap with the three required functions and regression tests

## Root Cause
`collectors-service/internal/generator/collector/exporters.go` generates:
```
dt={{ dateInZone "20060102" (now) "UTC" }}/hour={{ dateInZone "15" (now) "UTC" }}/archive_{{ dateInZone "150405.0000" (now) "UTC" }}.{{ randAlpha 22 }}.json.gz
```
But `partition.go:parseLegacyTemplate` parsed with `template.New(...).Parse(...)` — no Sprig functions registered.

## Test plan
- [x] `TestParseLegacyTemplate_DatadogKeyTemplate` — exact generator template parses and produces valid DD archive paths
- [x] `TestParseLegacyTemplate_SprigFunctionsAvailable` — each function tested individually
- [x] `TestValidateLegacyTemplate_DatadogKeyTemplate` — config validation accepts the template
- [x] Full `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to legacy S3 key template parsing by registering a small func map; primary risk is subtle behavior changes if users relied on templates failing or on different timezone/formatting semantics.
> 
> **Overview**
> Fixes a startup crash in `awss3exporter` when generated legacy `s3_key_template` strings (e.g., Datadog marshaler output) reference Sprig-style functions.
> 
> `parseLegacyTemplate` now registers a minimal func map (`dateInZone`, `now`, `randAlpha`) and adds regression/unit tests to ensure these templates both parse and validate, plus a changelog entry documenting the bug fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e88d681782d3ff652bf9f1f3ff492c4cd81006f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup crash in `awss3exporter` by adding Sprig `dateInZone`, `now`, and `randAlpha` to the legacy S3 key template parser. The `datadog` marshaler’s generated `s3_key_template` now parses and validates; changelog entry added under `exporter/awss3`.

- **Bug Fixes**
  - Register Sprig funcs in `parseLegacyTemplate` to prevent “function dateInZone not defined”.
  - Fallback to UTC on bad zone; keep `missingkey=error`.
  - Add regression tests for the Datadog template and each func.

<sup>Written for commit e88d681782d3ff652bf9f1f3ff492c4cd81006f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy S3 key templates now support dynamic template functions (dateInZone, now, randAlpha) for enhanced key generation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->