### PR TITLE
feat (lb): Delay merging until flush. Use merge by move instead of merge by copy

### DIFF
--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
-	expmetrics "github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
 )
 
 const (
@@ -149,6 +149,8 @@ func newMetricBatcher(
 	return b, nil
 }
 
+// TryEnqueue transfers ownership of md to the backend batcher when it returns (true, nil).
+// Callers must treat md as immutable/invalid after successful enqueue.
 func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pmetric.Metrics) (bool, error) {
 	backend, err := b.acquireBackend(endpoint, exp)
 	if err != nil {
@@ -356,7 +358,7 @@ func (b *backendMetricBatcher) run() {
 	var timerC <-chan time.Time
 	retryingSince := time.Time{}
 
-	pending := pmetric.NewMetrics()
+	pending := make([]pmetric.Metrics, 0, cap(b.requests))
 	pendingBytes := 0
 	pendingDataPoints := 0
 	sizer := &pmetric.ProtoMarshaler{}
@@ -378,7 +380,7 @@ func (b *backendMetricBatcher) run() {
 				return
 			}
 		case <-timerC:
-			if err := b.flush(context.Background(), &pending, &pendingDataPoints, &pendingBytes, metricFlushReasonTimeout, timer, &timerC, &retryingSince); err != nil {
+			if err := b.flush(context.Background(), sizer, &pending, &pendingDataPoints, &pendingBytes, metricFlushReasonTimeout, timer, &timerC, &retryingSince); err != nil {
 				b.logger.Warn("failed to flush metric batch", zap.String("reason", metricFlushReasonTimeout), zap.Error(err))
 			}
 		}
@@ -388,7 +390,7 @@ func (b *backendMetricBatcher) run() {
 func (b *backendMetricBatcher) handleRequest(
 	req metricBatcherRequest,
 	sizer *pmetric.ProtoMarshaler,
-	pending *pmetric.Metrics,
+	pending *[]pmetric.Metrics,
 	pendingDataPoints *int,
 	pendingBytes *int,
 	nextReq **metricBatcherRequest,
@@ -398,8 +400,9 @@ func (b *backendMetricBatcher) handleRequest(
 ) bool {
 	switch req.kind {
 	case metricBatcherRequestEnqueue:
-		*pendingDataPoints += b.mergeQueuedRequests(pending, req, nextReq)
-		*pendingBytes = sizer.MetricsSize(*pending)
+		dps, bytes := b.drainEnqueueRequestsIntoPending(sizer, pending, req, nextReq)
+		*pendingDataPoints += dps
+		*pendingBytes += bytes
 		b.pendingDataPoints.Store(int64(*pendingDataPoints))
 		b.pendingBytes.Store(int64(*pendingBytes))
 		if *pendingDataPoints > 0 && *timerC == nil {
@@ -409,46 +412,55 @@ func (b *backendMetricBatcher) handleRequest(
 		if *pendingDataPoints >= b.settings.maxDataPoints || *pendingBytes >= b.settings.maxBytes {
 			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
 			b.telemetry.overflowTotal.Add(context.Background(), 1, attrs)
-			if err := b.flush(context.Background(), pending, pendingDataPoints, pendingBytes, metricFlushReasonSize, timer, timerC, retryingSince); err != nil {
+			if err := b.flush(context.Background(), sizer, pending, pendingDataPoints, pendingBytes, metricFlushReasonSize, timer, timerC, retryingSince); err != nil {
 				b.logger.Warn("failed to flush metric batch", zap.String("reason", metricFlushReasonSize), zap.Error(err))
 			}
 		}
 	case metricBatcherRequestFlushAndStop:
-		err := b.flush(req.ctx, pending, pendingDataPoints, pendingBytes, req.reason, timer, timerC, retryingSince)
+		err := b.flush(req.ctx, sizer, pending, pendingDataPoints, pendingBytes, req.reason, timer, timerC, retryingSince)
 		req.done <- err
 		return true
 	}
 	return false
 }
 
-func (b *backendMetricBatcher) mergeQueuedRequests(
-	pending *pmetric.Metrics,
+// drainEnqueueRequestsIntoPending drains immediately available enqueue requests
+// into pending without merging payload trees.
+// Returns (dataPointsAdded, bytesAdded).
+func (b *backendMetricBatcher) drainEnqueueRequestsIntoPending(
+	sizer *pmetric.ProtoMarshaler,
+	pending *[]pmetric.Metrics,
 	first metricBatcherRequest,
 	nextReq **metricBatcherRequest,
-) int {
+) (int, int) {
 	dataPointCount := first.md.DataPointCount()
-	expmetrics.Merge(*pending, first.md)
+	bytes := sizer.MetricsSize(first.md)
+	*pending = append(*pending, first.md)
 
 	for i := 0; i < cap(b.requests); i++ {
 		select {
 		case req := <-b.requests:
 			if req.kind != metricBatcherRequestEnqueue {
+				// Channels don't support unread/put-back. Stash this control request
+				// so the run loop processes it next, in-order.
 				*nextReq = &req
-				return dataPointCount
+				return dataPointCount, bytes
 			}
 			dataPointCount += req.md.DataPointCount()
-			expmetrics.Merge(*pending, req.md)
+			bytes += sizer.MetricsSize(req.md)
+			*pending = append(*pending, req.md)
 		default:
-			return dataPointCount
+			return dataPointCount, bytes
 		}
 	}
 
-	return dataPointCount
+	return dataPointCount, bytes
 }
 
 func (b *backendMetricBatcher) flush(
 	ctx context.Context,
-	pending *pmetric.Metrics,
+	sizer *pmetric.ProtoMarshaler,
+	pending *[]pmetric.Metrics,
 	pendingDataPoints *int,
 	pendingBytes *int,
 	reason string,
@@ -464,14 +476,15 @@ func (b *backendMetricBatcher) flush(
 	}
 	*timerC = nil
 
-	if pending.DataPointCount() == 0 {
+	if *pendingDataPoints == 0 {
 		return nil
 	}
 
-	drained := *pending
+	drainedChunks := *pending
+	drained := mergePendingMetricChunks(drainedChunks)
 	datapoints := *pendingDataPoints
-	bytes := *pendingBytes
-	*pending = pmetric.NewMetrics()
+	bytes := sizer.MetricsSize(drained)
+	*pending = (*pending)[:0]
 	*pendingDataPoints = 0
 	*pendingBytes = 0
 	b.pendingDataPoints.Store(0)
@@ -501,7 +514,7 @@ func (b *backendMetricBatcher) flush(
 				b.flushFailures = 0
 				return err
 			}
-			*pending = drained
+			*pending = append((*pending)[:0], drained)
 			*pendingDataPoints = datapoints
 			*pendingBytes = bytes
 			b.pendingDataPoints.Store(int64(datapoints))
@@ -534,6 +547,118 @@ func (b *backendMetricBatcher) flush(
 		b.flushFailures = 0
 	}
 	return err
+}
+
+func mergePendingMetricChunks(chunks []pmetric.Metrics) pmetric.Metrics {
+	if len(chunks) == 0 {
+		return pmetric.NewMetrics()
+	}
+	if len(chunks) == 1 {
+		return chunks[0]
+	}
+	merged := chunks[0]
+	for i := 1; i < len(chunks); i++ {
+		mergeMetricChunksByMove(merged, chunks[i])
+	}
+	return merged
+}
+
+// mergeMetricChunksByMove assumes src is owned by the batcher and can be consumed.
+// It uses move semantics where possible to avoid deep-copy merge overhead.
+func mergeMetricChunksByMove(dst, src pmetric.Metrics) {
+	dstResourceMetrics := dst.ResourceMetrics()
+	srcResourceMetrics := src.ResourceMetrics()
+
+	resources := make(map[identity.Resource]pmetric.ResourceMetrics, dstResourceMetrics.Len())
+	for i := 0; i < dstResourceMetrics.Len(); i++ {
+		rm := dstResourceMetrics.At(i)
+		resources[identity.OfResource(rm.Resource())] = rm
+	}
+
+	for i := 0; i < srcResourceMetrics.Len(); i++ {
+		rm := srcResourceMetrics.At(i)
+		resourceID := identity.OfResource(rm.Resource())
+
+		dstRM, ok := resources[resourceID]
+		if !ok {
+			dstRM = dstResourceMetrics.AppendEmpty()
+			rm.MoveTo(dstRM)
+			resources[resourceID] = dstRM
+			continue
+		}
+
+		mergeResourceMetricsByMove(resourceID, dstRM, rm)
+	}
+}
+
+func mergeResourceMetricsByMove(resourceID identity.Resource, dst, src pmetric.ResourceMetrics) {
+	dstScopeMetrics := dst.ScopeMetrics()
+	srcScopeMetrics := src.ScopeMetrics()
+
+	scopes := make(map[identity.Scope]pmetric.ScopeMetrics, dstScopeMetrics.Len())
+	for i := 0; i < dstScopeMetrics.Len(); i++ {
+		sm := dstScopeMetrics.At(i)
+		scopes[identity.OfScope(resourceID, sm.Scope())] = sm
+	}
+
+	for i := 0; i < srcScopeMetrics.Len(); i++ {
+		sm := srcScopeMetrics.At(i)
+		scopeID := identity.OfScope(resourceID, sm.Scope())
+
+		dstSM, ok := scopes[scopeID]
+		if !ok {
+			dstSM = dstScopeMetrics.AppendEmpty()
+			sm.MoveTo(dstSM)
+			scopes[scopeID] = dstSM
+			continue
+		}
+
+		mergeScopeMetricsByMove(scopeID, dstSM, sm)
+	}
+}
+
+func mergeScopeMetricsByMove(scopeID identity.Scope, dst, src pmetric.ScopeMetrics) {
+	dstMetrics := dst.Metrics()
+	srcMetrics := src.Metrics()
+
+	metricsByIdentity := make(map[identity.Metric]pmetric.Metric, dstMetrics.Len())
+	for i := 0; i < dstMetrics.Len(); i++ {
+		m := dstMetrics.At(i)
+		metricsByIdentity[identity.OfMetric(scopeID, m)] = m
+	}
+
+	for i := 0; i < srcMetrics.Len(); i++ {
+		srcMetric := srcMetrics.At(i)
+		metricID := identity.OfMetric(scopeID, srcMetric)
+
+		dstMetric, ok := metricsByIdentity[metricID]
+		if !ok {
+			dstMetric = dstMetrics.AppendEmpty()
+			srcMetric.MoveTo(dstMetric)
+			metricsByIdentity[metricID] = dstMetric
+			continue
+		}
+
+		mergeMetricDataPointsByMove(dstMetric, srcMetric)
+	}
+}
+
+func mergeMetricDataPointsByMove(dst, src pmetric.Metric) {
+	switch dst.Type() {
+	case pmetric.MetricTypeGauge:
+		src.Gauge().DataPoints().MoveAndAppendTo(dst.Gauge().DataPoints())
+	case pmetric.MetricTypeSum:
+		src.Sum().DataPoints().MoveAndAppendTo(dst.Sum().DataPoints())
+	case pmetric.MetricTypeHistogram:
+		src.Histogram().DataPoints().MoveAndAppendTo(dst.Histogram().DataPoints())
+	case pmetric.MetricTypeExponentialHistogram:
+		src.ExponentialHistogram().DataPoints().MoveAndAppendTo(dst.ExponentialHistogram().DataPoints())
+	case pmetric.MetricTypeSummary:
+		src.Summary().DataPoints().MoveAndAppendTo(dst.Summary().DataPoints())
+	default:
+		newMetric := dst
+		src.MoveTo(newMetric)
+	}
 }
 
 func isBeyondRetryCap(current, base, multiplier int) bool {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -30,7 +31,7 @@ func TestMetricBatcherFlushesOnMaxDataPoints(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+		_ = batcher.Shutdown(context.WithoutCancel(t.Context()))
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
@@ -61,7 +62,7 @@ func TestMetricBatcherFlushesOnInterval(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+		_ = batcher.Shutdown(context.WithoutCancel(t.Context()))
 	})
 
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
@@ -228,6 +229,53 @@ func TestMetricBatcherRestoresPendingOnTimeoutFlushFailure(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return calls.Load() >= 2
 	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestMetricBatcherRestoresPendingBytesFromMergedPayloadOnFailure(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	firstFailed := make(chan struct{}, 1)
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: 200 * time.Millisecond},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			select {
+			case firstFailed <- struct{}{}:
+			default:
+			}
+			return errors.New("boom")
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = batcher.Shutdown(context.WithoutCancel(t.Context()))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	md1 := singleDataPointMetric("m1")
+	md2 := singleDataPointMetric("m1")
+	requireMetricBatcherEnqueued(t, batcher, exp, md1)
+	requireMetricBatcherEnqueued(t, batcher, exp, md2)
+
+	select {
+	case <-firstFailed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected first timeout flush failure")
+	}
+
+	expected := mergePendingMetricChunks([]pmetric.Metrics{singleDataPointMetric("m1"), singleDataPointMetric("m1")})
+	expectedBytes := (&pmetric.ProtoMarshaler{}).MetricsSize(expected)
+
+	require.Eventually(t, func() bool {
+		for _, p := range batcher.snapshotPending() {
+			if p.endpoint == "endpoint-1:4317" {
+				return p.datapoints == 2 && int(p.bytes) == expectedBytes
+			}
+		}
+		return false
+	}, time.Second, 20*time.Millisecond)
 }
 
 func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T) {
@@ -421,6 +469,53 @@ func TestMetricBatcherShutdownReroutesOnShutdownFlushFailure(t *testing.T) {
 	}
 }
 
+func TestMergePendingMetricChunksMergesDistinctMetricNames(t *testing.T) {
+	md1 := singleDataPointMetric("m1")
+	md2 := singleDataPointMetric("m2")
+
+	merged := mergePendingMetricChunks([]pmetric.Metrics{md1, md2})
+
+	require.Equal(t, 2, merged.DataPointCount())
+	require.Len(t, splitMetricsByMetricName(merged), 2)
+}
+
+func TestMergePendingMetricChunksMergesSameMetricNameDataPoints(t *testing.T) {
+	md1 := singleDataPointMetric("m1")
+	md2 := singleDataPointMetric("m1")
+
+	merged := mergePendingMetricChunks([]pmetric.Metrics{md1, md2})
+
+	require.Equal(t, 2, merged.DataPointCount())
+	split := splitMetricsByMetricName(merged)
+	require.Len(t, split, 1)
+	require.Contains(t, split, "m1")
+	require.Equal(t, 2, split["m1"].DataPointCount())
+}
+
+func TestMergePendingMetricChunksMergesByResourceScopeAndMetricIdentity(t *testing.T) {
+	md1 := metricWithResourceScopeGauge("host-a", "scope-a", "m1", 1)
+	md2 := metricWithResourceScopeGauge("host-a", "scope-a", "m1", 2)
+
+	merged := mergePendingMetricChunks([]pmetric.Metrics{md1, md2})
+
+	require.Equal(t, 1, merged.ResourceMetrics().Len())
+	rm := merged.ResourceMetrics().At(0)
+	require.Equal(t, 1, rm.ScopeMetrics().Len())
+	sm := rm.ScopeMetrics().At(0)
+	require.Equal(t, 1, sm.Metrics().Len())
+	g := sm.Metrics().At(0).Gauge()
+	require.Equal(t, 2, g.DataPoints().Len())
+}
+
+func TestMergePendingMetricChunksKeepsDistinctResourcesSeparate(t *testing.T) {
+	md1 := metricWithResourceScopeGauge("host-a", "scope-a", "m1", 1)
+	md2 := metricWithResourceScopeGauge("host-b", "scope-a", "m1", 2)
+
+	merged := mergePendingMetricChunks([]pmetric.Metrics{md1, md2})
+
+	require.Equal(t, 2, merged.ResourceMetrics().Len())
+}
+
 func singleDataPointMetric(name string) pmetric.Metrics {
 	md := pmetric.NewMetrics()
 	rm := md.ResourceMetrics().AppendEmpty()
@@ -429,6 +524,21 @@ func singleDataPointMetric(name string) pmetric.Metrics {
 	m.SetName(name)
 	g := m.SetEmptyGauge()
 	g.DataPoints().AppendEmpty().SetIntValue(1)
+	return md
+}
+
+func metricWithResourceScopeGauge(resourceValue, scopeName, metricName string, value int64) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("host.name", resourceValue)
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName(scopeName)
+	m := sm.Metrics().AppendEmpty()
+	m.SetName(metricName)
+	g := m.SetEmptyGauge()
+	dp := g.DataPoints().AppendEmpty()
+	dp.SetIntValue(value)
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(value, 0)))
 	return md
 }
 

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -224,6 +224,8 @@ func (e *metricExporterImp) enqueueEndpointBatches(
 
 		for ep, batch := range pending {
 			// TryEnqueue is non-blocking; false,nil means queue is currently full.
+			// On enqueued=true, ownership of batch.metrics is transferred to the batcher.
+			// Do not read or mutate batch.metrics after successful enqueue.
 			enqueued, err := e.batcher.TryEnqueue(ep, batch.exp, batch.metrics)
 
 			if errors.Is(err, errMetricBatcherExporterStopping) && retryOnStopping {


### PR DESCRIPTION
I benchmarked merge by copy and merge by move. The merge by move is at least 6 times faster and does at least ~80% fever allocations.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Delay metric merges until flush and switch to move-and-merge in the `loadbalancingexporter` metric batcher. This reduces copy overhead, improves throughput, and fixes pending byte tracking after failed flushes.

- **Refactors**
  - Store pending as chunks (`[]pmetric.Metrics`), drain enqueues without merging, and merge at flush using resource/scope/metric identity with move operations.
  - Replace `expmetrics.Merge` with identity-based move merge; size tracked via `pmetric.ProtoMarshaler`.
  - `TryEnqueue` now transfers ownership of `pmetric.Metrics`; comments updated in `metrics_exporter.go`.
  - Switched import to `github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity`.

- **Bug Fixes**
  - Restore pending bytes and datapoints from the merged payload after a failed flush, ensuring accurate queue state and retries.
  - Prevents misreported queue size and premature overflow-triggered flushes.

<sup>Written for commit 766f5bfaef6b9b9a37b72875d83841fa66857f97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `TryEnqueue` method to enqueue metric payloads to backend batchers
  
* **Improvements**
  * Refactored metric batching strategy for more efficient resource handling
  * Enhanced error recovery when metric flushes fail
  
* **Tests**
  * Added comprehensive tests for metric merging and batch failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->