### PR TITLE
fix (lb): protocol.otlp.sending_queue cannot be disabled

### DIFF
--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -57,6 +57,29 @@ type Config struct {
 	RoutingAttributes []string `mapstructure:"routing_attributes"`
 }
 
+func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
+	type rawConfig Config
+	if err := conf.Unmarshal((*rawConfig)(cfg)); err != nil {
+		return err
+	}
+
+	protocolRaw, ok := conf.ToStringMap()["protocol"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	otlpRaw, ok := protocolRaw["otlp"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	if rawQueue, ok := otlpRaw["sending_queue"]; ok && rawQueue == nil {
+		cfg.Protocol.OTLP.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+	}
+
+	return nil
+}
+
 type QueueSettings struct {
 	QueueConfig        configoptional.Optional[exporterhelper.QueueBatchConfig] `mapstructure:",squash"`
 	PayloadCompression QueuePayloadCompression                                  `mapstructure:"payload_compression"`

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -305,3 +305,26 @@ func TestLoadConfigWithMetricBatcher(t *testing.T) {
 	require.Equal(t, 300*time.Millisecond, cfg.MetricBatcher.FlushInterval)
 	require.Equal(t, 12, cfg.MetricBatcher.MaxRetryBufferMultiplier)
 }
+
+func TestLoadConfigWithNullNestedOTLPQueueDisablesChildQueue(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	conf := confmap.NewFromStringMap(map[string]any{
+		"protocol": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "localhost:4317",
+				"tls": map[string]any{
+					"insecure": true,
+				},
+				"sending_queue": nil,
+			},
+		},
+		"resolver": map[string]any{
+			"static": map[string]any{
+				"hostnames": []string{"localhost:4317"},
+			},
+		},
+	})
+
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.False(t, cfg.Protocol.OTLP.QueueConfig.HasValue())
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the inability to disable the OTLP sending queue in the load balancing exporter. Setting `protocol.otlp.sending_queue: null` now correctly disables the child queue.

- **Bug Fixes**
  - Added a custom `Unmarshal` on `Config` to treat `protocol.otlp.sending_queue: null` as `None` for `QueueConfig`.
  - Added a unit test to verify the queue is disabled when `null` is provided.

<sup>Written for commit 2c03f7e2c96dd5f8723f60e0e8511eed4979195c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of null OTLP queue configuration in the load balancing exporter to properly disable queue settings when explicitly set to null in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->