### PR TITLE
fix (lb): wiring for sending queue compression

### DIFF
--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -108,6 +108,9 @@ func buildExporterResilienceOptions(
 			}
 		}
 		options = append(options, xexporterhelper.WithQueueBatch(queueCfg, qbs))
+		if cfg.QueueSettings.CompressInMemory {
+			options = append(options, exporterhelper.WithQueueBatchInMemoryEncoding(true))
+		}
 	}
 	if cfg.Enabled {
 		options = append(options, exporterhelper.WithRetry(cfg.BackOffConfig))

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -280,6 +280,16 @@ func TestBuildExporterResilienceOptions(t *testing.T) {
 
 		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression), newSettings()), 2)
 	})
+	t.Run("Should add in-memory encoding option when compression in memory is enabled", func(t *testing.T) {
+		o := []exporterhelper.Option{}
+		cfg := createDefaultConfig().(*Config)
+		cfg.TimeoutSettings = exporterhelper.NewDefaultTimeoutConfig()
+		cfg.QueueSettings.QueueConfig = configoptional.Some(exporterhelper.NewDefaultQueueConfig())
+		cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
+		cfg.QueueSettings.CompressInMemory = true
+
+		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression), newSettings()), 3)
+	})
 	t.Run("Should have all resilience options if defined", func(t *testing.T) {
 		o := []exporterhelper.Option{}
 		cfg := createDefaultConfig().(*Config)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires in-memory compression for the sending queue in `loadbalancingexporter`. When `QueueSettings.CompressInMemory` is enabled, queue batches are now encoded in memory to match the configured compression.

- **Bug Fixes**
  - Pass `exporterhelper.WithQueueBatchInMemoryEncoding(true)` when `QueueSettings.CompressInMemory` is true.
  - Add a unit test to confirm the option is included when in-memory compression is enabled.

<sup>Written for commit c04b55f1c285bdf6eeb7bff36cb4afa6d755f485. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for in-memory queue batch encoding compression, enabling optimized data handling when compression is configured.

* **Tests**
  * Added test coverage for the in-memory queue batch encoding compression feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->