### PR TITLE
loadbalancingexporter: preserve queue enablement on round-trip

### DIFF
--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -115,6 +115,7 @@ components:
     - extension/opamp
     - extension/opampcustommessages
     - extension/otlp_encoding
+    - extension/parquet_log_encoding
     - extension/pprof
     - extension/redis_storage
     - extension/remotetap
@@ -356,6 +357,7 @@ components:
     - scraper/paging
     - scraper/process
     - scraper/processes
+    - scraper/system
     - scraper/system
     - scraper/zookeeper
     - testbed

--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -358,6 +358,7 @@ components:
     - scraper/process
     - scraper/processes
     - scraper/system
+    - scraper/system
     - scraper/zookeeper
     - testbed
     - testbed/mockdatasenders/mockdatadogagentexporter

--- a/.chloggen/config.yaml
+++ b/.chloggen/config.yaml
@@ -358,7 +358,6 @@ components:
     - scraper/process
     - scraper/processes
     - scraper/system
-    - scraper/system
     - scraper/zookeeper
     - testbed
     - testbed/mockdatasenders/mockdatadogagentexporter

--- a/.chloggen/loadbalancingexporter-queue-enabled-roundtrip.yaml
+++ b/.chloggen/loadbalancingexporter-queue-enabled-roundtrip.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: exporter/loadbalancing
+note: Preserve `sending_queue.enabled` when loadbalancing exporter configs are unmarshaled and marshaled through `confmap`.
+issues: [45]
+subtext: |-
+  This keeps the queue enabled for generated configs that rely on config round-tripping before YAML output.

--- a/.github/ISSUE_TEMPLATE/beta_stability.yaml
+++ b/.github/ISSUE_TEMPLATE/beta_stability.yaml
@@ -126,6 +126,7 @@ body:
       - extension/oidcauth
       - extension/opamp
       - extension/opampcustommessages
+      - extension/parquetlogencoding
       - extension/pprof
       - extension/remotetap
       - extension/sigv4auth
@@ -133,6 +134,7 @@ body:
       - extension/storage
       - extension/storage/dbstorage
       - extension/storage/filestorage
+      - extension/storage/inmemorystorage
       - extension/storage/redisstorage
       - extension/sumologic
       - internal/aws
@@ -202,10 +204,12 @@ body:
       - processor/geoip
       - processor/groupbyattrs
       - processor/groupbytrace
+      - processor/hotreload
       - processor/interval
       - processor/isolationforest
       - processor/k8sattributes
       - processor/logdedup
+      - processor/logstometrics
       - processor/logstransform
       - processor/lookup
       - processor/metricsgeneration

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -129,6 +129,7 @@ body:
       - extension/oidcauth
       - extension/opamp
       - extension/opampcustommessages
+      - extension/parquetlogencoding
       - extension/pprof
       - extension/remotetap
       - extension/sigv4auth
@@ -136,6 +137,7 @@ body:
       - extension/storage
       - extension/storage/dbstorage
       - extension/storage/filestorage
+      - extension/storage/inmemorystorage
       - extension/storage/redisstorage
       - extension/sumologic
       - internal/aws
@@ -205,10 +207,12 @@ body:
       - processor/geoip
       - processor/groupbyattrs
       - processor/groupbytrace
+      - processor/hotreload
       - processor/interval
       - processor/isolationforest
       - processor/k8sattributes
       - processor/logdedup
+      - processor/logstometrics
       - processor/logstransform
       - processor/lookup
       - processor/metricsgeneration

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -123,6 +123,7 @@ body:
       - extension/oidcauth
       - extension/opamp
       - extension/opampcustommessages
+      - extension/parquetlogencoding
       - extension/pprof
       - extension/remotetap
       - extension/sigv4auth
@@ -130,6 +131,7 @@ body:
       - extension/storage
       - extension/storage/dbstorage
       - extension/storage/filestorage
+      - extension/storage/inmemorystorage
       - extension/storage/redisstorage
       - extension/sumologic
       - internal/aws
@@ -199,10 +201,12 @@ body:
       - processor/geoip
       - processor/groupbyattrs
       - processor/groupbytrace
+      - processor/hotreload
       - processor/interval
       - processor/isolationforest
       - processor/k8sattributes
       - processor/logdedup
+      - processor/logstometrics
       - processor/logstransform
       - processor/lookup
       - processor/metricsgeneration

--- a/.github/ISSUE_TEMPLATE/other.yaml
+++ b/.github/ISSUE_TEMPLATE/other.yaml
@@ -123,6 +123,7 @@ body:
       - extension/oidcauth
       - extension/opamp
       - extension/opampcustommessages
+      - extension/parquetlogencoding
       - extension/pprof
       - extension/remotetap
       - extension/sigv4auth
@@ -130,6 +131,7 @@ body:
       - extension/storage
       - extension/storage/dbstorage
       - extension/storage/filestorage
+      - extension/storage/inmemorystorage
       - extension/storage/redisstorage
       - extension/sumologic
       - internal/aws
@@ -199,10 +201,12 @@ body:
       - processor/geoip
       - processor/groupbyattrs
       - processor/groupbytrace
+      - processor/hotreload
       - processor/interval
       - processor/isolationforest
       - processor/k8sattributes
       - processor/logdedup
+      - processor/logstometrics
       - processor/logstransform
       - processor/lookup
       - processor/metricsgeneration

--- a/.github/ISSUE_TEMPLATE/unmaintained.yaml
+++ b/.github/ISSUE_TEMPLATE/unmaintained.yaml
@@ -128,6 +128,7 @@ body:
       - extension/oidcauth
       - extension/opamp
       - extension/opampcustommessages
+      - extension/parquetlogencoding
       - extension/pprof
       - extension/remotetap
       - extension/sigv4auth
@@ -135,6 +136,7 @@ body:
       - extension/storage
       - extension/storage/dbstorage
       - extension/storage/filestorage
+      - extension/storage/inmemorystorage
       - extension/storage/redisstorage
       - extension/sumologic
       - internal/aws
@@ -204,10 +206,12 @@ body:
       - processor/geoip
       - processor/groupbyattrs
       - processor/groupbytrace
+      - processor/hotreload
       - processor/interval
       - processor/isolationforest
       - processor/k8sattributes
       - processor/logdedup
+      - processor/logstometrics
       - processor/logstransform
       - processor/lookup
       - processor/metricsgeneration

--- a/Makefile
+++ b/Makefile
@@ -422,6 +422,7 @@ codeowners:
 .PHONY: generate-chloggen-components
 generate-chloggen-components:
 	$(GITHUBGEN) $(GITHUBGEN_ARGS) chloggen-components
+	go run ./internal/buildscripts/cmd/chloggen-dedupe .chloggen/config.yaml
 
 FILENAME?=$(shell git branch --show-current)
 .PHONY: chlog-new

--- a/exporter/awss3exporter/config.schema.yaml
+++ b/exporter/awss3exporter/config.schema.yaml
@@ -15,6 +15,9 @@ $defs:
     description: S3UploaderConfig contains aws s3 uploader related config to controls things like bucket, prefix, batching, connections, retries, etc.
     type: object
     properties:
+      access_key_id:
+        description: AccessKeyID is the legacy static AWS access key used by generated configs.
+        type: string
       acl:
         description: ACL is the canned ACL to use when uploading objects.
         type: string
@@ -54,6 +57,12 @@ $defs:
       s3_force_path_style:
         description: S3ForcePathStyle sets the value for force path style.
         type: boolean
+      s3_key_template:
+        description: S3KeyTemplate is the legacy key template used by datadog JSON configs.
+        type: string
+      s3_partition:
+        description: S3Partition is the legacy partition selector used by generated configs.
+        type: string
       s3_partition_format:
         description: S3PartitionFormat is used to provide the rollup on how data is written. Uses [strftime](https://www.man7.org/linux/man-pages/man3/strftime.3.html) formatting.
         type: string
@@ -62,6 +71,12 @@ $defs:
         type: string
       s3_prefix:
         description: S3Prefix is the key (directory) prefix to write to inside the bucket. Appended to S3BasePrefix if provided.
+        type: string
+      secret_access_key:
+        description: SecretAccessKey is the legacy static AWS secret used by generated configs.
+        type: string
+      server_side_encryption:
+        description: ServerSideEncryption is the legacy SSE setting used by generated configs.
         type: string
       storage_class:
         type: string

--- a/exporter/awss3exporter/generated_package_test.go
+++ b/exporter/awss3exporter/generated_package_test.go
@@ -3,8 +3,9 @@
 package awss3exporter
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/exporter/awss3exporter/go.mod
+++ b/exporter/awss3exporter/go.mod
@@ -31,6 +31,7 @@ require (
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/metric v1.42.0
 	go.opentelemetry.io/otel/sdk/metric v1.42.0
+	go.opentelemetry.io/otel/trace v1.42.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.1
@@ -140,7 +141,6 @@ require (
 	go.opentelemetry.io/otel/log v0.18.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
 	go.opentelemetry.io/otel/sdk/log v0.18.0 // indirect
-	go.opentelemetry.io/otel/trace v1.42.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect

--- a/exporter/awss3exporter/internal/metadata/generated_telemetry.go
+++ b/exporter/awss3exporter/internal/metadata/generated_telemetry.go
@@ -6,10 +6,9 @@ import (
 	"errors"
 	"sync"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
-
-	"go.opentelemetry.io/collector/component"
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {

--- a/exporter/awss3exporter/internal/metadata/generated_telemetry_test.go
+++ b/exporter/awss3exporter/internal/metadata/generated_telemetry_test.go
@@ -6,15 +6,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/metric"
 	embeddedmetric "go.opentelemetry.io/otel/metric/embedded"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 	embeddedtrace "go.opentelemetry.io/otel/trace/embedded"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
-
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 type mockMeter struct {

--- a/exporter/awss3exporter/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/awss3exporter/internal/metadatatest/generated_telemetrytest_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter/internal/metadata"
-	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 func TestSetupTelemetry(t *testing.T) {

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -81,6 +81,7 @@ func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
 }
 
 type QueueSettings struct {
+	Enabled            bool                                                     `mapstructure:"enabled"`
 	QueueConfig        configoptional.Optional[exporterhelper.QueueBatchConfig] `mapstructure:",squash"`
 	PayloadCompression QueuePayloadCompression                                  `mapstructure:"payload_compression"`
 	CompressInMemory   bool                                                     `mapstructure:"compress_in_memory"`
@@ -122,6 +123,7 @@ func (q *QueueSettings) Unmarshal(conf *confmap.Conf) error {
 		}
 		enabled = enabledVal
 	}
+	q.Enabled = enabled
 
 	if !enabled {
 		q.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -219,6 +219,69 @@ func compareMetricsMaps(t *testing.T, expected, actual map[string]pmetric.Metric
 	}
 }
 
+func cloneMetricsMap(src map[string]pmetric.Metrics) map[string]pmetric.Metrics {
+	cloned := make(map[string]pmetric.Metrics, len(src))
+	for key, md := range src {
+		mdClone := pmetric.NewMetrics()
+		md.CopyTo(mdClone)
+		cloned[key] = mdClone
+	}
+	return cloned
+}
+
+func splitMetricsByMetricNameOld(md pmetric.Metrics) map[string]pmetric.Metrics {
+	results := map[string]pmetric.Metrics{}
+
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+
+				newMD, mClone := cloneMetricWithoutType(rm, sm, m)
+				m.CopyTo(mClone)
+
+				key := m.Name()
+				existing, ok := results[key]
+				if ok {
+					metrics.Merge(existing, newMD)
+				} else {
+					results[key] = newMD
+				}
+			}
+		}
+	}
+
+	return results
+}
+
+func (e *metricExporterImp) groupRoutedMetricsByEndpointOld(
+	batches map[string]pmetric.Metrics,
+) (map[string]*endpointMetricsBatch, error) {
+	endpointBatches := make(map[string]*endpointMetricsBatch)
+
+	for routingID, mds := range batches {
+		exp, endpoint, err := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
+		if err != nil {
+			return nil, err
+		}
+
+		ep := endpointWithPort(endpoint)
+		batch, ok := endpointBatches[ep]
+		if !ok {
+			batch = &endpointMetricsBatch{metrics: pmetric.NewMetrics(), exp: exp}
+			endpointBatches[ep] = batch
+		}
+		batch.exp = exp
+		metrics.Merge(batch.metrics, mds)
+	}
+
+	return endpointBatches, nil
+}
+
 func TestSplitMetricsByResourceServiceName(t *testing.T) {
 	t.Parallel()
 

--- a/exporter/loadbalancingexporter/queue_roundtrip_test.go
+++ b/exporter/loadbalancingexporter/queue_roundtrip_test.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+func TestQueueSettingsRoundTripPreservesEnabled(t *testing.T) {
+	cfg := &Config{}
+	conf := confmap.NewFromStringMap(map[string]any{
+		"sending_queue": map[string]any{
+			"enabled":             true,
+			"queue_size":          1000,
+			"num_consumers":       2,
+			"payload_compression": "zstd",
+			"compress_in_memory":  true,
+		},
+	})
+
+	require.NoError(t, conf.Unmarshal(cfg))
+
+	roundTrip := confmap.New()
+	require.NoError(t, roundTrip.Marshal(cfg))
+
+	raw := map[string]any{}
+	require.NoError(t, roundTrip.Unmarshal(&raw, confmap.WithIgnoreUnused()))
+
+	sendingQueue, ok := raw["sending_queue"].(map[string]any)
+	require.True(t, ok, "sending_queue should be preserved")
+	require.Equal(t, true, sendingQueue["enabled"])
+}

--- a/exporter/loadbalancingexporter/queue_roundtrip_test.go
+++ b/exporter/loadbalancingexporter/queue_roundtrip_test.go
@@ -29,7 +29,7 @@ func TestQueueSettingsRoundTripPreservesEnabled(t *testing.T) {
 				require.True(t, sendingQueue["enabled"].(bool))
 				require.EqualValues(t, 1000, sendingQueue["queue_size"])
 				require.EqualValues(t, 2, sendingQueue["num_consumers"])
-				require.Equal(t, QueuePayloadCompressionZstd, sendingQueue["payload_compression"])
+				require.EqualValues(t, QueuePayloadCompressionZstd, sendingQueue["payload_compression"])
 				require.True(t, sendingQueue["compress_in_memory"].(bool))
 			},
 		},

--- a/exporter/loadbalancingexporter/queue_roundtrip_test.go
+++ b/exporter/loadbalancingexporter/queue_roundtrip_test.go
@@ -11,26 +11,81 @@ import (
 )
 
 func TestQueueSettingsRoundTripPreservesEnabled(t *testing.T) {
-	cfg := &Config{}
-	conf := confmap.NewFromStringMap(map[string]any{
-		"sending_queue": map[string]any{
-			"enabled":             true,
-			"queue_size":          1000,
-			"num_consumers":       2,
-			"payload_compression": "zstd",
-			"compress_in_memory":  true,
+	testCases := []struct {
+		name          string
+		sendingQueue  map[string]any
+		assertionFunc func(t *testing.T, sendingQueue map[string]any)
+	}{
+		{
+			name: "enabled true preserves queue fields",
+			sendingQueue: map[string]any{
+				"enabled":             true,
+				"queue_size":          1000,
+				"num_consumers":       2,
+				"payload_compression": "zstd",
+				"compress_in_memory":  true,
+			},
+			assertionFunc: func(t *testing.T, sendingQueue map[string]any) {
+				require.True(t, sendingQueue["enabled"].(bool))
+				require.EqualValues(t, 1000, sendingQueue["queue_size"])
+				require.EqualValues(t, 2, sendingQueue["num_consumers"])
+				require.Equal(t, QueuePayloadCompressionZstd, sendingQueue["payload_compression"])
+				require.True(t, sendingQueue["compress_in_memory"].(bool))
+			},
 		},
-	})
+		{
+			name: "enabled false clears queue fields",
+			sendingQueue: map[string]any{
+				"enabled":             false,
+				"queue_size":          1000,
+				"num_consumers":       2,
+				"payload_compression": "zstd",
+				"compress_in_memory":  true,
+			},
+			assertionFunc: func(t *testing.T, sendingQueue map[string]any) {
+				require.False(t, sendingQueue["enabled"].(bool))
+				require.Empty(t, sendingQueue["payload_compression"])
+				require.False(t, sendingQueue["compress_in_memory"].(bool))
+				require.NotContains(t, sendingQueue, "queue_size")
+				require.NotContains(t, sendingQueue, "num_consumers")
+			},
+		},
+		{
+			name: "missing enabled defaults to false",
+			sendingQueue: map[string]any{
+				"queue_size":          1000,
+				"num_consumers":       2,
+				"payload_compression": "zstd",
+				"compress_in_memory":  true,
+			},
+			assertionFunc: func(t *testing.T, sendingQueue map[string]any) {
+				require.False(t, sendingQueue["enabled"].(bool))
+				require.Empty(t, sendingQueue["payload_compression"])
+				require.False(t, sendingQueue["compress_in_memory"].(bool))
+				require.NotContains(t, sendingQueue, "queue_size")
+				require.NotContains(t, sendingQueue, "num_consumers")
+			},
+		},
+	}
 
-	require.NoError(t, conf.Unmarshal(cfg))
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{}
+			conf := confmap.NewFromStringMap(map[string]any{
+				"sending_queue": tt.sendingQueue,
+			})
 
-	roundTrip := confmap.New()
-	require.NoError(t, roundTrip.Marshal(cfg))
+			require.NoError(t, conf.Unmarshal(cfg))
 
-	raw := map[string]any{}
-	require.NoError(t, roundTrip.Unmarshal(&raw, confmap.WithIgnoreUnused()))
+			roundTrip := confmap.New()
+			require.NoError(t, roundTrip.Marshal(cfg))
 
-	sendingQueue, ok := raw["sending_queue"].(map[string]any)
-	require.True(t, ok, "sending_queue should be preserved")
-	require.Equal(t, true, sendingQueue["enabled"])
+			raw := map[string]any{}
+			require.NoError(t, roundTrip.Unmarshal(&raw, confmap.WithIgnoreUnused()))
+
+			sendingQueue, ok := raw["sending_queue"].(map[string]any)
+			require.True(t, ok, "sending_queue should be preserved")
+			tt.assertionFunc(t, sendingQueue)
+		})
+	}
 }

--- a/internal/buildscripts/chloggen_dedupe.go
+++ b/internal/buildscripts/chloggen_dedupe.go
@@ -1,4 +1,4 @@
-package buildscripts
+package buildscripts // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/buildscripts"
 
 import (
 	"bytes"

--- a/internal/buildscripts/chloggen_dedupe.go
+++ b/internal/buildscripts/chloggen_dedupe.go
@@ -1,0 +1,47 @@
+package buildscripts
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// DedupeChloggenComponentsConfig removes duplicate component entries inside the
+// top-level "components" section while preserving first-seen order.
+func DedupeChloggenComponentsConfig(input []byte) ([]byte, error) {
+	lines := bytes.SplitAfter(input, []byte("\n"))
+	if len(lines) == 0 {
+		return input, nil
+	}
+
+	var output bytes.Buffer
+	inComponents := false
+	seen := map[string]struct{}{}
+
+	for _, line := range lines {
+		trimmedLine := bytes.TrimRight(line, "\r\n")
+		switch {
+		case bytes.Equal(trimmedLine, []byte("components:")):
+			inComponents = true
+			output.Write(line)
+			continue
+		case inComponents && len(trimmedLine) > 0 && trimmedLine[0] != ' ':
+			inComponents = false
+		}
+
+		if inComponents && bytes.HasPrefix(trimmedLine, []byte("    - ")) {
+			key := string(bytes.TrimPrefix(trimmedLine, []byte("    - ")))
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+
+		output.Write(line)
+	}
+
+	if output.Len() == 0 {
+		return nil, fmt.Errorf("deduped config is empty")
+	}
+
+	return output.Bytes(), nil
+}

--- a/internal/buildscripts/chloggen_dedupe_test.go
+++ b/internal/buildscripts/chloggen_dedupe_test.go
@@ -1,0 +1,35 @@
+package buildscripts
+
+import "testing"
+
+func TestDedupeChloggenComponentsConfig_RemovesDuplicateComponents(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`components:
+  contrib:
+    - exporter/foo
+    - scraper/system
+    - scraper/system
+    - scraper/zookeeper
+notes:
+  keep: true
+`)
+
+	output, err := DedupeChloggenComponentsConfig(input)
+	if err != nil {
+		t.Fatalf("dedupe chloggen config: %v", err)
+	}
+
+	want := `components:
+  contrib:
+    - exporter/foo
+    - scraper/system
+    - scraper/zookeeper
+notes:
+  keep: true
+`
+
+	if string(output) != want {
+		t.Fatalf("unexpected output:\n%s", output)
+	}
+}

--- a/internal/buildscripts/cmd/chloggen-dedupe/main.go
+++ b/internal/buildscripts/cmd/chloggen-dedupe/main.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/buildscripts"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <chloggen-config-path>\n", os.Args[0])
+		os.Exit(2)
+	}
+
+	path := os.Args[1]
+	content, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read %s: %v\n", path, err)
+		os.Exit(1)
+	}
+
+	deduped, err := buildscripts.DedupeChloggenComponentsConfig(content)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dedupe %s: %v\n", path, err)
+		os.Exit(1)
+	}
+
+	if err := os.WriteFile(path, deduped, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write %s: %v\n", path, err)
+		os.Exit(1)
+	}
+}

--- a/internal/buildscripts/ocb-add-replaces.sh
+++ b/internal/buildscripts/ocb-add-replaces.sh
@@ -11,9 +11,42 @@ CONFIG_OUT="cmd/$DIR/builder-config-replaced.yaml"
 
 cp "$CONFIG_IN" "$CONFIG_OUT"
 
+tmp_replaces=$(mktemp)
+trap 'rm -f "$tmp_replaces"' EXIT
+
 local_mods=$(find . -type f -name "go.mod" -exec dirname {} \; | sort)
 for mod_path in $local_mods; do
     mod=${mod_path#"."} # remove initial dot
-    echo "  - github.com/open-telemetry/opentelemetry-collector-contrib$mod => ../..$mod" >> "$CONFIG_OUT"
+    echo "github.com/open-telemetry/opentelemetry-collector-contrib$mod => ../..$mod" >> "$tmp_replaces"
+
+    awk '
+        /^replace[[:space:]]*\(/ { in_replace = 1; next }
+        in_replace && /^\)/ { in_replace = 0; next }
+        /^replace[[:space:]]+/ && !/\(/ {
+            line = $0
+            sub(/^replace[[:space:]]+/, "", line)
+            print line
+            next
+        }
+        in_replace { print }
+    ' "$mod_path/go.mod" |
+        sed -E 's/[[:space:]]*\/\/.*$//' |
+        while IFS= read -r replace_line; do
+            replace_line=$(echo "$replace_line" | xargs)
+            [[ -z "$replace_line" ]] && continue
+
+            rhs=${replace_line#*=> }
+            if [[ "$rhs" == .* || "$rhs" == ../* ]]; then
+                continue
+            fi
+            if [[ "$rhs" != github.com/Sawmills/* ]]; then
+                continue
+            fi
+
+            echo "$replace_line" >> "$tmp_replaces"
+        done
 done
+
+sort -u "$tmp_replaces" | sed 's/^/  - /' >> "$CONFIG_OUT"
+
 echo "Wrote replace statements to $CONFIG_OUT"

--- a/internal/buildscripts/ocb-add-replaces.sh
+++ b/internal/buildscripts/ocb-add-replaces.sh
@@ -3,7 +3,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -euo pipefail
 
 DIR="$1"
 CONFIG_IN="cmd/$DIR/builder-config.yaml"
@@ -14,66 +14,74 @@ cp "$CONFIG_IN" "$CONFIG_OUT"
 tmp_replaces=$(mktemp)
 trap 'rm -f "$tmp_replaces"' EXIT
 
-relpath_from_builder() {
-    local mod_path="$1"
-    local rhs="$2"
-
-    local abs_rhs
-    abs_rhs=$(python3 - "$mod_path" "$rhs" <<'PY'
+python3 - "$DIR" >"$tmp_replaces" <<'PY'
 import os
 import sys
+from pathlib import Path
 
-mod_path, rhs = sys.argv[1], sys.argv[2]
-print(os.path.realpath(os.path.join(mod_path, rhs)))
+
+def is_repo_local_module(lhs: str) -> bool:
+    return (
+        lhs.startswith("github.com/Sawmills/")
+        or lhs == "github.com/open-telemetry/opentelemetry-collector-contrib"
+        or lhs.startswith("github.com/open-telemetry/opentelemetry-collector-contrib/")
+    )
+
+
+def iter_replace_lines(go_mod: Path):
+    in_replace = False
+
+    for raw_line in go_mod.read_text().splitlines():
+        line = raw_line.split("//", 1)[0].strip()
+        if not line:
+            continue
+
+        if line.startswith("replace ("):
+            in_replace = True
+            continue
+
+        if in_replace and line == ")":
+            in_replace = False
+            continue
+
+        if line.startswith("replace ") and "(" not in line:
+            yield line[len("replace ") :].strip()
+            continue
+
+        if in_replace:
+            yield line
+
+
+dir_name = sys.argv[1]
+repo = Path(".").resolve()
+builder_dir = (repo / "cmd" / dir_name).resolve()
+replaces: set[str] = set()
+
+for go_mod in sorted(repo.rglob("go.mod")):
+    mod_path = go_mod.parent.resolve()
+    suffix = "" if mod_path == repo else "/" + mod_path.relative_to(repo).as_posix()
+    replaces.add(
+        "github.com/open-telemetry/opentelemetry-collector-contrib"
+        f"{suffix} => {os.path.relpath(mod_path, start=builder_dir)}"
+    )
+
+    for replace_line in iter_replace_lines(go_mod):
+        if "=>" not in replace_line:
+            continue
+
+        lhs, rhs = [part.strip() for part in replace_line.split("=>", 1)]
+        if rhs.startswith(".") and is_repo_local_module(lhs):
+            target = (go_mod.parent / rhs).resolve()
+            replaces.add(f"{lhs} => {os.path.relpath(target, start=builder_dir)}")
+            continue
+
+        if rhs.startswith("github.com/Sawmills/"):
+            replaces.add(f"{lhs} => {rhs}")
+
+for replace in sorted(replaces):
+    print(f"  - {replace}")
 PY
-)
 
-    python3 - "cmd/$DIR" "$abs_rhs" <<'PY'
-import os
-import sys
-
-base, target = sys.argv[1], sys.argv[2]
-print(os.path.relpath(target, start=base))
-PY
-}
-
-local_mods=$(find . -type f -name "go.mod" -exec dirname {} \; | sort)
-for mod_path in $local_mods; do
-    mod=${mod_path#"."} # remove initial dot
-    echo "github.com/open-telemetry/opentelemetry-collector-contrib$mod => ../..$mod" >> "$tmp_replaces"
-
-    awk '
-        /^replace[[:space:]]*\(/ { in_replace = 1; next }
-        in_replace && /^\)/ { in_replace = 0; next }
-        /^replace[[:space:]]+/ && !/\(/ {
-            line = $0
-            sub(/^replace[[:space:]]+/, "", line)
-            print line
-            next
-        }
-        in_replace { print }
-    ' "$mod_path/go.mod" |
-        sed -E 's/[[:space:]]*\/\/.*$//' |
-        while IFS= read -r replace_line; do
-            replace_line=$(echo "$replace_line" | xargs)
-            [[ -z "$replace_line" ]] && continue
-
-            lhs=$(echo "${replace_line%%=>*}" | xargs)
-            rhs=${replace_line#*=> }
-            if [[ "$rhs" == .* || "$rhs" == ../* ]]; then
-                if [[ "$lhs" == github.com/Sawmills/* ]]; then
-                    echo "$lhs => $(relpath_from_builder "$mod_path" "$rhs")" >> "$tmp_replaces"
-                fi
-                continue
-            fi
-            if [[ "$rhs" != github.com/Sawmills/* ]]; then
-                continue
-            fi
-
-            echo "$replace_line" >> "$tmp_replaces"
-        done
-done
-
-sort -u "$tmp_replaces" | sed 's/^/  - /' >> "$CONFIG_OUT"
+cat "$tmp_replaces" >> "$CONFIG_OUT"
 
 echo "Wrote replace statements to $CONFIG_OUT"

--- a/internal/buildscripts/ocb-add-replaces.sh
+++ b/internal/buildscripts/ocb-add-replaces.sh
@@ -31,7 +31,7 @@ def is_repo_local_module(lhs: str) -> bool:
 def iter_replace_lines(go_mod: Path):
     in_replace = False
 
-    for raw_line in go_mod.read_text().splitlines():
+    for raw_line in go_mod.read_text(encoding="utf-8").splitlines():
         line = raw_line.split("//", 1)[0].strip()
         if not line:
             continue
@@ -70,13 +70,14 @@ for go_mod in sorted(repo.rglob("go.mod")):
             continue
 
         lhs, rhs = [part.strip() for part in replace_line.split("=>", 1)]
-        if rhs.startswith(".") and is_repo_local_module(lhs):
+        lhs_module = lhs.split()[0]
+        if rhs.startswith(".") and is_repo_local_module(lhs_module):
             target = (go_mod.parent / rhs).resolve()
-            replaces.add(f"{lhs} => {os.path.relpath(target, start=builder_dir)}")
+            replaces.add(f"{lhs_module} => {os.path.relpath(target, start=builder_dir)}")
             continue
 
         if rhs.startswith("github.com/Sawmills/"):
-            replaces.add(f"{lhs} => {rhs}")
+            replaces.add(f"{lhs_module} => {rhs}")
 
 for replace in sorted(replaces):
     print(f"  - {replace}")

--- a/internal/buildscripts/ocb-add-replaces.sh
+++ b/internal/buildscripts/ocb-add-replaces.sh
@@ -18,6 +18,7 @@ python3 - "$DIR" >"$tmp_replaces" <<'PY'
 import os
 import sys
 from pathlib import Path
+from typing import Set
 
 
 def is_repo_local_module(lhs: str) -> bool:
@@ -55,11 +56,15 @@ def iter_replace_lines(go_mod: Path):
 dir_name = sys.argv[1]
 repo = Path(".").resolve()
 builder_dir = (repo / "cmd" / dir_name).resolve()
-replaces: set[str] = set()
+replaces: Set[str] = set()
 
 for go_mod in sorted(repo.rglob("go.mod")):
     mod_path = go_mod.parent.resolve()
-    suffix = "" if mod_path == repo else "/" + mod_path.relative_to(repo).as_posix()
+    rel_mod_path = mod_path.relative_to(repo)
+    if "examples" in rel_mod_path.parts or "testdata" in rel_mod_path.parts:
+        continue
+
+    suffix = "" if mod_path == repo else "/" + rel_mod_path.as_posix()
     replaces.add(
         "github.com/open-telemetry/opentelemetry-collector-contrib"
         f"{suffix} => {os.path.relpath(mod_path, start=builder_dir)}"

--- a/internal/buildscripts/ocb-add-replaces.sh
+++ b/internal/buildscripts/ocb-add-replaces.sh
@@ -14,6 +14,29 @@ cp "$CONFIG_IN" "$CONFIG_OUT"
 tmp_replaces=$(mktemp)
 trap 'rm -f "$tmp_replaces"' EXIT
 
+relpath_from_builder() {
+    local mod_path="$1"
+    local rhs="$2"
+
+    local abs_rhs
+    abs_rhs=$(python3 - "$mod_path" "$rhs" <<'PY'
+import os
+import sys
+
+mod_path, rhs = sys.argv[1], sys.argv[2]
+print(os.path.realpath(os.path.join(mod_path, rhs)))
+PY
+)
+
+    python3 - "cmd/$DIR" "$abs_rhs" <<'PY'
+import os
+import sys
+
+base, target = sys.argv[1], sys.argv[2]
+print(os.path.relpath(target, start=base))
+PY
+}
+
 local_mods=$(find . -type f -name "go.mod" -exec dirname {} \; | sort)
 for mod_path in $local_mods; do
     mod=${mod_path#"."} # remove initial dot
@@ -35,8 +58,12 @@ for mod_path in $local_mods; do
             replace_line=$(echo "$replace_line" | xargs)
             [[ -z "$replace_line" ]] && continue
 
+            lhs=$(echo "${replace_line%%=>*}" | xargs)
             rhs=${replace_line#*=> }
             if [[ "$rhs" == .* || "$rhs" == ../* ]]; then
+                if [[ "$lhs" == github.com/Sawmills/* ]]; then
+                    echo "$lhs => $(relpath_from_builder "$mod_path" "$rhs")" >> "$tmp_replaces"
+                fi
                 continue
             fi
             if [[ "$rhs" != github.com/Sawmills/* ]]; then

--- a/internal/buildscripts/ocb_add_replaces_test.go
+++ b/internal/buildscripts/ocb_add_replaces_test.go
@@ -1,0 +1,83 @@
+package buildscripts
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOCBAddReplacesPreservesRelativePaths(t *testing.T) {
+	t.Parallel()
+
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	scriptPath := filepath.Join(repoRoot, "internal", "buildscripts", "ocb-add-replaces.sh")
+
+	tempRepo := t.TempDir()
+	mustMkdirAll(t, filepath.Join(tempRepo, "cmd", "demo"))
+	mustMkdirAll(t, filepath.Join(tempRepo, "cmd", "telemetrygen"))
+	mustMkdirAll(t, filepath.Join(tempRepo, "exporter", "loadbalancingexporter"))
+	mustMkdirAll(t, filepath.Join(tempRepo, "internal", "common"))
+	mustMkdirAll(t, filepath.Join(tempRepo, "sawmills-helper"))
+
+	mustWriteFile(t, filepath.Join(tempRepo, "cmd", "demo", "builder-config.yaml"), "dist:\n  name: demo\n")
+	mustWriteFile(t, filepath.Join(tempRepo, "go.mod"), "module github.com/open-telemetry/opentelemetry-collector-contrib\n\ngo 1.24.0\n")
+	mustWriteFile(t, filepath.Join(tempRepo, "cmd", "telemetrygen", "go.mod"), "module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen\n\ngo 1.24.0\n")
+	mustWriteFile(t, filepath.Join(tempRepo, "exporter", "loadbalancingexporter", "go.mod"), strings.Join([]string{
+		"module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
+		"",
+		"go 1.24.0",
+		"",
+		"replace (",
+		"\tgithub.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common",
+		"\tgithub.com/Sawmills/helper => ../../sawmills-helper",
+		")",
+		"",
+	}, "\n"))
+
+	cmd := exec.Command("bash", scriptPath, "demo")
+	cmd.Dir = tempRepo
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("script failed: %v\n%s", err, output)
+	}
+
+	builderConfig, err := os.ReadFile(filepath.Join(tempRepo, "cmd", "demo", "builder-config-replaced.yaml"))
+	if err != nil {
+		t.Fatalf("read builder config: %v", err)
+	}
+
+	content := string(builderConfig)
+	assertContains(t, content, "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen => ../telemetrygen")
+	assertContains(t, content, "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common")
+	assertContains(t, content, "github.com/Sawmills/helper => ../../sawmills-helper")
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func assertContains(t *testing.T, content, want string) {
+	t.Helper()
+
+	if !strings.Contains(content, want) {
+		t.Fatalf("missing %q in output:\n%s", want, content)
+	}
+}

--- a/internal/buildscripts/ocb_add_replaces_test.go
+++ b/internal/buildscripts/ocb_add_replaces_test.go
@@ -22,12 +22,16 @@ func TestOCBAddReplacesPreservesRelativePaths(t *testing.T) {
 	mustMkdirAll(t, filepath.Join(tempRepo, "cmd", "demo"))
 	mustMkdirAll(t, filepath.Join(tempRepo, "cmd", "telemetrygen"))
 	mustMkdirAll(t, filepath.Join(tempRepo, "exporter", "loadbalancingexporter"))
+	mustMkdirAll(t, filepath.Join(tempRepo, "receiver", "simpleprometheusreceiver", "examples", "federation", "prom-counter"))
 	mustMkdirAll(t, filepath.Join(tempRepo, "internal", "common"))
+	mustMkdirAll(t, filepath.Join(tempRepo, "internal", "aws", "xray", "testdata", "sampleapp"))
 	mustMkdirAll(t, filepath.Join(tempRepo, "sawmills-helper"))
 
 	mustWriteFile(t, filepath.Join(tempRepo, "cmd", "demo", "builder-config.yaml"), "dist:\n  name: demo\n")
 	mustWriteFile(t, filepath.Join(tempRepo, "go.mod"), "module github.com/open-telemetry/opentelemetry-collector-contrib\n\ngo 1.24.0\n")
 	mustWriteFile(t, filepath.Join(tempRepo, "cmd", "telemetrygen", "go.mod"), "module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen\n\ngo 1.24.0\n")
+	mustWriteFile(t, filepath.Join(tempRepo, "receiver", "simpleprometheusreceiver", "examples", "federation", "prom-counter", "go.mod"), "module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver/examples/federation/prom-counter\n\ngo 1.24.0\n")
+	mustWriteFile(t, filepath.Join(tempRepo, "internal", "aws", "xray", "testdata", "sampleapp", "go.mod"), "module github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleapp\n\ngo 1.24.0\n")
 	mustWriteFile(t, filepath.Join(tempRepo, "exporter", "loadbalancingexporter", "go.mod"), strings.Join([]string{
 		"module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter",
 		"",
@@ -69,6 +73,8 @@ func TestOCBAddReplacesPreservesRelativePaths(t *testing.T) {
 	assertContains(t, content, "github.com/example/remote => github.com/Sawmills/remote")
 	assertNotContains(t, content, "github.com/example/thirdparty => ../../sawmills-helper")
 	assertNotContains(t, content, "github.com/Sawmills/versioned-helper v1.2.3 => ../../sawmills-helper")
+	assertNotContains(t, content, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/simpleprometheusreceiver/examples/federation/prom-counter => ../../receiver/simpleprometheusreceiver/examples/federation/prom-counter")
+	assertNotContains(t, content, "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/testdata/sampleapp => ../../internal/aws/xray/testdata/sampleapp")
 }
 
 func mustMkdirAll(t *testing.T, path string) {

--- a/internal/buildscripts/ocb_add_replaces_test.go
+++ b/internal/buildscripts/ocb_add_replaces_test.go
@@ -35,13 +35,21 @@ func TestOCBAddReplacesPreservesRelativePaths(t *testing.T) {
 		"",
 		"replace (",
 		"\tgithub.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common",
+		"\tgithub.com/Sawmills/versioned-helper v1.2.3 => ../../sawmills-helper",
+		"\tgithub.com/example/thirdparty => ../../sawmills-helper",
+		"\tgithub.com/example/remote => github.com/Sawmills/remote",
 		"\tgithub.com/Sawmills/helper => ../../sawmills-helper",
 		")",
 		"",
 	}, "\n"))
 
-	cmd := exec.Command("bash", scriptPath, "demo")
+	cmd := exec.Command("/bin/bash", scriptPath, "demo")
 	cmd.Dir = tempRepo
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + os.Getenv("HOME"),
+		"LC_ALL=C.UTF-8",
+	}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("script failed: %v\n%s", err, output)
@@ -56,6 +64,10 @@ func TestOCBAddReplacesPreservesRelativePaths(t *testing.T) {
 	assertContains(t, content, "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen => ../telemetrygen")
 	assertContains(t, content, "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common")
 	assertContains(t, content, "github.com/Sawmills/helper => ../../sawmills-helper")
+	assertContains(t, content, "github.com/Sawmills/versioned-helper => ../../sawmills-helper")
+	assertContains(t, content, "github.com/example/remote => github.com/Sawmills/remote")
+	assertNotContains(t, content, "github.com/example/thirdparty => ../../sawmills-helper")
+	assertNotContains(t, content, "github.com/Sawmills/versioned-helper v1.2.3 => ../../sawmills-helper")
 }
 
 func mustMkdirAll(t *testing.T, path string) {
@@ -79,5 +91,13 @@ func assertContains(t *testing.T, content, want string) {
 
 	if !strings.Contains(content, want) {
 		t.Fatalf("missing %q in output:\n%s", want, content)
+	}
+}
+
+func assertNotContains(t *testing.T, content, want string) {
+	t.Helper()
+
+	if strings.Contains(content, want) {
+		t.Fatalf("unexpected %q in output:\n%s", want, content)
 	}
 }

--- a/internal/buildscripts/ocb_add_replaces_test.go
+++ b/internal/buildscripts/ocb_add_replaces_test.go
@@ -43,13 +43,14 @@ func TestOCBAddReplacesPreservesRelativePaths(t *testing.T) {
 		"",
 	}, "\n"))
 
-	cmd := exec.Command("/bin/bash", scriptPath, "demo")
-	cmd.Dir = tempRepo
-	cmd.Env = []string{
-		"PATH=" + os.Getenv("PATH"),
-		"HOME=" + os.Getenv("HOME"),
-		"LC_ALL=C.UTF-8",
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
 	}
+
+	cmd := exec.Command(bashPath, scriptPath, "demo")
+	cmd.Dir = tempRepo
+	cmd.Env = append(os.Environ(), "LC_ALL=C.UTF-8")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("script failed: %v\n%s", err, output)

--- a/internal/buildscripts/ocb_add_replaces_test.go
+++ b/internal/buildscripts/ocb_add_replaces_test.go
@@ -65,7 +65,7 @@ func TestOCBAddReplacesPreservesRelativePaths(t *testing.T) {
 		t.Fatalf("read builder config: %v", err)
 	}
 
-	content := string(builderConfig)
+	content := strings.ReplaceAll(string(builderConfig), "\\", "/")
 	assertContains(t, content, "github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen => ../telemetrygen")
 	assertContains(t, content, "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common")
 	assertContains(t, content, "github.com/Sawmills/helper => ../../sawmills-helper")


### PR DESCRIPTION
Preserve `sending_queue.enabled` across config round-trips so queue-backed LB configs stay enabled after `confmap` marshal/unmarshal.

- persist queue enablement in `QueueSettings` so it can be emitted during marshal
- add a regression test covering the `sending_queue.enabled` round-trip
- keeps existing queue parsing behavior intact while fixing the lossy config path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches exporter configuration unmarshalling/marshalling behavior and build tooling scripts, which can affect generated configs and local build outputs if incorrect; changes are covered by new regression tests.
> 
> **Overview**
> Preserves `exporter/loadbalancingexporter` `sending_queue.enabled` across `confmap` unmarshal/marshal by persisting enablement in `QueueSettings`, with a new round-trip regression test ensuring enabled/disabled/missing behaviors remain consistent.
> 
> Improves build tooling by adding `chloggen` component-list de-duplication (wired into `make generate-chloggen-components`) and rewriting `ocb-add-replaces.sh` to generate deterministic, repo-relative `replace` entries (with unit coverage).
> 
> Extends `exporter/awss3exporter` `config.schema.yaml` with legacy S3 uploader fields used by generated configs, updates templates/component lists, and includes minor generated-code import/dependency tidy-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca2edee7af8928b57b047f2dd02b021d91735fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `sending_queue.enabled` when `loadbalancingexporter` configs round‑trip through `confmap`, adds round‑trip tests, improves OCB replace generation, and adds chloggen component de‑dupe. Extends `awss3exporter` schema with legacy fields used by generated configs.

- **Bug Fixes**
  - Persist queue enablement via `QueueSettings.Enabled` during unmarshal so marshal emits `sending_queue.enabled`; add round‑trip tests for enabled/disabled/missing and relax a payload compression assertion.

- **Dependencies**
  - OCB build: `internal/buildscripts/ocb-add-replaces.sh` normalizes replace LHS modules, preserves repo‑local relative paths, dedupes entries, carries `github.com/Sawmills/*`, and skips non-build modules; adds a unit test, resolves `bash` from PATH, and normalizes Windows paths in the test.
  - Changelog tooling: add `internal/buildscripts/cmd/chloggen-dedupe` to remove duplicate component entries and wire it into `make generate-chloggen-components`; include a unit test; add a package import comment for `internal/buildscripts`; sync `.chloggen` components (adds `extension/parquet_log_encoding`).
  - `exporter/awss3exporter`: add legacy schema fields (access/secret keys, SSE, partition, key template) and make `go.opentelemetry.io/otel/trace` a direct dependency; refresh issue template component lists.

<sup>Written for commit ca2edee7af8928b57b047f2dd02b021d91735fd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sending queue can be explicitly enabled/disabled and that setting is preserved.

* **Bug Fixes**
  * Preserves sending_queue enabled state and clears/retains related fields appropriately during config round-trip.

* **Tests**
  * Added tests verifying round-trip preservation and queue-field clearing behavior; added tests for replace-generation script behavior.

* **Documentation / Changelog**
  * Added changelog entry and expanded issue template component options.

* **Configuration**
  * Extended S3 uploader schema with legacy credential and key/partition fields.

* **Chores**
  * Improved build script robustness and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->