### PR TITLE
[codex] add loadbalancingexporter queue age metrics

### DIFF
--- a/.chloggen/loadbalancingexporter-queue-age-metrics.yaml
+++ b/.chloggen/loadbalancingexporter-queue-age-metrics.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add queue age metrics for the loadbalancing exporter sending queue and internal post-routing batchers.
+issues: [47]
+subtext: |-
+  This adds oldest-pending age gauges plus flush-age histograms so operators can distinguish deep queues from stale queues across both exporterhelper sending_queue backlog and the loadbalancing exporter's internal log and metric batchers.

--- a/exporter/awss3exporter/config.schema.yaml
+++ b/exporter/awss3exporter/config.schema.yaml
@@ -95,6 +95,9 @@ properties:
     type: string
   marshaler:
     $ref: marshaler_type
+  max_file_size_bytes:
+    description: MaxFileSizeBytes sets the uncompressed size threshold at which the jsonBatchingMarshaler flushes its buffer to S3. When > 0 and MarshalerName is OtlpJSON, the batching marshaler is used instead of the default pass-through marshaler.
+    type: integer
   resource_attrs_to_s3:
     $ref: resource_attrs_to_s_3
   s3uploader:

--- a/exporter/awss3exporter/exporter.go
+++ b/exporter/awss3exporter/exporter.go
@@ -115,15 +115,16 @@ func (e *s3Exporter) getUploadOpts(res pcommon.Resource) *upload.UploadOptions {
 func (e *s3Exporter) start(ctx context.Context, host component.Host) error {
 	var m marshaler
 	var err error
-	if e.config.Encoding != nil {
+	switch {
+	case e.config.Encoding != nil:
 		if m, err = newMarshalerFromEncoding(e.config.Encoding, e.config.EncodingFileExtension, host, e.logger); err != nil {
 			return err
 		}
-	} else if e.config.MaxFileSizeBytes > 0 {
+	case e.config.MaxFileSizeBytes > 0:
 		if m, err = newMarshalerWithConfig(e.config.MarshalerName, e.config.MaxFileSizeBytes, e.logger); err != nil {
 			return err
 		}
-	} else {
+	default:
 		if m, err = newMarshaler(e.config.MarshalerName, e.logger); err != nil {
 			return fmt.Errorf("unknown marshaler %q", e.config.MarshalerName)
 		}
@@ -204,7 +205,8 @@ func (e *s3Exporter) flushMarshaler(ctx context.Context, reason string) error {
 		return nil
 	}
 
-	if flusher, ok := e.marshaler.(logFlusherWithReason); ok {
+	switch flusher := e.marshaler.(type) {
+	case logFlusherWithReason:
 		buf, err := flusher.FlushLogsWithReason(reason)
 		if err != nil {
 			return err
@@ -217,7 +219,7 @@ func (e *s3Exporter) flushMarshaler(ctx context.Context, reason string) error {
 				return err
 			}
 		}
-	} else if flusher, ok := e.marshaler.(logFlusher); ok {
+	case logFlusher:
 		buf, err := flusher.FlushLogs()
 		if err != nil {
 			return err

--- a/exporter/awss3exporter/json_batching_marshaler.go
+++ b/exporter/awss3exporter/json_batching_marshaler.go
@@ -69,13 +69,13 @@ func (m *jsonBatchingMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
 	m.uncompressedSize += len(data)
 
 	if m.uncompressedSize >= m.maxBatchSize {
-		return m.flushLogBatch()
+		return m.flushLogBatch(), nil
 	}
 
 	return []byte{}, nil
 }
 
-func (m *jsonBatchingMarshaler) createJSONL(batches []json.RawMessage) []byte {
+func createJSONL(batches []json.RawMessage) []byte {
 	if len(batches) == 0 {
 		return []byte("")
 	}
@@ -91,12 +91,12 @@ func (m *jsonBatchingMarshaler) createJSONL(batches []json.RawMessage) []byte {
 	return result.Bytes()
 }
 
-func (m *jsonBatchingMarshaler) flushLogBatch() ([]byte, error) {
+func (m *jsonBatchingMarshaler) flushLogBatch() []byte {
 	if m.logsBatchCount == 0 {
-		return nil, nil
+		return nil
 	}
 
-	jsonlData := m.createJSONL(m.logBatches)
+	jsonlData := createJSONL(m.logBatches)
 
 	if m.logger != nil {
 		m.logger.Debug("Flushed uncompressed JSONL log batch",
@@ -108,13 +108,13 @@ func (m *jsonBatchingMarshaler) flushLogBatch() ([]byte, error) {
 	m.logsBatchCount = 0
 	m.uncompressedSize = 0
 
-	return jsonlData, nil
+	return jsonlData
 }
 
 func (m *jsonBatchingMarshaler) FlushLogs() ([]byte, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	return m.flushLogBatch()
+	return m.flushLogBatch(), nil
 }
 
 func (m *jsonBatchingMarshaler) MarshalTraces(td ptrace.Traces) ([]byte, error) {
@@ -175,7 +175,7 @@ func (m *jsonBatchingMarshaler) flushTraceBatch() ([]byte, error) {
 		wrapped = append(wrapped, envelope)
 	}
 
-	jsonlData := m.createJSONL(wrapped)
+	jsonlData := createJSONL(wrapped)
 
 	if m.logger != nil {
 		m.logger.Debug("Flushed uncompressed JSONL trace batch",
@@ -200,10 +200,10 @@ func (m *jsonBatchingMarshaler) MarshalMetrics(md pmetric.Metrics) ([]byte, erro
 	return m.metricsMarshaler.MarshalMetrics(md)
 }
 
-func (m *jsonBatchingMarshaler) format() string {
+func (*jsonBatchingMarshaler) format() string {
 	return "json"
 }
 
-func (m *jsonBatchingMarshaler) compressed() bool {
+func (*jsonBatchingMarshaler) compressed() bool {
 	return false
 }

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -465,9 +465,6 @@ The following metrics are recorded by this exporter:
 * `otelcol_loadbalancer_num_backend_updates` records how many of the resolutions resulted in a new list of backends. Use this information to understand how frequent your backend updates are and how often the ring is rebalanced. If the DNS hostname is always returning the same list of IP addresses but this metric keeps increasing, it might indicate a bug in the load balancer.
 * `otelcol_loadbalancer_backend_latency` measures the latency for each backend.
 * `otelcol_loadbalancer_backend_outcome` counts what the outcomes were for each endpoint, `success=true|false`.
-* When `sending_queue` is enabled with an exporterhelper build that includes queue-age instrumentation, standard queue age metrics are also available:
-  * `otelcol_exporter_queue_oldest_batch_age` reports the age of the oldest batch still waiting in the exporter queue.
-  * `otelcol_exporter_queue_batch_send_age` records how long a batch spent in the exporter queue before a consumer picked it up.
 * When the internal LB batchers are active, age metrics are also emitted for post-routing backlog:
   * `otelcol_loadbalancer_log_batch_pending_oldest_record_age` reports the age of the oldest log record currently pending for each backend endpoint.
   * `otelcol_loadbalancer_log_batch_pending_oldest_record_age_max` reports the maximum pending oldest-log age across all backend endpoints.

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -465,3 +465,13 @@ The following metrics are recorded by this exporter:
 * `otelcol_loadbalancer_num_backend_updates` records how many of the resolutions resulted in a new list of backends. Use this information to understand how frequent your backend updates are and how often the ring is rebalanced. If the DNS hostname is always returning the same list of IP addresses but this metric keeps increasing, it might indicate a bug in the load balancer.
 * `otelcol_loadbalancer_backend_latency` measures the latency for each backend.
 * `otelcol_loadbalancer_backend_outcome` counts what the outcomes were for each endpoint, `success=true|false`.
+* When `sending_queue` is enabled, standard exporterhelper queue age metrics are also available:
+  * `otelcol_exporter_queue_oldest_batch_age` reports the age of the oldest batch still waiting in the exporter queue.
+  * `otelcol_exporter_queue_batch_send_age` records how long a batch spent in the exporter queue before a consumer picked it up.
+* When the internal LB batchers are active, age metrics are also emitted for post-routing backlog:
+  * `otelcol_loadbalancer_log_batch_pending_oldest_record_age` reports the age of the oldest log record currently pending for each backend endpoint.
+  * `otelcol_loadbalancer_log_batch_pending_oldest_record_age_max` reports the maximum pending oldest-log age across all backend endpoints.
+  * `otelcol_loadbalancer_log_batch_flush_oldest_record_age` records the age of the oldest log record in each flushed batch.
+  * `otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age` reports the age of the oldest metric datapoint currently pending for each backend endpoint.
+  * `otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age_max` reports the maximum pending oldest-datapoint age across all backend endpoints.
+  * `otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age` records the age of the oldest metric datapoint in each flushed batch.

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -465,7 +465,7 @@ The following metrics are recorded by this exporter:
 * `otelcol_loadbalancer_num_backend_updates` records how many of the resolutions resulted in a new list of backends. Use this information to understand how frequent your backend updates are and how often the ring is rebalanced. If the DNS hostname is always returning the same list of IP addresses but this metric keeps increasing, it might indicate a bug in the load balancer.
 * `otelcol_loadbalancer_backend_latency` measures the latency for each backend.
 * `otelcol_loadbalancer_backend_outcome` counts what the outcomes were for each endpoint, `success=true|false`.
-* When `sending_queue` is enabled, standard exporterhelper queue age metrics are also available:
+* When `sending_queue` is enabled with an exporterhelper build that includes queue-age instrumentation, standard queue age metrics are also available:
   * `otelcol_exporter_queue_oldest_batch_age` reports the age of the oldest batch still waiting in the exporter queue.
   * `otelcol_exporter_queue_batch_send_age` records how long a batch spent in the exporter queue before a consumer picked it up.
 * When the internal LB batchers are active, age metrics are also emitted for post-routing backlog:

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -257,7 +257,7 @@ exporters:
       payload_compression: zstd
 ```
 
-`sending_queue.compress_in_memory` is retained for compatibility. It requires `sending_queue` to be configured and a non-`none` `sending_queue.payload_compression` value. When enabled, the exporter uses an internal in-memory storage backend so the queue payload codec still applies.
+`sending_queue.compress_in_memory` is retained for compatibility. It requires `sending_queue` to be configured and a non-`none` `sending_queue.payload_compression` value. `sending_queue.payload_compression` remains the active queue payload codec setting.
 
 Kubernetes resolver example (For a more specific example: [example/k8s-resolver](./example/k8s-resolver/README.md))
 > [!IMPORTANT]

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -108,9 +108,6 @@ func buildExporterResilienceOptions(
 			}
 		}
 		options = append(options, xexporterhelper.WithQueueBatch(queueCfg, qbs))
-		if cfg.QueueSettings.CompressInMemory {
-			options = append(options, exporterhelper.WithQueueBatchInMemoryEncoding(true))
-		}
 	}
 	if cfg.Enabled {
 		options = append(options, exporterhelper.WithRetry(cfg.BackOffConfig))

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -280,7 +280,7 @@ func TestBuildExporterResilienceOptions(t *testing.T) {
 
 		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression), newSettings()), 2)
 	})
-	t.Run("Should add in-memory encoding option when compression in memory is enabled", func(t *testing.T) {
+	t.Run("Should keep queue options count when compression in memory is enabled", func(t *testing.T) {
 		o := []exporterhelper.Option{}
 		cfg := createDefaultConfig().(*Config)
 		cfg.TimeoutSettings = exporterhelper.NewDefaultTimeoutConfig()
@@ -288,7 +288,7 @@ func TestBuildExporterResilienceOptions(t *testing.T) {
 		cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
 		cfg.QueueSettings.CompressInMemory = true
 
-		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression), newSettings()), 3)
+		assert.Len(t, buildExporterResilienceOptions(o, cfg, newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression), newSettings()), 2)
 	})
 	t.Run("Should have all resilience options if defined", func(t *testing.T) {
 		o := []exporterhelper.Option{}

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -216,6 +216,6 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => 
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics => ../../internal/exp/metrics
 
-replace go.opentelemetry.io/collector/exporter/exporterhelper v0.149.1-0.20260402195938-76ede073ee8e => github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.1
+replace go.opentelemetry.io/collector/exporter/exporterhelper v0.149.1-0.20260402195938-76ede073ee8e => github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.3
 
-replace go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.1-0.20260402195938-76ede073ee8e => github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.1
+replace go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.1-0.20260402195938-76ede073ee8e => github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.3

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -215,7 +215,3 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics => ../../internal/exp/metrics
-
-replace go.opentelemetry.io/collector/exporter/exporterhelper v0.149.1-0.20260402195938-76ede073ee8e => github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.3
-
-replace go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.1-0.20260402195938-76ede073ee8e => github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.3

--- a/exporter/loadbalancingexporter/go.sum
+++ b/exporter/loadbalancingexporter/go.sum
@@ -1,9 +1,9 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.1 h1:9SZhwUGER1B/naxD+gAxazKn2Sq/w/vxLe/jbrG8KWg=
-github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.1/go.mod h1:vrebAHP8yYENZwHrOhfYqXDOlkqzB3pIOydIlbH/zoc=
-github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.1 h1:qaa2zAfOIKMpV4Z4OGBlQ0jVLh7LWphKZKWwYg6gzrM=
-github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.1/go.mod h1:rgd0kMwhRYZlCmQTau1zO/OI3tMcQqiFTYGooQ3RV5U=
+github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.3 h1:iGUWw/TEMfOEgdbhYCtl+sjT52FvQSsRxDIgxcoKBxU=
+github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.3/go.mod h1:mkCJzZNAUyO0PPXtOWyxRXOEIrsstwBaj0FHanzwXNU=
+github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.3 h1:5HG+EtaSZQy2qYqLKQzbFDyTVIGcAsL9pbHabBEGCgg=
+github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.3/go.mod h1:rgd0kMwhRYZlCmQTau1zO/OI3tMcQqiFTYGooQ3RV5U=
 github.com/aws/aws-sdk-go-v2 v1.41.3 h1:4kQ/fa22KjDt13QCy1+bYADvdgcxpfH18f0zP542kZA=
 github.com/aws/aws-sdk-go-v2 v1.41.3/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/config v1.32.11 h1:ftxI5sgz8jZkckuUHXfC/wMUc8u3fG1vQS0plr2F2Zs=

--- a/exporter/loadbalancingexporter/go.sum
+++ b/exporter/loadbalancingexporter/go.sum
@@ -1,9 +1,5 @@
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.3 h1:iGUWw/TEMfOEgdbhYCtl+sjT52FvQSsRxDIgxcoKBxU=
-github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper v0.149.0-sawmills.3/go.mod h1:mkCJzZNAUyO0PPXtOWyxRXOEIrsstwBaj0FHanzwXNU=
-github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.3 h1:5HG+EtaSZQy2qYqLKQzbFDyTVIGcAsL9pbHabBEGCgg=
-github.com/Sawmills/opentelemetry-collector/exporter/exporterhelper/xexporterhelper v0.149.0-sawmills.3/go.mod h1:rgd0kMwhRYZlCmQTau1zO/OI3tMcQqiFTYGooQ3RV5U=
 github.com/aws/aws-sdk-go-v2 v1.41.3 h1:4kQ/fa22KjDt13QCy1+bYADvdgcxpfH18f0zP542kZA=
 github.com/aws/aws-sdk-go-v2 v1.41.3/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/config v1.32.11 h1:ftxI5sgz8jZkckuUHXfC/wMUc8u3fG1vQS0plr2F2Zs=
@@ -265,6 +261,10 @@ go.opentelemetry.io/collector/consumer/xconsumer v0.149.1-0.20260402195938-76ede
 go.opentelemetry.io/collector/consumer/xconsumer v0.149.1-0.20260402195938-76ede073ee8e/go.mod h1:/6GxiFXbETTbPmdyyCcLjzF6cJg2AQ+CLF3yrjecL20=
 go.opentelemetry.io/collector/exporter v1.55.1-0.20260402195938-76ede073ee8e h1:EAcrFOISLJd/mOOeHlYGET7hFsWq/Y9t9xoAXJBFJ4c=
 go.opentelemetry.io/collector/exporter v1.55.1-0.20260402195938-76ede073ee8e/go.mod h1:CT1a6LcOvSq1+e8JtB8TOeokO7NvbA3GPapyPYQg4/0=
+go.opentelemetry.io/collector/exporter/exporterhelper v0.149.1-0.20260402195938-76ede073ee8e h1:KWSyQGSZBldbG1C6ly+F50myVhIty34nLqqSFNGgbJI=
+go.opentelemetry.io/collector/exporter/exporterhelper v0.149.1-0.20260402195938-76ede073ee8e/go.mod h1:mkCJzZNAUyO0PPXtOWyxRXOEIrsstwBaj0FHanzwXNU=
+go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.1-0.20260402195938-76ede073ee8e h1:f2wMIWld0vfso0rE7ppW8fUSBTXfpoBB+Od6BiC+Gj0=
+go.opentelemetry.io/collector/exporter/exporterhelper/xexporterhelper v0.149.1-0.20260402195938-76ede073ee8e/go.mod h1:rgd0kMwhRYZlCmQTau1zO/OI3tMcQqiFTYGooQ3RV5U=
 go.opentelemetry.io/collector/exporter/exportertest v0.149.1-0.20260402195938-76ede073ee8e h1:VaoNlT5JOq2ypGlpKGR7gXtw5Bs/YNRsJGoGvhWRkyc=
 go.opentelemetry.io/collector/exporter/exportertest v0.149.1-0.20260402195938-76ede073ee8e/go.mod h1:WbCmeP0j2EfCiM8FkrNrebht1pzfz5tU76fV9t3tKTc=
 go.opentelemetry.io/collector/exporter/otlpexporter v0.149.1-0.20260402195938-76ede073ee8e h1:eb9rbBrIP6xvY1alOIDWInu+hzRoyqDOcSdqmMOM6Cc=

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -86,6 +86,7 @@ type backendLogBatcher struct {
 	pendingRecords atomic.Int64
 	pendingBytes   atomic.Int64
 	oldestEnqueue  atomic.Int64
+	queuedOldest   atomic.Int64
 }
 
 type logBatcherTelemetry struct {
@@ -141,6 +142,9 @@ func (b *logBatcher) Enqueue(ctx context.Context, endpoint string, exp *wrappedE
 	defer backend.inflight.Done()
 	select {
 	case backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: logs}:
+		if len(backend.requests) > 0 {
+			backend.noteQueuedOldest(time.Now().UnixNano())
+		}
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -397,9 +401,12 @@ func (b *backendLogBatcher) handleRequest(
 ) bool {
 	switch req.kind {
 	case logBatcherRequestEnqueue:
-		acceptedAt := time.Now()
+		queuedOldest := b.queuedOldest.Swap(0)
 		if *pendingRecords == 0 {
-			b.oldestEnqueue.Store(acceptedAt.UnixNano())
+			if queuedOldest == 0 {
+				queuedOldest = time.Now().UnixNano()
+			}
+			b.oldestEnqueue.Store(queuedOldest)
 		}
 		*pendingRecords += b.mergeQueuedRequests(pending, req, nextReq)
 		// Track max_bytes using the actual serialized merged OTLP payload.
@@ -423,6 +430,13 @@ func (b *backendLogBatcher) handleRequest(
 		return true
 	}
 	return false
+}
+
+func (b *backendLogBatcher) noteQueuedOldest(unixNano int64) {
+	if unixNano == 0 {
+		return
+	}
+	b.queuedOldest.CompareAndSwap(0, unixNano)
 }
 
 func (b *backendLogBatcher) mergeQueuedRequests(pending *plog.Logs, first logBatcherRequest, nextReq **logBatcherRequest) int {

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -141,7 +141,7 @@ func (b *logBatcher) Enqueue(ctx context.Context, endpoint string, exp *wrappedE
 	}
 	defer backend.inflight.Done()
 	select {
-	case backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: logs, enqueuedAt: time.Now()}:
+	case backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: logs}:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -398,8 +398,9 @@ func (b *backendLogBatcher) handleRequest(
 ) bool {
 	switch req.kind {
 	case logBatcherRequestEnqueue:
+		acceptedAt := time.Now()
 		if *pendingRecords == 0 {
-			b.oldestEnqueue.Store(req.enqueuedAt.UnixNano())
+			b.oldestEnqueue.Store(acceptedAt.UnixNano())
 		}
 		*pendingRecords += b.mergeQueuedRequests(pending, req, nextReq)
 		// Track max_bytes using the actual serialized merged OTLP payload.

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -59,7 +59,6 @@ type logBatcherRequest struct {
 	ctx        context.Context
 	reason     string
 	done       chan error
-	enqueuedAt time.Time
 }
 
 type logBatcherRequestKind int

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -54,11 +54,11 @@ type logBatcher struct {
 }
 
 type logBatcherRequest struct {
-	kind       logBatcherRequestKind
-	logs       plog.Logs
-	ctx        context.Context
-	reason     string
-	done       chan error
+	kind   logBatcherRequestKind
+	logs   plog.Logs
+	ctx    context.Context
+	reason string
+	done   chan error
 }
 
 type logBatcherRequestKind int

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -54,11 +54,12 @@ type logBatcher struct {
 }
 
 type logBatcherRequest struct {
-	kind   logBatcherRequestKind
-	logs   plog.Logs
-	ctx    context.Context
-	reason string
-	done   chan error
+	kind       logBatcherRequestKind
+	logs       plog.Logs
+	ctx        context.Context
+	reason     string
+	done       chan error
+	enqueuedAt time.Time
 }
 
 type logBatcherRequestKind int
@@ -85,19 +86,23 @@ type backendLogBatcher struct {
 
 	pendingRecords atomic.Int64
 	pendingBytes   atomic.Int64
+	oldestEnqueue  atomic.Int64
 }
 
 type logBatcherTelemetry struct {
-	logger         *zap.Logger
-	meter          metric.Meter
-	batchSize      metric.Int64Histogram
-	batchBytes     metric.Int64Histogram
-	flushTotal     metric.Int64Counter
-	flushErrors    metric.Int64Counter
-	droppedRecords metric.Int64Counter
-	overflowTotal  metric.Int64Counter
-	pendingRecords metric.Int64ObservableGauge
-	pendingBytes   metric.Int64ObservableGauge
+	logger               *zap.Logger
+	meter                metric.Meter
+	batchSize            metric.Int64Histogram
+	batchBytes           metric.Int64Histogram
+	flushTotal           metric.Int64Counter
+	flushErrors          metric.Int64Counter
+	flushOldestRecordAge metric.Int64Histogram
+	droppedRecords       metric.Int64Counter
+	overflowTotal        metric.Int64Counter
+	pendingRecords       metric.Int64ObservableGauge
+	pendingBytes         metric.Int64ObservableGauge
+	pendingOldestAge     metric.Int64ObservableGauge
+	pendingOldestAgeMax  metric.Int64ObservableGauge
 
 	mu            sync.Mutex
 	registrations []metric.Registration
@@ -136,7 +141,7 @@ func (b *logBatcher) Enqueue(ctx context.Context, endpoint string, exp *wrappedE
 	}
 	defer backend.inflight.Done()
 	select {
-	case backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: logs}:
+	case backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: logs, enqueuedAt: time.Now()}:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -201,19 +206,31 @@ func (b *logBatcher) scheduleBackendCleanup(backend *backendLogBatcher, reason s
 	}()
 }
 
-func (b *logBatcher) snapshotPending() []logBatcherPending {
+type logBatcherSnapshot struct {
+	pending            []logBatcherPending
+	maxOldestAgeMillis int64
+}
+
+func (b *logBatcher) snapshotPending() logBatcherSnapshot {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
+	now := time.Now()
 	pending := make([]logBatcherPending, 0, len(b.backends))
+	var maxOldestAgeMillis int64
 	for endpoint, backend := range b.backends {
+		oldestAgeMillis := ageMillisFromUnixNano(now, backend.oldestEnqueue.Load())
+		if oldestAgeMillis > maxOldestAgeMillis {
+			maxOldestAgeMillis = oldestAgeMillis
+		}
 		pending = append(pending, logBatcherPending{
-			endpoint: endpoint,
-			records:  backend.pendingRecords.Load(),
-			bytes:    backend.pendingBytes.Load(),
+			endpoint:        endpoint,
+			records:         backend.pendingRecords.Load(),
+			bytes:           backend.pendingBytes.Load(),
+			oldestAgeMillis: oldestAgeMillis,
 		})
 	}
-	return pending
+	return logBatcherSnapshot{pending: pending, maxOldestAgeMillis: maxOldestAgeMillis}
 }
 
 func (b *logBatcher) acquireBackend(endpoint string, exp *wrappedExporter) (*backendLogBatcher, error) {
@@ -381,6 +398,9 @@ func (b *backendLogBatcher) handleRequest(
 ) bool {
 	switch req.kind {
 	case logBatcherRequestEnqueue:
+		if *pendingRecords == 0 {
+			b.oldestEnqueue.Store(req.enqueuedAt.UnixNano())
+		}
 		*pendingRecords += b.mergeQueuedRequests(pending, req, nextReq)
 		// Track max_bytes using the actual serialized merged OTLP payload.
 		// Resource/scope dedup during merge means chunk sizes are not additive.
@@ -450,14 +470,17 @@ func (b *backendLogBatcher) flush(
 	drained := *pending
 	records := *pendingRecords
 	bytes := *pendingBytes
+	oldestAgeMillis := ageMillisFromUnixNano(time.Now(), b.oldestEnqueue.Load())
 	*pending = plog.NewLogs()
 	*pendingRecords = 0
 	*pendingBytes = 0
 	b.pendingRecords.Store(0)
 	b.pendingBytes.Store(0)
+	b.oldestEnqueue.Store(0)
 
 	b.telemetry.batchSize.Record(ctx, int64(records), metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint))))
 	b.telemetry.batchBytes.Record(ctx, int64(bytes), metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint))))
+	b.telemetry.flushOldestRecordAge.Record(ctx, oldestAgeMillis, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason))))
 	b.telemetry.flushTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason))))
 
 	err := b.send(ctx, b.exporter(), drained, reason)
@@ -469,9 +492,10 @@ func (b *backendLogBatcher) flush(
 }
 
 type logBatcherPending struct {
-	endpoint string
-	records  int64
-	bytes    int64
+	endpoint        string
+	records         int64
+	bytes           int64
+	oldestAgeMillis int64
 }
 
 func newLogBatcherTelemetry(settings component.TelemetrySettings) (*logBatcherTelemetry, error) {
@@ -503,6 +527,12 @@ func newLogBatcherTelemetry(settings component.TelemetrySettings) (*logBatcherTe
 		metric.WithUnit("{errors}"),
 	)
 	errs = errors.Join(errs, err)
+	t.flushOldestRecordAge, err = meter.Int64Histogram(
+		"otelcol_loadbalancer_log_batch_flush_oldest_record_age",
+		metric.WithDescription("Age in ms of the oldest log record in a flushed backend batch."),
+		metric.WithUnit("ms"),
+	)
+	errs = errors.Join(errs, err)
 	t.droppedRecords, err = meter.Int64Counter(
 		"otelcol_loadbalancer_log_batch_dropped_records",
 		metric.WithDescription("Number of dropped log records in the internal log batcher."),
@@ -527,19 +557,34 @@ func newLogBatcherTelemetry(settings component.TelemetrySettings) (*logBatcherTe
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
+	t.pendingOldestAge, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_log_batch_pending_oldest_record_age",
+		metric.WithDescription("Age in ms of the oldest pending log record per backend batch."),
+		metric.WithUnit("ms"),
+	)
+	errs = errors.Join(errs, err)
+	t.pendingOldestAgeMax, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_log_batch_pending_oldest_record_age_max",
+		metric.WithDescription("Maximum age in ms of the oldest pending log record across backend batches."),
+		metric.WithUnit("ms"),
+	)
+	errs = errors.Join(errs, err)
 
 	return t, errs
 }
 
-func (t *logBatcherTelemetry) start(snapshot func() []logBatcherPending) error {
+func (t *logBatcherTelemetry) start(snapshot func() logBatcherSnapshot) error {
 	reg, err := t.meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
-		for _, pending := range snapshot() {
+		state := snapshot()
+		for _, pending := range state.pending {
 			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", pending.endpoint)))
 			observer.ObserveInt64(t.pendingRecords, pending.records, attrs)
 			observer.ObserveInt64(t.pendingBytes, pending.bytes, attrs)
+			observer.ObserveInt64(t.pendingOldestAge, pending.oldestAgeMillis, attrs)
 		}
+		observer.ObserveInt64(t.pendingOldestAgeMax, state.maxOldestAgeMillis)
 		return nil
-	}, t.pendingRecords, t.pendingBytes)
+	}, t.pendingRecords, t.pendingBytes, t.pendingOldestAge, t.pendingOldestAgeMax)
 	if err != nil {
 		return err
 	}
@@ -558,4 +603,16 @@ func (t *logBatcherTelemetry) shutdown() {
 		}
 	}
 	t.registrations = nil
+}
+
+func ageMillisFromUnixNano(now time.Time, unixNano int64) int64 {
+	if unixNano <= 0 {
+		return 0
+	}
+
+	age := now.Sub(time.Unix(0, unixNano)).Milliseconds()
+	if age < 0 {
+		return 0
+	}
+	return age
 }

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -54,11 +54,12 @@ type logBatcher struct {
 }
 
 type logBatcherRequest struct {
-	kind   logBatcherRequestKind
-	logs   plog.Logs
-	ctx    context.Context
-	reason string
-	done   chan error
+	kind               logBatcherRequestKind
+	logs               plog.Logs
+	ctx                context.Context
+	reason             string
+	done               chan error
+	enqueuedAtUnixNano int64
 }
 
 type logBatcherRequestKind int
@@ -86,7 +87,6 @@ type backendLogBatcher struct {
 	pendingRecords atomic.Int64
 	pendingBytes   atomic.Int64
 	oldestEnqueue  atomic.Int64
-	queuedOldest   atomic.Int64
 }
 
 type logBatcherTelemetry struct {
@@ -140,11 +140,9 @@ func (b *logBatcher) Enqueue(ctx context.Context, endpoint string, exp *wrappedE
 		return err
 	}
 	defer backend.inflight.Done()
+	enqueuedAtUnixNano := time.Now().UnixNano()
 	select {
-	case backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: logs}:
-		if len(backend.requests) > 0 {
-			backend.noteQueuedOldest(time.Now().UnixNano())
-		}
+	case backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: logs, enqueuedAtUnixNano: enqueuedAtUnixNano}:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -222,14 +220,19 @@ func (b *logBatcher) snapshotPending() logBatcherSnapshot {
 	pending := make([]logBatcherPending, 0, len(b.backends))
 	var maxOldestAgeMillis int64
 	for endpoint, backend := range b.backends {
-		oldestAgeMillis := ageMillisFromUnixNano(now, backend.oldestEnqueue.Load())
+		records := backend.pendingRecords.Load()
+		bytes := backend.pendingBytes.Load()
+		var oldestAgeMillis int64
+		if records > 0 {
+			oldestAgeMillis = ageMillisFromUnixNano(now, backend.oldestEnqueue.Load())
+		}
 		if oldestAgeMillis > maxOldestAgeMillis {
 			maxOldestAgeMillis = oldestAgeMillis
 		}
 		pending = append(pending, logBatcherPending{
 			endpoint:        endpoint,
-			records:         backend.pendingRecords.Load(),
-			bytes:           backend.pendingBytes.Load(),
+			records:         records,
+			bytes:           bytes,
 			oldestAgeMillis: oldestAgeMillis,
 		})
 	}
@@ -401,14 +404,11 @@ func (b *backendLogBatcher) handleRequest(
 ) bool {
 	switch req.kind {
 	case logBatcherRequestEnqueue:
-		queuedOldest := b.queuedOldest.Swap(0)
-		if *pendingRecords == 0 {
-			if queuedOldest == 0 {
-				queuedOldest = time.Now().UnixNano()
-			}
-			b.oldestEnqueue.Store(queuedOldest)
+		recordsAdded, oldestEnqueue := b.mergeQueuedRequests(pending, req, nextReq)
+		*pendingRecords += recordsAdded
+		if *pendingRecords > 0 && b.oldestEnqueue.Load() == 0 {
+			b.oldestEnqueue.Store(oldestEnqueue)
 		}
-		*pendingRecords += b.mergeQueuedRequests(pending, req, nextReq)
 		// Track max_bytes using the actual serialized merged OTLP payload.
 		// Resource/scope dedup during merge means chunk sizes are not additive.
 		*pendingBytes = sizer.LogsSize(*pending)
@@ -432,32 +432,38 @@ func (b *backendLogBatcher) handleRequest(
 	return false
 }
 
-func (b *backendLogBatcher) noteQueuedOldest(unixNano int64) {
-	if unixNano == 0 {
-		return
-	}
-	b.queuedOldest.CompareAndSwap(0, unixNano)
-}
+func (b *backendLogBatcher) mergeQueuedRequests(pending *plog.Logs, first logBatcherRequest, nextReq **logBatcherRequest) (int, int64) {
+	recordCount := 0
+	var oldestEnqueue int64
 
-func (b *backendLogBatcher) mergeQueuedRequests(pending *plog.Logs, first logBatcherRequest, nextReq **logBatcherRequest) int {
-	recordCount := first.logs.LogRecordCount()
-	*pending = mergeLogs(*pending, first.logs)
+	mergeRequest := func(req logBatcherRequest) {
+		count := req.logs.LogRecordCount()
+		if count == 0 {
+			return
+		}
+		recordCount += count
+		if oldestEnqueue == 0 || req.enqueuedAtUnixNano < oldestEnqueue {
+			oldestEnqueue = req.enqueuedAtUnixNano
+		}
+		*pending = mergeLogs(*pending, req.logs)
+	}
+
+	mergeRequest(first)
 
 	for i := 0; i < cap(b.requests); i++ {
 		select {
 		case req := <-b.requests:
 			if req.kind != logBatcherRequestEnqueue {
 				*nextReq = &req
-				return recordCount
+				return recordCount, oldestEnqueue
 			}
-			recordCount += req.logs.LogRecordCount()
-			*pending = mergeLogs(*pending, req.logs)
+			mergeRequest(req)
 		default:
-			return recordCount
+			return recordCount, oldestEnqueue
 		}
 	}
 
-	return recordCount
+	return recordCount, oldestEnqueue
 }
 
 func (b *backendLogBatcher) flush(

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -346,6 +346,67 @@ func TestLogBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) {
 	require.False(t, stored.Before(start), "oldest timestamp should reflect backend acceptance time, not sender-side time")
 }
 
+func TestLogBatcherPendingAgeIncludesTimeBufferedBeforeWorkerDequeues(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	sendStarted := make(chan struct{}, 1)
+	unblockSend := make(chan struct{})
+	sendReleased := false
+
+	batcher, err := newLogBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		logBatcherSettings{maxRecords: 1000, maxBytes: 1 << 20, flushInterval: 10 * time.Millisecond},
+		func(_ context.Context, _ *wrappedExporter, _ plog.Logs, _ string) error {
+			select {
+			case sendStarted <- struct{}{}:
+			default:
+			}
+			<-unblockSend
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if !sendReleased {
+			close(unblockSend)
+		}
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	exp := newWrappedExporter(newNopMockLogsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, simpleLogs()))
+
+	select {
+	case <-sendStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected backend send to start")
+	}
+
+	batcher.mu.RLock()
+	backend := batcher.backends["endpoint-1:4317"]
+	batcher.mu.RUnlock()
+	require.NotNil(t, backend)
+	backend.settings.flushInterval = time.Hour
+
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, simpleLogs()))
+	time.Sleep(60 * time.Millisecond)
+	close(unblockSend)
+	sendReleased = true
+
+	var oldestAgeMillis int64
+	require.Eventually(t, func() bool {
+		for _, pending := range batcher.snapshotPending().pending {
+			if pending.endpoint == "endpoint-1:4317" && pending.records == 1 {
+				oldestAgeMillis = pending.oldestAgeMillis
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 20*time.Millisecond)
+
+	require.GreaterOrEqual(t, oldestAgeMillis, int64(40), "oldest age should include time spent buffered in backend.requests")
+}
+
 func findGaugePointValue(t *testing.T, dps []metricdata.DataPoint[int64], attrs attribute.Set) int64 {
 	t.Helper()
 

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -18,6 +18,8 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 )
@@ -257,7 +259,64 @@ func TestLogBatcherEnqueueAfterShutdownReturnsStoppingError(t *testing.T) {
 		simpleLogs(),
 	)
 	require.ErrorIs(t, err, errLogBatcherExporterStopping)
-	assert.Empty(t, batcher.snapshotPending())
+	snapshot := batcher.snapshotPending()
+	assert.Empty(t, snapshot.pending)
+	assert.Zero(t, snapshot.maxOldestAgeMillis)
+}
+
+func TestLogBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
+	telemetry := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetry.Shutdown(context.Background()))
+	})
+
+	batcher, err := newLogBatcher(componenttest.NewNopTelemetrySettings().Logger, telemetry.NewTelemetrySettings(), logBatcherSettings{
+		maxRecords:    100,
+		maxBytes:      1 << 20,
+		flushInterval: time.Hour,
+	}, func(context.Context, *wrappedExporter, plog.Logs, string) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	exp := newWrappedExporter(newNopMockLogsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, simpleLogs()))
+	time.Sleep(25 * time.Millisecond)
+
+	pendingMetric, err := telemetry.GetMetric("otelcol_loadbalancer_log_batch_pending_oldest_record_age")
+	require.NoError(t, err)
+	pendingGauge, ok := pendingMetric.Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	require.Greater(t, findGaugePointValue(t, pendingGauge.DataPoints, attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"))), int64(0))
+
+	maxMetric, err := telemetry.GetMetric("otelcol_loadbalancer_log_batch_pending_oldest_record_age_max")
+	require.NoError(t, err)
+	maxGauge, ok := maxMetric.Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	require.Greater(t, maxGauge.DataPoints[0].Value, int64(0))
+
+	require.NoError(t, batcher.Shutdown(t.Context()))
+
+	flushMetric, err := telemetry.GetMetric("otelcol_loadbalancer_log_batch_flush_oldest_record_age")
+	require.NoError(t, err)
+	flushHistogram, ok := flushMetric.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, flushHistogram.DataPoints, 1)
+	require.Equal(t, uint64(1), flushHistogram.DataPoints[0].Count)
+	require.Greater(t, flushHistogram.DataPoints[0].Sum, int64(0))
+}
+
+func findGaugePointValue(t *testing.T, dps []metricdata.DataPoint[int64], attrs attribute.Set) int64 {
+	t.Helper()
+
+	for _, dp := range dps {
+		if dp.Attributes.Equals(&attrs) {
+			return dp.Value
+		}
+	}
+
+	t.Fatalf("gauge datapoint with attrs %v not found", attrs)
+	return 0
 }
 
 func TestLogBatcherRemoveRespectsContextWhileWaitingForInflight(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -458,20 +458,11 @@ func TestLogBatcherPendingAgeIncludesTimeBufferedBeforeWorkerDequeues(t *testing
 func TestLogBatcherSnapshotPendingIgnoresOldestAgeWhenNoRecordsPending(t *testing.T) {
 	batcher := &logBatcher{
 		backends: map[string]*backendLogBatcher{
-			"endpoint-1:4317": {
-				oldestEnqueue: func() atomic.Int64 {
-					var v atomic.Int64
-					v.Store(time.Now().Add(-time.Second).UnixNano())
-					return v
-				}(),
-				pendingBytes: func() atomic.Int64 {
-					var v atomic.Int64
-					v.Store(123)
-					return v
-				}(),
-			},
+			"endpoint-1:4317": {},
 		},
 	}
+	batcher.backends["endpoint-1:4317"].oldestEnqueue.Store(time.Now().Add(-time.Second).UnixNano())
+	batcher.backends["endpoint-1:4317"].pendingBytes.Store(123)
 
 	snapshot := batcher.snapshotPending()
 	require.Len(t, snapshot.pending, 1)

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -267,7 +267,7 @@ func TestLogBatcherEnqueueAfterShutdownReturnsStoppingError(t *testing.T) {
 func TestLogBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
 	telemetry := componenttest.NewTelemetry()
 	t.Cleanup(func() {
-		require.NoError(t, telemetry.Shutdown(context.Background()))
+		require.NoError(t, telemetry.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	batcher, err := newLogBatcher(componenttest.NewNopTelemetrySettings().Logger, telemetry.NewTelemetrySettings(), logBatcherSettings{
@@ -287,13 +287,13 @@ func TestLogBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
 	require.NoError(t, err)
 	pendingGauge, ok := pendingMetric.Data.(metricdata.Gauge[int64])
 	require.True(t, ok)
-	require.Greater(t, findGaugePointValue(t, pendingGauge.DataPoints, attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"))), int64(0))
+	require.Positive(t, findGaugePointValue(t, pendingGauge.DataPoints, attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"))))
 
 	maxMetric, err := telemetry.GetMetric("otelcol_loadbalancer_log_batch_pending_oldest_record_age_max")
 	require.NoError(t, err)
 	maxGauge, ok := maxMetric.Data.(metricdata.Gauge[int64])
 	require.True(t, ok)
-	require.Greater(t, maxGauge.DataPoints[0].Value, int64(0))
+	require.Positive(t, maxGauge.DataPoints[0].Value)
 
 	require.NoError(t, batcher.Shutdown(t.Context()))
 
@@ -303,7 +303,7 @@ func TestLogBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, flushHistogram.DataPoints, 1)
 	require.Equal(t, uint64(1), flushHistogram.DataPoints[0].Count)
-	require.Greater(t, flushHistogram.DataPoints[0].Sum, int64(0))
+	require.Positive(t, flushHistogram.DataPoints[0].Sum)
 }
 
 func TestLogBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -306,6 +306,48 @@ func TestLogBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
 	require.Greater(t, flushHistogram.DataPoints[0].Sum, int64(0))
 }
 
+func TestLogBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) {
+	backend := &backendLogBatcher{
+		endpoint:  "endpoint-1:4317",
+		settings:  logBatcherSettings{maxRecords: 100, maxBytes: 1 << 20, flushInterval: time.Hour},
+		requests:  make(chan logBatcherRequest, 1),
+		done:      make(chan struct{}),
+		telemetry: &logBatcherTelemetry{},
+	}
+
+	pending := plog.NewLogs()
+	pendingRecords := 0
+	pendingBytes := 0
+	sizer := &plog.ProtoMarshaler{}
+	var nextReq *logBatcherRequest
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+
+	start := time.Now()
+	stale := start.Add(-time.Hour)
+	stopped := backend.handleRequest(
+		logBatcherRequest{
+			kind:       logBatcherRequestEnqueue,
+			logs:       simpleLogs(),
+			enqueuedAt: stale,
+		},
+		sizer,
+		&pending,
+		&pendingRecords,
+		&pendingBytes,
+		&nextReq,
+		timer,
+		&timerC,
+	)
+	require.False(t, stopped)
+
+	stored := time.Unix(0, backend.oldestEnqueue.Load())
+	require.False(t, stored.Before(start), "oldest timestamp should reflect backend acceptance time, not sender-side time")
+}
+
 func findGaugePointValue(t *testing.T, dps []metricdata.DataPoint[int64], attrs attribute.Set) int64 {
 	t.Helper()
 

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -327,12 +327,10 @@ func TestLogBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) {
 	var timerC <-chan time.Time
 
 	start := time.Now()
-	stale := start.Add(-time.Hour)
 	stopped := backend.handleRequest(
 		logBatcherRequest{
-			kind:       logBatcherRequestEnqueue,
-			logs:       simpleLogs(),
-			enqueuedAt: stale,
+			kind: logBatcherRequestEnqueue,
+			logs: simpleLogs(),
 		},
 		sizer,
 		&pending,

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -329,8 +329,9 @@ func TestLogBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) {
 	start := time.Now()
 	stopped := backend.handleRequest(
 		logBatcherRequest{
-			kind: logBatcherRequestEnqueue,
-			logs: simpleLogs(),
+			kind:               logBatcherRequestEnqueue,
+			logs:               simpleLogs(),
+			enqueuedAtUnixNano: start.UnixNano(),
 		},
 		sizer,
 		&pending,
@@ -343,7 +344,54 @@ func TestLogBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) {
 	require.False(t, stopped)
 
 	stored := time.Unix(0, backend.oldestEnqueue.Load())
-	require.False(t, stored.Before(start), "oldest timestamp should reflect backend acceptance time, not sender-side time")
+	require.False(t, stored.Before(start), "oldest timestamp should reflect request enqueue time")
+}
+
+func TestLogBatcherHandleRequestUsesOldestDrainedEnqueueTime(t *testing.T) {
+	backend := &backendLogBatcher{
+		endpoint:  "endpoint-1:4317",
+		settings:  logBatcherSettings{maxRecords: 100, maxBytes: 1 << 20, flushInterval: time.Hour},
+		requests:  make(chan logBatcherRequest, 1),
+		done:      make(chan struct{}),
+		telemetry: &logBatcherTelemetry{},
+	}
+
+	older := time.Now().Add(-80 * time.Millisecond).UnixNano()
+	newer := time.Now().Add(-20 * time.Millisecond).UnixNano()
+	backend.requests <- logBatcherRequest{
+		kind:               logBatcherRequestEnqueue,
+		logs:               simpleLogs(),
+		enqueuedAtUnixNano: older,
+	}
+
+	pending := plog.NewLogs()
+	pendingRecords := 0
+	pendingBytes := 0
+	sizer := &plog.ProtoMarshaler{}
+	var nextReq *logBatcherRequest
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+
+	stopped := backend.handleRequest(
+		logBatcherRequest{
+			kind:               logBatcherRequestEnqueue,
+			logs:               simpleLogs(),
+			enqueuedAtUnixNano: newer,
+		},
+		sizer,
+		&pending,
+		&pendingRecords,
+		&pendingBytes,
+		&nextReq,
+		timer,
+		&timerC,
+	)
+	require.False(t, stopped)
+	require.Equal(t, 2, pendingRecords)
+	require.Equal(t, older, backend.oldestEnqueue.Load())
 }
 
 func TestLogBatcherPendingAgeIncludesTimeBufferedBeforeWorkerDequeues(t *testing.T) {
@@ -405,6 +453,31 @@ func TestLogBatcherPendingAgeIncludesTimeBufferedBeforeWorkerDequeues(t *testing
 	}, 2*time.Second, 20*time.Millisecond)
 
 	require.GreaterOrEqual(t, oldestAgeMillis, int64(40), "oldest age should include time spent buffered in backend.requests")
+}
+
+func TestLogBatcherSnapshotPendingIgnoresOldestAgeWhenNoRecordsPending(t *testing.T) {
+	batcher := &logBatcher{
+		backends: map[string]*backendLogBatcher{
+			"endpoint-1:4317": {
+				oldestEnqueue: func() atomic.Int64 {
+					var v atomic.Int64
+					v.Store(time.Now().Add(-time.Second).UnixNano())
+					return v
+				}(),
+				pendingBytes: func() atomic.Int64 {
+					var v atomic.Int64
+					v.Store(123)
+					return v
+				}(),
+			},
+		},
+	}
+
+	snapshot := batcher.snapshotPending()
+	require.Len(t, snapshot.pending, 1)
+	require.Zero(t, snapshot.pending[0].records)
+	require.Zero(t, snapshot.pending[0].oldestAgeMillis)
+	require.Zero(t, snapshot.maxOldestAgeMillis)
 }
 
 func findGaugePointValue(t *testing.T, dps []metricdata.DataPoint[int64], attrs attribute.Set) int64 {

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -65,11 +65,12 @@ type metricBatcher struct {
 }
 
 type metricBatcherRequest struct {
-	kind   metricBatcherRequestKind
-	md     pmetric.Metrics
-	ctx    context.Context
-	reason string
-	done   chan error
+	kind               metricBatcherRequestKind
+	md                 pmetric.Metrics
+	ctx                context.Context
+	reason             string
+	done               chan error
+	enqueuedAtUnixNano int64
 }
 
 type metricBatcherRequestKind int
@@ -98,7 +99,6 @@ type backendMetricBatcher struct {
 	pendingDataPoints atomic.Int64
 	pendingBytes      atomic.Int64
 	oldestEnqueue     atomic.Int64
-	queuedOldest      atomic.Int64
 
 	flushFailures int
 }
@@ -169,11 +169,9 @@ func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pme
 	default:
 	}
 
+	enqueuedAtUnixNano := time.Now().UnixNano()
 	select {
-	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md}:
-		if len(backend.requests) > 0 {
-			backend.noteQueuedOldest(time.Now().UnixNano())
-		}
+	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md, enqueuedAtUnixNano: enqueuedAtUnixNano}:
 		return true, nil
 	case <-backend.done:
 		return false, errMetricBatcherExporterStopping
@@ -258,14 +256,19 @@ func (b *metricBatcher) snapshotPending() metricBatcherSnapshot {
 	pending := make([]metricBatcherPending, 0, len(b.backends))
 	var maxOldestAgeMillis int64
 	for endpoint, backend := range b.backends {
-		oldestAgeMillis := ageMillisFromUnixNano(now, backend.oldestEnqueue.Load())
+		datapoints := backend.pendingDataPoints.Load()
+		bytes := backend.pendingBytes.Load()
+		var oldestAgeMillis int64
+		if datapoints > 0 {
+			oldestAgeMillis = ageMillisFromUnixNano(now, backend.oldestEnqueue.Load())
+		}
 		if oldestAgeMillis > maxOldestAgeMillis {
 			maxOldestAgeMillis = oldestAgeMillis
 		}
 		pending = append(pending, metricBatcherPending{
 			endpoint:        endpoint,
-			datapoints:      backend.pendingDataPoints.Load(),
-			bytes:           backend.pendingBytes.Load(),
+			datapoints:      datapoints,
+			bytes:           bytes,
 			oldestAgeMillis: oldestAgeMillis,
 		})
 	}
@@ -421,16 +424,12 @@ func (b *backendMetricBatcher) handleRequest(
 ) bool {
 	switch req.kind {
 	case metricBatcherRequestEnqueue:
-		queuedOldest := b.queuedOldest.Swap(0)
-		if *pendingDataPoints == 0 {
-			if queuedOldest == 0 {
-				queuedOldest = time.Now().UnixNano()
-			}
-			b.oldestEnqueue.Store(queuedOldest)
-		}
-		dps, bytes := b.drainEnqueueRequestsIntoPending(sizer, pending, req, nextReq)
+		dps, bytes, oldestEnqueue := b.drainEnqueueRequestsIntoPending(sizer, pending, req, nextReq)
 		*pendingDataPoints += dps
 		*pendingBytes += bytes
+		if *pendingDataPoints > 0 && b.oldestEnqueue.Load() == 0 {
+			b.oldestEnqueue.Store(oldestEnqueue)
+		}
 		b.pendingDataPoints.Store(int64(*pendingDataPoints))
 		b.pendingBytes.Store(int64(*pendingBytes))
 		if *pendingDataPoints > 0 && *timerC == nil {
@@ -452,25 +451,33 @@ func (b *backendMetricBatcher) handleRequest(
 	return false
 }
 
-func (b *backendMetricBatcher) noteQueuedOldest(unixNano int64) {
-	if unixNano == 0 {
-		return
-	}
-	b.queuedOldest.CompareAndSwap(0, unixNano)
-}
-
 // drainEnqueueRequestsIntoPending drains immediately available enqueue requests
 // into pending without merging payload trees.
-// Returns (dataPointsAdded, bytesAdded).
+// Returns (dataPointsAdded, bytesAdded, oldestEnqueueUnixNano).
 func (b *backendMetricBatcher) drainEnqueueRequestsIntoPending(
 	sizer *pmetric.ProtoMarshaler,
 	pending *[]pmetric.Metrics,
 	first metricBatcherRequest,
 	nextReq **metricBatcherRequest,
-) (int, int) {
-	dataPointCount := first.md.DataPointCount()
-	bytes := sizer.MetricsSize(first.md)
-	*pending = append(*pending, first.md)
+) (int, int, int64) {
+	dataPointCount := 0
+	bytes := 0
+	var oldestEnqueue int64
+
+	appendRequest := func(req metricBatcherRequest) {
+		count := req.md.DataPointCount()
+		if count == 0 {
+			return
+		}
+		dataPointCount += count
+		bytes += sizer.MetricsSize(req.md)
+		if oldestEnqueue == 0 || req.enqueuedAtUnixNano < oldestEnqueue {
+			oldestEnqueue = req.enqueuedAtUnixNano
+		}
+		*pending = append(*pending, req.md)
+	}
+
+	appendRequest(first)
 
 	for i := 0; i < cap(b.requests); i++ {
 		select {
@@ -479,17 +486,15 @@ func (b *backendMetricBatcher) drainEnqueueRequestsIntoPending(
 				// Channels don't support unread/put-back. Stash this control request
 				// so the run loop processes it next, in-order.
 				*nextReq = &req
-				return dataPointCount, bytes
+				return dataPointCount, bytes, oldestEnqueue
 			}
-			dataPointCount += req.md.DataPointCount()
-			bytes += sizer.MetricsSize(req.md)
-			*pending = append(*pending, req.md)
+			appendRequest(req)
 		default:
-			return dataPointCount, bytes
+			return dataPointCount, bytes, oldestEnqueue
 		}
 	}
 
-	return dataPointCount, bytes
+	return dataPointCount, bytes, oldestEnqueue
 }
 
 func (b *backendMetricBatcher) flush(

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -65,11 +65,11 @@ type metricBatcher struct {
 }
 
 type metricBatcherRequest struct {
-	kind       metricBatcherRequestKind
-	md         pmetric.Metrics
-	ctx        context.Context
-	reason     string
-	done       chan error
+	kind   metricBatcherRequestKind
+	md     pmetric.Metrics
+	ctx    context.Context
+	reason string
+	done   chan error
 }
 
 type metricBatcherRequestKind int

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -70,7 +70,6 @@ type metricBatcherRequest struct {
 	ctx        context.Context
 	reason     string
 	done       chan error
-	enqueuedAt time.Time
 }
 
 type metricBatcherRequestKind int

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -170,7 +170,7 @@ func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pme
 	}
 
 	select {
-	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md, enqueuedAt: time.Now()}:
+	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md}:
 		return true, nil
 	case <-backend.done:
 		return false, errMetricBatcherExporterStopping
@@ -418,8 +418,9 @@ func (b *backendMetricBatcher) handleRequest(
 ) bool {
 	switch req.kind {
 	case metricBatcherRequestEnqueue:
+		acceptedAt := time.Now()
 		if *pendingDataPoints == 0 {
-			b.oldestEnqueue.Store(req.enqueuedAt.UnixNano())
+			b.oldestEnqueue.Store(acceptedAt.UnixNano())
 		}
 		dps, bytes := b.drainEnqueueRequestsIntoPending(sizer, pending, req, nextReq)
 		*pendingDataPoints += dps
@@ -515,10 +516,10 @@ func (b *backendMetricBatcher) flush(
 	b.oldestEnqueue.Store(0)
 
 	attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
+	flushAttrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason)))
 	b.telemetry.batchDataPoints.Record(ctx, int64(datapoints), attrs)
 	b.telemetry.batchBytes.Record(ctx, int64(bytes), attrs)
-	b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason))))
-	b.telemetry.flushTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason))))
+	b.telemetry.flushTotal.Add(ctx, 1, flushAttrs)
 
 	err := b.send(ctx, b.exporter(), drained, reason)
 	if err != nil {
@@ -534,6 +535,7 @@ func (b *backendMetricBatcher) flush(
 			overAge := now.Sub(*retryingSince) >= metricBatcherMaxRetryAge
 			if overCap || overAge {
 				b.logger.Error("dropping metric batch after retry limits exceeded", zap.String("endpoint", b.endpoint), zap.String("reason", reason), zap.Int("failures", b.flushFailures), zap.Int("datapoints", datapoints), zap.Int("bytes", bytes), zap.Bool("over_cap", overCap), zap.Bool("over_age", overAge), zap.Duration("retry_age", now.Sub(*retryingSince)), zap.Error(err))
+				b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
 				b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
 				*retryingSince = time.Time{}
 				b.flushFailures = 0
@@ -555,6 +557,7 @@ func (b *backendMetricBatcher) flush(
 			if b.drainErr != nil && (reason == metricFlushReasonResolverChange || reason == metricFlushReasonShutdown) {
 				rerouteErr := b.drainErr(ctx, drained, reason)
 				if rerouteErr == nil {
+					b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
 					return nil
 				}
 				var mErr consumererror.Metrics
@@ -564,11 +567,13 @@ func (b *backendMetricBatcher) flush(
 				}
 				err = errors.Join(err, rerouteErr)
 			}
+			b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
 			b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
 		}
 	}
 
 	if err == nil {
+		b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
 		*retryingSince = time.Time{}
 		b.flushFailures = 0
 	}

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -98,6 +98,7 @@ type backendMetricBatcher struct {
 	pendingDataPoints atomic.Int64
 	pendingBytes      atomic.Int64
 	oldestEnqueue     atomic.Int64
+	queuedOldest      atomic.Int64
 
 	flushFailures int
 }
@@ -170,6 +171,9 @@ func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pme
 
 	select {
 	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md}:
+		if len(backend.requests) > 0 {
+			backend.noteQueuedOldest(time.Now().UnixNano())
+		}
 		return true, nil
 	case <-backend.done:
 		return false, errMetricBatcherExporterStopping
@@ -417,9 +421,12 @@ func (b *backendMetricBatcher) handleRequest(
 ) bool {
 	switch req.kind {
 	case metricBatcherRequestEnqueue:
-		acceptedAt := time.Now()
+		queuedOldest := b.queuedOldest.Swap(0)
 		if *pendingDataPoints == 0 {
-			b.oldestEnqueue.Store(acceptedAt.UnixNano())
+			if queuedOldest == 0 {
+				queuedOldest = time.Now().UnixNano()
+			}
+			b.oldestEnqueue.Store(queuedOldest)
 		}
 		dps, bytes := b.drainEnqueueRequestsIntoPending(sizer, pending, req, nextReq)
 		*pendingDataPoints += dps
@@ -443,6 +450,13 @@ func (b *backendMetricBatcher) handleRequest(
 		return true
 	}
 	return false
+}
+
+func (b *backendMetricBatcher) noteQueuedOldest(unixNano int64) {
+	if unixNano == 0 {
+		return
+	}
+	b.queuedOldest.CompareAndSwap(0, unixNano)
 }
 
 // drainEnqueueRequestsIntoPending drains immediately available enqueue requests

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -65,11 +65,12 @@ type metricBatcher struct {
 }
 
 type metricBatcherRequest struct {
-	kind   metricBatcherRequestKind
-	md     pmetric.Metrics
-	ctx    context.Context
-	reason string
-	done   chan error
+	kind       metricBatcherRequestKind
+	md         pmetric.Metrics
+	ctx        context.Context
+	reason     string
+	done       chan error
+	enqueuedAt time.Time
 }
 
 type metricBatcherRequestKind int
@@ -97,21 +98,25 @@ type backendMetricBatcher struct {
 
 	pendingDataPoints atomic.Int64
 	pendingBytes      atomic.Int64
+	oldestEnqueue     atomic.Int64
 
 	flushFailures int
 }
 
 type metricBatcherTelemetry struct {
-	logger            *zap.Logger
-	meter             metric.Meter
-	batchDataPoints   metric.Int64Histogram
-	batchBytes        metric.Int64Histogram
-	flushTotal        metric.Int64Counter
-	flushErrors       metric.Int64Counter
-	droppedDataPoints metric.Int64Counter
-	overflowTotal     metric.Int64Counter
-	pendingDataPoints metric.Int64ObservableGauge
-	pendingBytes      metric.Int64ObservableGauge
+	logger                *zap.Logger
+	meter                 metric.Meter
+	batchDataPoints       metric.Int64Histogram
+	batchBytes            metric.Int64Histogram
+	flushTotal            metric.Int64Counter
+	flushErrors           metric.Int64Counter
+	flushOldestPointAge   metric.Int64Histogram
+	droppedDataPoints     metric.Int64Counter
+	overflowTotal         metric.Int64Counter
+	pendingDataPoints     metric.Int64ObservableGauge
+	pendingBytes          metric.Int64ObservableGauge
+	pendingOldestPointAge metric.Int64ObservableGauge
+	pendingOldestPointMax metric.Int64ObservableGauge
 
 	mu            sync.Mutex
 	registrations []metric.Registration
@@ -165,7 +170,7 @@ func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pme
 	}
 
 	select {
-	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md}:
+	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md, enqueuedAt: time.Now()}:
 		return true, nil
 	case <-backend.done:
 		return false, errMetricBatcherExporterStopping
@@ -231,24 +236,37 @@ func (b *metricBatcher) scheduleBackendCleanup(backend *backendMetricBatcher, re
 }
 
 type metricBatcherPending struct {
-	endpoint   string
-	datapoints int64
-	bytes      int64
+	endpoint        string
+	datapoints      int64
+	bytes           int64
+	oldestAgeMillis int64
 }
 
-func (b *metricBatcher) snapshotPending() []metricBatcherPending {
+type metricBatcherSnapshot struct {
+	pending            []metricBatcherPending
+	maxOldestAgeMillis int64
+}
+
+func (b *metricBatcher) snapshotPending() metricBatcherSnapshot {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
+	now := time.Now()
 	pending := make([]metricBatcherPending, 0, len(b.backends))
+	var maxOldestAgeMillis int64
 	for endpoint, backend := range b.backends {
+		oldestAgeMillis := ageMillisFromUnixNano(now, backend.oldestEnqueue.Load())
+		if oldestAgeMillis > maxOldestAgeMillis {
+			maxOldestAgeMillis = oldestAgeMillis
+		}
 		pending = append(pending, metricBatcherPending{
-			endpoint:   endpoint,
-			datapoints: backend.pendingDataPoints.Load(),
-			bytes:      backend.pendingBytes.Load(),
+			endpoint:        endpoint,
+			datapoints:      backend.pendingDataPoints.Load(),
+			bytes:           backend.pendingBytes.Load(),
+			oldestAgeMillis: oldestAgeMillis,
 		})
 	}
-	return pending
+	return metricBatcherSnapshot{pending: pending, maxOldestAgeMillis: maxOldestAgeMillis}
 }
 
 func (b *metricBatcher) acquireBackend(endpoint string, exp *wrappedExporter) (*backendMetricBatcher, error) {
@@ -400,6 +418,9 @@ func (b *backendMetricBatcher) handleRequest(
 ) bool {
 	switch req.kind {
 	case metricBatcherRequestEnqueue:
+		if *pendingDataPoints == 0 {
+			b.oldestEnqueue.Store(req.enqueuedAt.UnixNano())
+		}
 		dps, bytes := b.drainEnqueueRequestsIntoPending(sizer, pending, req, nextReq)
 		*pendingDataPoints += dps
 		*pendingBytes += bytes
@@ -484,15 +505,19 @@ func (b *backendMetricBatcher) flush(
 	drained := mergePendingMetricChunks(drainedChunks)
 	datapoints := *pendingDataPoints
 	bytes := sizer.MetricsSize(drained)
+	oldestUnixNano := b.oldestEnqueue.Load()
+	oldestAgeMillis := ageMillisFromUnixNano(time.Now(), oldestUnixNano)
 	*pending = (*pending)[:0]
 	*pendingDataPoints = 0
 	*pendingBytes = 0
 	b.pendingDataPoints.Store(0)
 	b.pendingBytes.Store(0)
+	b.oldestEnqueue.Store(0)
 
 	attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
 	b.telemetry.batchDataPoints.Record(ctx, int64(datapoints), attrs)
 	b.telemetry.batchBytes.Record(ctx, int64(bytes), attrs)
+	b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason))))
 	b.telemetry.flushTotal.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason))))
 
 	err := b.send(ctx, b.exporter(), drained, reason)
@@ -519,6 +544,7 @@ func (b *backendMetricBatcher) flush(
 			*pendingBytes = bytes
 			b.pendingDataPoints.Store(int64(datapoints))
 			b.pendingBytes.Store(int64(bytes))
+			b.oldestEnqueue.Store(oldestUnixNano)
 			if *timerC == nil {
 				delay := b.settings.flushInterval * time.Duration(1<<min(b.flushFailures-1, 4))
 				delay = min(delay, maxMetricBatchRetryBackoff)
@@ -703,6 +729,12 @@ func newMetricBatcherTelemetry(settings component.TelemetrySettings) (*metricBat
 		metric.WithUnit("{errors}"),
 	)
 	errs = errors.Join(errs, err)
+	t.flushOldestPointAge, err = meter.Int64Histogram(
+		"otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age",
+		metric.WithDescription("Age in ms of the oldest metric datapoint in a flushed backend batch."),
+		metric.WithUnit("ms"),
+	)
+	errs = errors.Join(errs, err)
 	t.droppedDataPoints, err = meter.Int64Counter(
 		"otelcol_loadbalancer_metric_batch_dropped_datapoints",
 		metric.WithDescription("Number of dropped metric datapoints in the internal metric batcher."),
@@ -727,19 +759,34 @@ func newMetricBatcherTelemetry(settings component.TelemetrySettings) (*metricBat
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
+	t.pendingOldestPointAge, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age",
+		metric.WithDescription("Age in ms of the oldest pending metric datapoint per backend batch."),
+		metric.WithUnit("ms"),
+	)
+	errs = errors.Join(errs, err)
+	t.pendingOldestPointMax, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age_max",
+		metric.WithDescription("Maximum age in ms of the oldest pending metric datapoint across backend batches."),
+		metric.WithUnit("ms"),
+	)
+	errs = errors.Join(errs, err)
 
 	return t, errs
 }
 
-func (t *metricBatcherTelemetry) start(snapshot func() []metricBatcherPending) error {
+func (t *metricBatcherTelemetry) start(snapshot func() metricBatcherSnapshot) error {
 	reg, err := t.meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
-		for _, pending := range snapshot() {
+		state := snapshot()
+		for _, pending := range state.pending {
 			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", pending.endpoint)))
 			observer.ObserveInt64(t.pendingDataPoints, pending.datapoints, attrs)
 			observer.ObserveInt64(t.pendingBytes, pending.bytes, attrs)
+			observer.ObserveInt64(t.pendingOldestPointAge, pending.oldestAgeMillis, attrs)
 		}
+		observer.ObserveInt64(t.pendingOldestPointMax, state.maxOldestAgeMillis)
 		return nil
-	}, t.pendingDataPoints, t.pendingBytes)
+	}, t.pendingDataPoints, t.pendingBytes, t.pendingOldestPointAge, t.pendingOldestPointMax)
 	if err != nil {
 		return err
 	}

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -325,6 +325,89 @@ func TestMetricBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
 	require.Greater(t, flushHistogram.DataPoints[0].Sum, int64(0))
 }
 
+func TestMetricBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) {
+	backend := &backendMetricBatcher{
+		endpoint:  "endpoint-1:4317",
+		settings:  metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		requests:  make(chan metricBatcherRequest, 1),
+		done:      make(chan struct{}),
+		telemetry: &metricBatcherTelemetry{},
+	}
+
+	pending := make([]pmetric.Metrics, 0, 1)
+	pendingDataPoints := 0
+	pendingBytes := 0
+	sizer := &pmetric.ProtoMarshaler{}
+	var nextReq *metricBatcherRequest
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+	retryingSince := time.Time{}
+
+	start := time.Now()
+	stale := start.Add(-time.Hour)
+	stopped := backend.handleRequest(
+		metricBatcherRequest{
+			kind:       metricBatcherRequestEnqueue,
+			md:         singleDataPointMetric("m1"),
+			enqueuedAt: stale,
+		},
+		sizer,
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&nextReq,
+		timer,
+		&timerC,
+		&retryingSince,
+	)
+	require.False(t, stopped)
+
+	stored := time.Unix(0, backend.oldestEnqueue.Load())
+	require.False(t, stored.Before(start), "oldest timestamp should reflect backend acceptance time, not sender-side time")
+}
+
+func TestMetricBatcherFlushAgeRecordedOnlyAfterTerminalFlush(t *testing.T) {
+	telemetry := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetry.Shutdown(context.Background()))
+	})
+
+	var calls atomic.Int64
+	batcher, err := newMetricBatcher(
+		componenttest.NewNopTelemetrySettings().Logger,
+		telemetry.NewTelemetrySettings(),
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: 20 * time.Millisecond},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			if calls.Add(1) == 1 {
+				return errors.New("boom")
+			}
+			return nil
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
+
+	require.Eventually(t, func() bool {
+		return calls.Load() >= 2
+	}, 2*time.Second, 20*time.Millisecond)
+
+	flushMetric, err := telemetry.GetMetric("otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age")
+	require.NoError(t, err)
+	flushHistogram, ok := flushMetric.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, flushHistogram.DataPoints, 1)
+	require.Equal(t, uint64(1), flushHistogram.DataPoints[0].Count)
+}
+
 func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	sendStarted := make(chan struct{}, 1)

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -457,6 +457,68 @@ func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T)
 	require.False(t, enqueued)
 }
 
+func TestMetricBatcherPendingAgeIncludesTimeBufferedBeforeWorkerDequeues(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	sendStarted := make(chan struct{}, 1)
+	unblockSend := make(chan struct{})
+	sendReleased := false
+
+	batcher, err := newMetricBatcher(
+		ts.Logger,
+		ts.TelemetrySettings,
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: 10 * time.Millisecond},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			select {
+			case sendStarted <- struct{}{}:
+			default:
+			}
+			<-unblockSend
+			return nil
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if !sendReleased {
+			close(unblockSend)
+		}
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
+
+	select {
+	case <-sendStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected backend send to start")
+	}
+
+	batcher.mu.RLock()
+	backend := batcher.backends["endpoint-1:4317"]
+	batcher.mu.RUnlock()
+	require.NotNil(t, backend)
+	backend.settings.flushInterval = time.Hour
+
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m2"))
+	time.Sleep(60 * time.Millisecond)
+	close(unblockSend)
+	sendReleased = true
+
+	var oldestAgeMillis int64
+	require.Eventually(t, func() bool {
+		for _, pending := range batcher.snapshotPending().pending {
+			if pending.endpoint == "endpoint-1:4317" && pending.datapoints == 1 {
+				oldestAgeMillis = pending.oldestAgeMillis
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 20*time.Millisecond)
+
+	require.GreaterOrEqual(t, oldestAgeMillis, int64(40), "oldest age should include time spent buffered in backend.requests")
+}
+
 func TestMetricBatcherRemoveReroutesOnResolverChangeFlushFailure(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	rerouted := make(chan int, 1)

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -11,8 +11,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestMetricBatcherFlushesOnMaxDataPoints(t *testing.T) {
@@ -269,13 +272,57 @@ func TestMetricBatcherRestoresPendingBytesFromMergedPayloadOnFailure(t *testing.
 	expectedBytes := (&pmetric.ProtoMarshaler{}).MetricsSize(expected)
 
 	require.Eventually(t, func() bool {
-		for _, p := range batcher.snapshotPending() {
+		for _, p := range batcher.snapshotPending().pending {
 			if p.endpoint == "endpoint-1:4317" {
 				return p.datapoints == 2 && int(p.bytes) == expectedBytes
 			}
 		}
 		return false
 	}, time.Second, 20*time.Millisecond)
+}
+
+func TestMetricBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
+	telemetry := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetry.Shutdown(context.Background()))
+	})
+
+	batcher, err := newMetricBatcher(
+		componenttest.NewNopTelemetrySettings().Logger,
+		telemetry.NewTelemetrySettings(),
+		metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		func(_ context.Context, _ *wrappedExporter, _ pmetric.Metrics, _ string) error {
+			return nil
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
+	time.Sleep(25 * time.Millisecond)
+
+	pendingMetric, err := telemetry.GetMetric("otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age")
+	require.NoError(t, err)
+	pendingGauge, ok := pendingMetric.Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	require.Greater(t, findGaugePointValue(t, pendingGauge.DataPoints, attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"))), int64(0))
+
+	maxMetric, err := telemetry.GetMetric("otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age_max")
+	require.NoError(t, err)
+	maxGauge, ok := maxMetric.Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	require.Greater(t, maxGauge.DataPoints[0].Value, int64(0))
+
+	require.NoError(t, batcher.Shutdown(t.Context()))
+
+	flushMetric, err := telemetry.GetMetric("otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age")
+	require.NoError(t, err)
+	flushHistogram, ok := flushMetric.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, flushHistogram.DataPoints, 1)
+	require.Equal(t, uint64(1), flushHistogram.DataPoints[0].Count)
+	require.Greater(t, flushHistogram.DataPoints[0].Sum, int64(0))
 }
 
 func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T) {
@@ -386,7 +433,7 @@ func TestMetricBatcherDropsPendingWhenRetryBufferCapExceeded(t *testing.T) {
 	}, 2*time.Second, 20*time.Millisecond)
 
 	require.Eventually(t, func() bool {
-		for _, p := range batcher.snapshotPending() {
+		for _, p := range batcher.snapshotPending().pending {
 			if p.endpoint == "endpoint-1:4317" {
 				return p.datapoints == 0
 			}
@@ -428,7 +475,7 @@ func TestMetricBatcherDropsPendingWhenRetryAgeExceeded(t *testing.T) {
 	}, 2*time.Second, 20*time.Millisecond)
 
 	require.Eventually(t, func() bool {
-		for _, p := range batcher.snapshotPending() {
+		for _, p := range batcher.snapshotPending().pending {
 			if p.endpoint == "endpoint-1:4317" {
 				return p.datapoints == 0
 			}

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -284,7 +284,7 @@ func TestMetricBatcherRestoresPendingBytesFromMergedPayloadOnFailure(t *testing.
 func TestMetricBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
 	telemetry := componenttest.NewTelemetry()
 	t.Cleanup(func() {
-		require.NoError(t, telemetry.Shutdown(context.Background()))
+		require.NoError(t, telemetry.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	batcher, err := newMetricBatcher(
@@ -306,13 +306,13 @@ func TestMetricBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
 	require.NoError(t, err)
 	pendingGauge, ok := pendingMetric.Data.(metricdata.Gauge[int64])
 	require.True(t, ok)
-	require.Greater(t, findGaugePointValue(t, pendingGauge.DataPoints, attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"))), int64(0))
+	require.Positive(t, findGaugePointValue(t, pendingGauge.DataPoints, attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"))))
 
 	maxMetric, err := telemetry.GetMetric("otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age_max")
 	require.NoError(t, err)
 	maxGauge, ok := maxMetric.Data.(metricdata.Gauge[int64])
 	require.True(t, ok)
-	require.Greater(t, maxGauge.DataPoints[0].Value, int64(0))
+	require.Positive(t, maxGauge.DataPoints[0].Value)
 
 	require.NoError(t, batcher.Shutdown(t.Context()))
 
@@ -322,7 +322,7 @@ func TestMetricBatcherRecordsPendingOldestAgeAndFlushAge(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, flushHistogram.DataPoints, 1)
 	require.Equal(t, uint64(1), flushHistogram.DataPoints[0].Count)
-	require.Greater(t, flushHistogram.DataPoints[0].Sum, int64(0))
+	require.Positive(t, flushHistogram.DataPoints[0].Sum)
 }
 
 func TestMetricBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) {
@@ -370,7 +370,7 @@ func TestMetricBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) 
 func TestMetricBatcherFlushAgeRecordedOnlyAfterTerminalFlush(t *testing.T) {
 	telemetry := componenttest.NewTelemetry()
 	t.Cleanup(func() {
-		require.NoError(t, telemetry.Shutdown(context.Background()))
+		require.NoError(t, telemetry.Shutdown(context.WithoutCancel(t.Context())))
 	})
 
 	var calls atomic.Int64

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -347,12 +347,10 @@ func TestMetricBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) 
 	retryingSince := time.Time{}
 
 	start := time.Now()
-	stale := start.Add(-time.Hour)
 	stopped := backend.handleRequest(
 		metricBatcherRequest{
-			kind:       metricBatcherRequestEnqueue,
-			md:         singleDataPointMetric("m1"),
-			enqueuedAt: stale,
+			kind: metricBatcherRequestEnqueue,
+			md:   singleDataPointMetric("m1"),
 		},
 		sizer,
 		&pending,

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -394,16 +394,22 @@ func TestMetricBatcherFlushAgeRecordedOnlyAfterTerminalFlush(t *testing.T) {
 	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
 	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("m1"))
 
+	var flushHistogram metricdata.Histogram[int64]
 	require.Eventually(t, func() bool {
-		return calls.Load() >= 2
+		flushMetric, metricErr := telemetry.GetMetric("otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age")
+		if metricErr != nil {
+			return false
+		}
+		histogram, ok := flushMetric.Data.(metricdata.Histogram[int64])
+		if !ok || len(histogram.DataPoints) != 1 || histogram.DataPoints[0].Count == 0 {
+			return false
+		}
+		flushHistogram = histogram
+		return true
 	}, 2*time.Second, 20*time.Millisecond)
 
-	flushMetric, err := telemetry.GetMetric("otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age")
-	require.NoError(t, err)
-	flushHistogram, ok := flushMetric.Data.(metricdata.Histogram[int64])
-	require.True(t, ok)
-	require.Len(t, flushHistogram.DataPoints, 1)
 	require.Equal(t, uint64(1), flushHistogram.DataPoints[0].Count)
+	require.GreaterOrEqual(t, calls.Load(), int64(2))
 }
 
 func TestMetricBatcherTryEnqueueReturnsFalseWhenBackendQueueIsFull(t *testing.T) {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -349,8 +349,9 @@ func TestMetricBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) 
 	start := time.Now()
 	stopped := backend.handleRequest(
 		metricBatcherRequest{
-			kind: metricBatcherRequestEnqueue,
-			md:   singleDataPointMetric("m1"),
+			kind:               metricBatcherRequestEnqueue,
+			md:                 singleDataPointMetric("m1"),
+			enqueuedAtUnixNano: start.UnixNano(),
 		},
 		sizer,
 		&pending,
@@ -364,7 +365,56 @@ func TestMetricBatcherHandleRequestUsesAcceptanceTimeForOldestAge(t *testing.T) 
 	require.False(t, stopped)
 
 	stored := time.Unix(0, backend.oldestEnqueue.Load())
-	require.False(t, stored.Before(start), "oldest timestamp should reflect backend acceptance time, not sender-side time")
+	require.False(t, stored.Before(start), "oldest timestamp should reflect request enqueue time")
+}
+
+func TestMetricBatcherHandleRequestUsesOldestDrainedEnqueueTime(t *testing.T) {
+	backend := &backendMetricBatcher{
+		endpoint:  "endpoint-1:4317",
+		settings:  metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		requests:  make(chan metricBatcherRequest, 1),
+		done:      make(chan struct{}),
+		telemetry: &metricBatcherTelemetry{},
+	}
+
+	older := time.Now().Add(-80 * time.Millisecond).UnixNano()
+	newer := time.Now().Add(-20 * time.Millisecond).UnixNano()
+	backend.requests <- metricBatcherRequest{
+		kind:               metricBatcherRequestEnqueue,
+		md:                 singleDataPointMetric("queued"),
+		enqueuedAtUnixNano: older,
+	}
+
+	pending := make([]pmetric.Metrics, 0, 1)
+	pendingDataPoints := 0
+	pendingBytes := 0
+	sizer := &pmetric.ProtoMarshaler{}
+	var nextReq *metricBatcherRequest
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+	retryingSince := time.Time{}
+
+	stopped := backend.handleRequest(
+		metricBatcherRequest{
+			kind:               metricBatcherRequestEnqueue,
+			md:                 singleDataPointMetric("current"),
+			enqueuedAtUnixNano: newer,
+		},
+		sizer,
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&nextReq,
+		timer,
+		&timerC,
+		&retryingSince,
+	)
+	require.False(t, stopped)
+	require.Equal(t, 2, pendingDataPoints)
+	require.Equal(t, older, backend.oldestEnqueue.Load())
 }
 
 func TestMetricBatcherFlushAgeRecordedOnlyAfterTerminalFlush(t *testing.T) {
@@ -517,6 +567,31 @@ func TestMetricBatcherPendingAgeIncludesTimeBufferedBeforeWorkerDequeues(t *test
 	}, 2*time.Second, 20*time.Millisecond)
 
 	require.GreaterOrEqual(t, oldestAgeMillis, int64(40), "oldest age should include time spent buffered in backend.requests")
+}
+
+func TestMetricBatcherSnapshotPendingIgnoresOldestAgeWhenNoDatapointsPending(t *testing.T) {
+	batcher := &metricBatcher{
+		backends: map[string]*backendMetricBatcher{
+			"endpoint-1:4317": {
+				oldestEnqueue: func() atomic.Int64 {
+					var v atomic.Int64
+					v.Store(time.Now().Add(-time.Second).UnixNano())
+					return v
+				}(),
+				pendingBytes: func() atomic.Int64 {
+					var v atomic.Int64
+					v.Store(123)
+					return v
+				}(),
+			},
+		},
+	}
+
+	snapshot := batcher.snapshotPending()
+	require.Len(t, snapshot.pending, 1)
+	require.Zero(t, snapshot.pending[0].datapoints)
+	require.Zero(t, snapshot.pending[0].oldestAgeMillis)
+	require.Zero(t, snapshot.maxOldestAgeMillis)
 }
 
 func TestMetricBatcherRemoveReroutesOnResolverChangeFlushFailure(t *testing.T) {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -572,20 +572,11 @@ func TestMetricBatcherPendingAgeIncludesTimeBufferedBeforeWorkerDequeues(t *test
 func TestMetricBatcherSnapshotPendingIgnoresOldestAgeWhenNoDatapointsPending(t *testing.T) {
 	batcher := &metricBatcher{
 		backends: map[string]*backendMetricBatcher{
-			"endpoint-1:4317": {
-				oldestEnqueue: func() atomic.Int64 {
-					var v atomic.Int64
-					v.Store(time.Now().Add(-time.Second).UnixNano())
-					return v
-				}(),
-				pendingBytes: func() atomic.Int64 {
-					var v atomic.Int64
-					v.Store(123)
-					return v
-				}(),
-			},
+			"endpoint-1:4317": {},
 		},
 	}
+	batcher.backends["endpoint-1:4317"].oldestEnqueue.Store(time.Now().Add(-time.Second).UnixNano())
+	batcher.backends["endpoint-1:4317"].pendingBytes.Store(123)
 
 	snapshot := batcher.snapshotPending()
 	require.Len(t, snapshot.pending, 1)


### PR DESCRIPTION
## Summary
- add queue-age gauges and flush-age histograms for the internal log and metric batchers
- expose both per-endpoint and aggregate max oldest-age views
- document the new LB and sending_queue age metrics in the exporter README

## Why
The exporter already exposed queue depth and batch-size signals, but it could not show whether telemetry was getting stale inside the sending queue or the internal post-routing batchers.

## Validation
- go test .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes internal log/metric batching state tracking and telemetry emission, which can affect flush behavior and performance under load; it also alters resilience option wiring around `sending_queue` compression.
> 
> **Overview**
> Adds **queue-age visibility** to `loadbalancingexporter` by tracking enqueue timestamps and emitting per-endpoint oldest-pending age gauges plus aggregate max gauges, alongside flush-time histograms for both log and metric post-routing batchers.
> 
> Updates docs and tests to cover the new metrics and timing semantics (including time buffered before dequeue), removes the `WithQueueBatchInMemoryEncoding` option wiring (keeping `sending_queue.compress_in_memory` as a compatibility knob), and drops local `go.mod` `replace` overrides to use upstream `exporterhelper` modules. Separately, `awss3exporter` gains a `max_file_size_bytes` schema field and small marshaler/flush refactors to simplify control flow and JSONL batching returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d989c09b6b7bef4b7008502644d0297416d4c790. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds queue-age metrics to `loadbalancingexporter` to surface staleness in post-routing batchers and at flush for logs and metrics. Addresses Linear 47 and aligns with upstream `go.opentelemetry.io/collector/exporter/exporterhelper` and `.../exporterhelper/xexporterhelper`.

- **New Features**
  - Per-endpoint gauges for oldest pending age: `otelcol_loadbalancer_log_batch_pending_oldest_record_age`, `otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age`.
  - Max oldest-age across endpoints: `otelcol_loadbalancer_log_batch_pending_oldest_record_age_max`, `otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age_max`.
  - Flush histograms: `otelcol_loadbalancer_log_batch_flush_oldest_record_age`, `otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age`. README updated; tests cover pending and flush age.

- **Bug Fixes**
  - Queue age uses the earliest enqueued timestamp across drained items and includes time buffered before a worker dequeues; gauges reset on drain/flush. For metrics, flush-age is recorded only on terminal outcomes (success, reroute, drop).
  - Keeps `sending_queue.compress_in_memory` as a public setting and removes the internal `WithQueueBatchInMemoryEncoding`; uses upstream modules. Refreshes `awss3exporter` config schema to include `max_file_size_bytes` and applies minor marshaler/flush lint fixes with no behavior change.

<sup>Written for commit d989c09b6b7bef4b7008502644d0297416d4c790. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added telemetry: per-backend pending-oldest ages for logs/metrics, cross-backend max gauges, and flush-time histograms capturing oldest ages (including retry/drop outcomes).

* **Documentation**
  * README clarified queue/batcher payload/compression behavior and documents the new queue-age metrics.

* **Tests**
  * Added tests validating pending-oldest and flush-oldest telemetry and enqueue timing semantics.

* **Refactor**
  * Simplified marshaler selection/flush control flow and adjusted batching marshaler behavior.

* **Chores**
  * Removed local module replace directives and added changelog entry for queue-age metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->