### PR TITLE
[exporter/loadbalancing] compress log batcher chunks

### DIFF
--- a/.chloggen/loadbalancingexporter-log-batcher-compression.yaml
+++ b/.chloggen/loadbalancingexporter-log-batcher-compression.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add optional in-memory compression for loadbalancing exporter log batcher chunks.
+issues: [7312]
+subtext: |-
+  Set `log_batcher.payload_compression` to `zstd` or `snappy` to keep queued and pending post-routing log batches compressed until they are flushed.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -130,6 +130,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `max_records` flushes a backend batch when it reaches this many log records. Default: `512`.
   * `max_bytes` flushes a backend batch when its serialized OTLP payload size before compression reaches this many bytes. Default: `1048576` (`1 MiB`).
   * `flush_interval` flushes a backend batch after this interval even if size limits are not reached. Default: `100ms`.
+  * `payload_compression` compresses log batcher chunks while they are pending in memory. Supported values: `none`, `snappy`, `zstd`. Default: `none`.
 
 Simple example
 
@@ -149,6 +150,7 @@ exporters:
       max_records: 512
       max_bytes: 1048576
       flush_interval: 100ms
+      payload_compression: zstd
     routing_key: "service"
     protocol:
       otlp:

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -88,10 +88,11 @@ type QueueSettings struct {
 }
 
 type LogBatcherConfig struct {
-	Enabled       bool          `mapstructure:"enabled"`
-	MaxRecords    int           `mapstructure:"max_records"`
-	MaxBytes      int           `mapstructure:"max_bytes"`
-	FlushInterval time.Duration `mapstructure:"flush_interval"`
+	Enabled            bool                    `mapstructure:"enabled"`
+	MaxRecords         int                     `mapstructure:"max_records"`
+	MaxBytes           int                     `mapstructure:"max_bytes"`
+	FlushInterval      time.Duration           `mapstructure:"flush_interval"`
+	PayloadCompression QueuePayloadCompression `mapstructure:"payload_compression"`
 }
 
 type MetricBatcherConfig struct {
@@ -212,6 +213,12 @@ func (c LogBatcherConfig) Validate() error {
 	}
 	if c.FlushInterval <= 0 {
 		return errors.New("log_batcher.flush_interval must be greater than 0 when log_batcher.enabled=true")
+	}
+	switch c.PayloadCompression {
+	case "", QueuePayloadCompressionNone, QueuePayloadCompressionSnappy, QueuePayloadCompressionZstd:
+		// Valid payload compression value.
+	default:
+		return fmt.Errorf("log_batcher.payload_compression must be one of [none, snappy, zstd], found %q", c.PayloadCompression)
 	}
 	return nil
 }

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -87,6 +87,10 @@ func TestConfigValidateLogBatcher(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "log_batcher.flush_interval")
 
 	cfg.LogBatcher.FlushInterval = time.Second
+	cfg.LogBatcher.PayloadCompression = QueuePayloadCompression("brotli")
+	require.ErrorContains(t, cfg.Validate(), "log_batcher.payload_compression")
+
+	cfg.LogBatcher.PayloadCompression = QueuePayloadCompressionZstd
 	require.NoError(t, cfg.Validate())
 }
 
@@ -259,10 +263,11 @@ func TestLoadConfigWithLogBatcher(t *testing.T) {
 			},
 		},
 		"log_batcher": map[string]any{
-			"enabled":        true,
-			"max_records":    1024,
-			"max_bytes":      2097152,
-			"flush_interval": "250ms",
+			"enabled":             true,
+			"max_records":         1024,
+			"max_bytes":           2097152,
+			"flush_interval":      "250ms",
+			"payload_compression": "zstd",
 		},
 	})
 
@@ -271,6 +276,7 @@ func TestLoadConfigWithLogBatcher(t *testing.T) {
 	require.Equal(t, 1024, cfg.LogBatcher.MaxRecords)
 	require.Equal(t, 2097152, cfg.LogBatcher.MaxBytes)
 	require.Equal(t, 250*time.Millisecond, cfg.LogBatcher.FlushInterval)
+	require.Equal(t, QueuePayloadCompressionZstd, cfg.LogBatcher.PayloadCompression)
 }
 
 func TestLoadConfigWithMetricBatcher(t *testing.T) {

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -90,6 +90,9 @@ func TestConfigValidateLogBatcher(t *testing.T) {
 	cfg.LogBatcher.PayloadCompression = QueuePayloadCompression("brotli")
 	require.ErrorContains(t, cfg.Validate(), "log_batcher.payload_compression")
 
+	cfg.LogBatcher.PayloadCompression = QueuePayloadCompressionSnappy
+	require.NoError(t, cfg.Validate())
+
 	cfg.LogBatcher.PayloadCompression = QueuePayloadCompressionZstd
 	require.NoError(t, cfg.Validate())
 }

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -54,10 +54,11 @@ func createDefaultConfig() component.Config {
 			PayloadCompression: QueuePayloadCompressionNone,
 		},
 		LogBatcher: LogBatcherConfig{
-			Enabled:       false,
-			MaxRecords:    defaultLogBatchMaxRecords,
-			MaxBytes:      defaultLogBatchMaxBytes,
-			FlushInterval: defaultLogBatchFlushTimeout,
+			Enabled:            false,
+			MaxRecords:         defaultLogBatchMaxRecords,
+			MaxBytes:           defaultLogBatchMaxBytes,
+			FlushInterval:      defaultLogBatchFlushTimeout,
+			PayloadCompression: QueuePayloadCompressionNone,
 		},
 		MetricBatcher: MetricBatcherConfig{
 			Enabled:                  false,

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -109,6 +109,7 @@ func TestDefaultLogBatcherConfig(t *testing.T) {
 	assert.Equal(t, defaultLogBatchMaxRecords, cfg.LogBatcher.MaxRecords)
 	assert.Equal(t, defaultLogBatchMaxBytes, cfg.LogBatcher.MaxBytes)
 	assert.Equal(t, defaultLogBatchFlushTimeout, cfg.LogBatcher.FlushInterval)
+	assert.Equal(t, QueuePayloadCompressionNone, cfg.LogBatcher.PayloadCompression)
 }
 
 func TestDefaultMetricBatcherConfig(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -34,9 +34,10 @@ const (
 var errLogBatcherExporterStopping = errors.New("log batcher exporter is stopping")
 
 type logBatcherSettings struct {
-	maxRecords    int
-	maxBytes      int
-	flushInterval time.Duration
+	maxRecords         int
+	maxBytes           int
+	flushInterval      time.Duration
+	payloadCompression QueuePayloadCompression
 }
 
 type logBatcherSendFunc func(context.Context, *wrappedExporter, plog.Logs, string) error
@@ -56,6 +57,7 @@ type logBatcher struct {
 type logBatcherRequest struct {
 	kind               logBatcherRequestKind
 	logs               plog.Logs
+	compressedChunk    compressedLogBatcherChunk
 	ctx                context.Context
 	reason             string
 	done               chan error
@@ -84,25 +86,30 @@ type backendLogBatcher struct {
 	done     chan struct{}
 	inflight sync.WaitGroup
 
-	pendingRecords atomic.Int64
-	pendingBytes   atomic.Int64
-	oldestEnqueue  atomic.Int64
+	pendingRecords         atomic.Int64
+	pendingBytes           atomic.Int64
+	pendingCompressedBytes atomic.Int64
+	oldestEnqueue          atomic.Int64
+
+	payloadCodecMu sync.Mutex
+	payloadCodec   *queuePayloadCodec
 }
 
 type logBatcherTelemetry struct {
-	logger               *zap.Logger
-	meter                metric.Meter
-	batchSize            metric.Int64Histogram
-	batchBytes           metric.Int64Histogram
-	flushTotal           metric.Int64Counter
-	flushErrors          metric.Int64Counter
-	flushOldestRecordAge metric.Int64Histogram
-	droppedRecords       metric.Int64Counter
-	overflowTotal        metric.Int64Counter
-	pendingRecords       metric.Int64ObservableGauge
-	pendingBytes         metric.Int64ObservableGauge
-	pendingOldestAge     metric.Int64ObservableGauge
-	pendingOldestAgeMax  metric.Int64ObservableGauge
+	logger                 *zap.Logger
+	meter                  metric.Meter
+	batchSize              metric.Int64Histogram
+	batchBytes             metric.Int64Histogram
+	flushTotal             metric.Int64Counter
+	flushErrors            metric.Int64Counter
+	flushOldestRecordAge   metric.Int64Histogram
+	droppedRecords         metric.Int64Counter
+	overflowTotal          metric.Int64Counter
+	pendingRecords         metric.Int64ObservableGauge
+	pendingBytes           metric.Int64ObservableGauge
+	pendingCompressedBytes metric.Int64ObservableGauge
+	pendingOldestAge       metric.Int64ObservableGauge
+	pendingOldestAgeMax    metric.Int64ObservableGauge
 
 	mu            sync.Mutex
 	registrations []metric.Registration
@@ -141,8 +148,17 @@ func (b *logBatcher) Enqueue(ctx context.Context, endpoint string, exp *wrappedE
 	}
 	defer backend.inflight.Done()
 	enqueuedAtUnixNano := time.Now().UnixNano()
+	req := logBatcherRequest{kind: logBatcherRequestEnqueue, logs: logs, enqueuedAtUnixNano: enqueuedAtUnixNano}
+	if backend.payloadCodec != nil {
+		compressedChunk, err := backend.newCompressedLogBatcherChunk(logs, enqueuedAtUnixNano)
+		if err != nil {
+			return err
+		}
+		req.logs = plog.NewLogs()
+		req.compressedChunk = compressedChunk
+	}
 	select {
-	case backend.requests <- logBatcherRequest{kind: logBatcherRequestEnqueue, logs: logs, enqueuedAtUnixNano: enqueuedAtUnixNano}:
+	case backend.requests <- req:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -222,6 +238,7 @@ func (b *logBatcher) snapshotPending() logBatcherSnapshot {
 	for endpoint, backend := range b.backends {
 		records := backend.pendingRecords.Load()
 		bytes := backend.pendingBytes.Load()
+		compressedBytes := backend.pendingCompressedBytes.Load()
 		var oldestAgeMillis int64
 		if records > 0 {
 			oldestAgeMillis = ageMillisFromUnixNano(now, backend.oldestEnqueue.Load())
@@ -233,6 +250,7 @@ func (b *logBatcher) snapshotPending() logBatcherSnapshot {
 			endpoint:        endpoint,
 			records:         records,
 			bytes:           bytes,
+			compressedBytes: compressedBytes,
 			oldestAgeMillis: oldestAgeMillis,
 		})
 	}
@@ -291,18 +309,26 @@ func newBackendLogBatcher(
 	send logBatcherSendFunc,
 ) *backendLogBatcher {
 	backend := &backendLogBatcher{
-		endpoint:  endpoint,
-		exp:       exp,
-		logger:    logger.With(zap.String("endpoint", endpoint)),
-		settings:  settings,
-		send:      send,
-		telemetry: telemetry,
-		requests:  make(chan logBatcherRequest, 16),
-		done:      make(chan struct{}),
+		endpoint:     endpoint,
+		exp:          exp,
+		logger:       logger.With(zap.String("endpoint", endpoint)),
+		settings:     settings,
+		send:         send,
+		telemetry:    telemetry,
+		requests:     make(chan logBatcherRequest, 16),
+		done:         make(chan struct{}),
+		payloadCodec: newLogBatcherPayloadCodec(settings.payloadCompression),
 	}
 
 	go backend.run()
 	return backend
+}
+
+func newLogBatcherPayloadCodec(compression QueuePayloadCompression) *queuePayloadCodec {
+	if compression == "" || compression == QueuePayloadCompressionNone {
+		return nil
+	}
+	return newQueuePayloadCodec(compression)
 }
 
 func (b *backendLogBatcher) stopAndFlush(ctx context.Context, reason string) error {
@@ -356,7 +382,20 @@ func waitForInflight(ctx context.Context, wg *sync.WaitGroup) error {
 
 func (b *backendLogBatcher) run() {
 	defer close(b.done)
+	if b.payloadCodec != nil {
+		defer func() {
+			if err := b.payloadCodec.Close(); err != nil {
+				b.logger.Warn("failed to close log batcher payload codec", zap.Error(err))
+			}
+		}()
+		b.runCompressed()
+		return
+	}
 
+	b.runUncompressed()
+}
+
+func (b *backendLogBatcher) runUncompressed() {
 	timer := time.NewTimer(time.Hour)
 	if !timer.Stop() {
 		<-timer.C
@@ -466,6 +505,173 @@ func (b *backendLogBatcher) mergeQueuedRequests(pending *plog.Logs, first logBat
 	return recordCount, oldestEnqueue
 }
 
+type compressedLogBatcherChunk struct {
+	payload               []byte
+	records               int
+	uncompressedBytes     int
+	compressedBytes       int
+	oldestEnqueueUnixNano int64
+}
+
+func (b *backendLogBatcher) runCompressed() {
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+
+	pending := make([]compressedLogBatcherChunk, 0, cap(b.requests))
+	pendingBytes := 0
+	pendingCompressedBytes := 0
+	pendingRecords := 0
+	marshaler := &plog.ProtoMarshaler{}
+	unmarshaler := &plog.ProtoUnmarshaler{}
+	var nextReq *logBatcherRequest
+
+	for {
+		if nextReq != nil {
+			req := *nextReq
+			nextReq = nil
+			if b.handleCompressedRequest(req, marshaler, unmarshaler, &pending, &pendingRecords, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
+				return
+			}
+			continue
+		}
+
+		select {
+		case req := <-b.requests:
+			if b.handleCompressedRequest(req, marshaler, unmarshaler, &pending, &pendingRecords, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
+				return
+			}
+		case <-timerC:
+			if err := b.flushCompressed(context.Background(), marshaler, unmarshaler, &pending, &pendingRecords, &pendingBytes, &pendingCompressedBytes, logFlushReasonTimeout, timer, &timerC); err != nil {
+				b.logger.Warn("failed to flush compressed log batch", zap.String("reason", logFlushReasonTimeout), zap.Error(err))
+			}
+		}
+	}
+}
+
+func (b *backendLogBatcher) handleCompressedRequest(
+	req logBatcherRequest,
+	marshaler *plog.ProtoMarshaler,
+	unmarshaler *plog.ProtoUnmarshaler,
+	pending *[]compressedLogBatcherChunk,
+	pendingRecords *int,
+	pendingBytes *int,
+	pendingCompressedBytes *int,
+	nextReq **logBatcherRequest,
+	timer *time.Timer,
+	timerC *<-chan time.Time,
+) bool {
+	switch req.kind {
+	case logBatcherRequestEnqueue:
+		recordsAdded, bytesAdded, compressedBytesAdded, oldestEnqueue := b.drainEnqueueRequestsIntoCompressedChunks(pending, req, nextReq)
+		*pendingRecords += recordsAdded
+		*pendingBytes += bytesAdded
+		*pendingCompressedBytes += compressedBytesAdded
+		if *pendingRecords > 0 && b.oldestEnqueue.Load() == 0 {
+			b.oldestEnqueue.Store(oldestEnqueue)
+		}
+		b.pendingRecords.Store(int64(*pendingRecords))
+		b.pendingBytes.Store(int64(*pendingBytes))
+		b.pendingCompressedBytes.Store(int64(*pendingCompressedBytes))
+		if *pendingRecords > 0 && *timerC == nil {
+			timer.Reset(b.settings.flushInterval)
+			*timerC = timer.C
+		}
+		if *pendingRecords >= b.settings.maxRecords || *pendingBytes >= b.settings.maxBytes {
+			b.telemetry.overflowTotal.Add(context.Background(), 1, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint))))
+			if err := b.flushCompressed(context.Background(), marshaler, unmarshaler, pending, pendingRecords, pendingBytes, pendingCompressedBytes, logFlushReasonSize, timer, timerC); err != nil {
+				b.logger.Warn("failed to flush compressed log batch", zap.String("reason", logFlushReasonSize), zap.Error(err))
+			}
+		}
+	case logBatcherRequestFlushAndStop:
+		err := b.flushCompressed(req.ctx, marshaler, unmarshaler, pending, pendingRecords, pendingBytes, pendingCompressedBytes, req.reason, timer, timerC)
+		req.done <- err
+		return true
+	}
+	return false
+}
+
+func (b *backendLogBatcher) drainEnqueueRequestsIntoCompressedChunks(
+	pending *[]compressedLogBatcherChunk,
+	first logBatcherRequest,
+	nextReq **logBatcherRequest,
+) (int, int, int, int64) {
+	recordCount := 0
+	bytes := 0
+	compressedBytes := 0
+	var oldestEnqueue int64
+
+	appendRequest := func(req logBatcherRequest) {
+		count := req.compressedChunk.records
+		if count == 0 {
+			return
+		}
+		recordCount += count
+		bytes += req.compressedChunk.uncompressedBytes
+		compressedBytes += req.compressedChunk.compressedBytes
+		if oldestEnqueue == 0 || req.enqueuedAtUnixNano < oldestEnqueue {
+			oldestEnqueue = req.enqueuedAtUnixNano
+		}
+		*pending = append(*pending, req.compressedChunk)
+	}
+
+	appendRequest(first)
+
+	for i := 0; i < cap(b.requests); i++ {
+		select {
+		case req := <-b.requests:
+			if req.kind != logBatcherRequestEnqueue {
+				*nextReq = &req
+				return recordCount, bytes, compressedBytes, oldestEnqueue
+			}
+			appendRequest(req)
+		default:
+			return recordCount, bytes, compressedBytes, oldestEnqueue
+		}
+	}
+
+	return recordCount, bytes, compressedBytes, oldestEnqueue
+}
+
+func newCompressedLogBatcherChunk(marshaler *plog.ProtoMarshaler, codec *queuePayloadCodec, req logBatcherRequest) (compressedLogBatcherChunk, error) {
+	payload, err := marshaler.MarshalLogs(req.logs)
+	if err != nil {
+		return compressedLogBatcherChunk{}, err
+	}
+	encoded, err := codec.Encode(payload)
+	if err != nil {
+		return compressedLogBatcherChunk{}, err
+	}
+	encoded = append([]byte(nil), encoded...)
+	encoded = encoded[:len(encoded):len(encoded)]
+	return compressedLogBatcherChunk{
+		payload:               encoded,
+		records:               req.logs.LogRecordCount(),
+		uncompressedBytes:     len(payload),
+		compressedBytes:       len(encoded),
+		oldestEnqueueUnixNano: req.enqueuedAtUnixNano,
+	}, nil
+}
+
+func (b *backendLogBatcher) newCompressedLogBatcherChunk(logs plog.Logs, enqueuedAtUnixNano int64) (compressedLogBatcherChunk, error) {
+	b.payloadCodecMu.Lock()
+	defer b.payloadCodecMu.Unlock()
+	return newCompressedLogBatcherChunk(&plog.ProtoMarshaler{}, b.payloadCodec, logBatcherRequest{
+		logs:               logs,
+		enqueuedAtUnixNano: enqueuedAtUnixNano,
+	})
+}
+
+func decodeCompressedLogBatcherChunk(unmarshaler *plog.ProtoUnmarshaler, codec *queuePayloadCodec, chunk compressedLogBatcherChunk) (plog.Logs, error) {
+	payload, err := codec.Decode(chunk.payload)
+	if err != nil {
+		return plog.Logs{}, err
+	}
+	return unmarshaler.UnmarshalLogs(payload)
+}
+
 func (b *backendLogBatcher) flush(
 	ctx context.Context,
 	pending *plog.Logs,
@@ -511,10 +717,183 @@ func (b *backendLogBatcher) flush(
 	return err
 }
 
+func (b *backendLogBatcher) flushCompressed(
+	ctx context.Context,
+	sizer *plog.ProtoMarshaler,
+	unmarshaler *plog.ProtoUnmarshaler,
+	pending *[]compressedLogBatcherChunk,
+	pendingRecords *int,
+	pendingBytes *int,
+	pendingCompressedBytes *int,
+	reason string,
+	timer *time.Timer,
+	timerC *<-chan time.Time,
+) error {
+	if !timer.Stop() && *timerC != nil {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	*timerC = nil
+
+	if *pendingRecords == 0 {
+		return nil
+	}
+
+	drainedChunks := *pending
+	*pending = make([]compressedLogBatcherChunk, 0, cap(b.requests))
+	*pendingRecords = 0
+	*pendingBytes = 0
+	*pendingCompressedBytes = 0
+	b.pendingRecords.Store(0)
+	b.pendingBytes.Store(0)
+	b.pendingCompressedBytes.Store(0)
+	b.oldestEnqueue.Store(0)
+	defer clearCompressedLogBatcherChunks(drainedChunks)
+
+	var errs error
+	for len(drainedChunks) > 0 {
+		var window []compressedLogBatcherChunk
+		var records int
+		var oldestUnixNano int64
+		window, drainedChunks, records, oldestUnixNano = nextCompressedLogBatcherWindow(drainedChunks, b.settings.maxRecords, b.settings.maxBytes)
+
+		b.payloadCodecMu.Lock()
+		drained, err := mergeCompressedLogBatcherChunks(unmarshaler, b.payloadCodec, window)
+		b.payloadCodecMu.Unlock()
+		if err != nil {
+			b.telemetry.flushErrors.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint))))
+			b.telemetry.droppedRecords.Add(ctx, int64(records), metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint))))
+			errs = errors.Join(errs, err)
+			continue
+		}
+
+		bytes := sizer.LogsSize(drained)
+		oldestAgeMillis := ageMillisFromUnixNano(time.Now(), oldestUnixNano)
+		attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
+		flushAttrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason)))
+		b.telemetry.batchSize.Record(ctx, int64(records), attrs)
+		b.telemetry.batchBytes.Record(ctx, int64(bytes), attrs)
+		b.telemetry.flushOldestRecordAge.Record(ctx, oldestAgeMillis, flushAttrs)
+		b.telemetry.flushTotal.Add(ctx, 1, flushAttrs)
+
+		err = b.send(ctx, b.exporter(), drained, reason)
+		if err != nil {
+			b.telemetry.flushErrors.Add(ctx, 1, attrs)
+			b.telemetry.droppedRecords.Add(ctx, int64(records), attrs)
+			errs = errors.Join(errs, err)
+		}
+	}
+
+	return errs
+}
+
+func nextCompressedLogBatcherWindow(chunks []compressedLogBatcherChunk, maxRecords, maxBytes int) ([]compressedLogBatcherChunk, []compressedLogBatcherChunk, int, int64) {
+	records := 0
+	bytes := 0
+	var oldestUnixNano int64
+	end := 0
+	for end < len(chunks) {
+		chunk := chunks[end]
+		if end > 0 && (records+chunk.records > maxRecords || bytes+chunk.uncompressedBytes > maxBytes) {
+			break
+		}
+		records += chunk.records
+		bytes += chunk.uncompressedBytes
+		if oldestUnixNano == 0 || chunk.oldestEnqueueUnixNano < oldestUnixNano {
+			oldestUnixNano = chunk.oldestEnqueueUnixNano
+		}
+		end++
+		if records >= maxRecords || bytes >= maxBytes {
+			break
+		}
+	}
+	return chunks[:end], chunks[end:], records, oldestUnixNano
+}
+
+func mergeCompressedLogBatcherChunks(unmarshaler *plog.ProtoUnmarshaler, codec *queuePayloadCodec, chunks []compressedLogBatcherChunk) (plog.Logs, error) {
+	if len(chunks) == 0 {
+		return plog.NewLogs(), nil
+	}
+
+	merged, err := decodeCompressedLogBatcherChunk(unmarshaler, codec, chunks[0])
+	if err != nil {
+		return plog.Logs{}, err
+	}
+	for i := 1; i < len(chunks); i++ {
+		logs, err := decodeCompressedLogBatcherChunk(unmarshaler, codec, chunks[i])
+		if err != nil {
+			return plog.Logs{}, err
+		}
+		mergeLogChunksByMove(merged, logs)
+	}
+	return merged, nil
+}
+
+func mergeLogChunksByMove(dst, src plog.Logs) {
+	dstResourceLogs := dst.ResourceLogs()
+	srcResourceLogs := src.ResourceLogs()
+	for i := 0; i < srcResourceLogs.Len(); i++ {
+		srcRL := srcResourceLogs.At(i)
+		dstRL, ok := findMatchingResourceLogs(dst, srcRL)
+		if !ok {
+			dstRL = dstResourceLogs.AppendEmpty()
+			srcRL.MoveTo(dstRL)
+			continue
+		}
+
+		mergeResourceLogsByMove(dstRL, srcRL)
+	}
+}
+
+func mergeResourceLogsByMove(dst, src plog.ResourceLogs) {
+	dstScopeLogs := dst.ScopeLogs()
+	srcScopeLogs := src.ScopeLogs()
+	for i := 0; i < srcScopeLogs.Len(); i++ {
+		srcSL := srcScopeLogs.At(i)
+		dstSL, ok := findMatchingScopeLogs(dst, srcSL)
+		if !ok {
+			dstSL = dstScopeLogs.AppendEmpty()
+			srcSL.MoveTo(dstSL)
+			continue
+		}
+
+		srcSL.LogRecords().MoveAndAppendTo(dstSL.LogRecords())
+	}
+}
+
+func findMatchingResourceLogs(dest plog.Logs, src plog.ResourceLogs) (plog.ResourceLogs, bool) {
+	for i := 0; i < dest.ResourceLogs().Len(); i++ {
+		rl := dest.ResourceLogs().At(i)
+		if resourceLogsMatches(rl, src) {
+			return rl, true
+		}
+	}
+	return plog.ResourceLogs{}, false
+}
+
+func findMatchingScopeLogs(dest plog.ResourceLogs, src plog.ScopeLogs) (plog.ScopeLogs, bool) {
+	for i := 0; i < dest.ScopeLogs().Len(); i++ {
+		sl := dest.ScopeLogs().At(i)
+		if scopeLogsMatches(sl, src) {
+			return sl, true
+		}
+	}
+	return plog.ScopeLogs{}, false
+}
+
+func clearCompressedLogBatcherChunks(chunks []compressedLogBatcherChunk) {
+	for i := range chunks {
+		chunks[i] = compressedLogBatcherChunk{}
+	}
+}
+
 type logBatcherPending struct {
 	endpoint        string
 	records         int64
 	bytes           int64
+	compressedBytes int64
 	oldestAgeMillis int64
 }
 
@@ -577,6 +956,12 @@ func newLogBatcherTelemetry(settings component.TelemetrySettings) (*logBatcherTe
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
+	t.pendingCompressedBytes, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_log_batch_pending_compressed_bytes",
+		metric.WithDescription("Current compressed serialized OTLP bytes per pending backend batch."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
 	t.pendingOldestAge, err = meter.Int64ObservableGauge(
 		"otelcol_loadbalancer_log_batch_pending_oldest_record_age",
 		metric.WithDescription("Age in ms of the oldest pending log record per backend batch."),
@@ -600,11 +985,12 @@ func (t *logBatcherTelemetry) start(snapshot func() logBatcherSnapshot) error {
 			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", pending.endpoint)))
 			observer.ObserveInt64(t.pendingRecords, pending.records, attrs)
 			observer.ObserveInt64(t.pendingBytes, pending.bytes, attrs)
+			observer.ObserveInt64(t.pendingCompressedBytes, pending.compressedBytes, attrs)
 			observer.ObserveInt64(t.pendingOldestAge, pending.oldestAgeMillis, attrs)
 		}
 		observer.ObserveInt64(t.pendingOldestAgeMax, state.maxOldestAgeMillis)
 		return nil
-	}, t.pendingRecords, t.pendingBytes, t.pendingOldestAge, t.pendingOldestAgeMax)
+	}, t.pendingRecords, t.pendingBytes, t.pendingCompressedBytes, t.pendingOldestAge, t.pendingOldestAgeMax)
 	if err != nil {
 		return err
 	}

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -6,6 +6,7 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 import (
 	"context"
 	"errors"
+	"math/bits"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -511,6 +512,35 @@ type compressedLogBatcherChunk struct {
 	uncompressedBytes     int
 	compressedBytes       int
 	oldestEnqueueUnixNano int64
+	sizingResources       []compressedLogBatcherResourceSizing
+	sizingMetadata        plog.Logs
+}
+
+type compressedLogBatcherResourceSizing struct {
+	resource plog.ResourceLogs
+	scopes   []compressedLogBatcherScopeSizing
+}
+
+type compressedLogBatcherScopeSizing struct {
+	scope             plog.ScopeLogs
+	recordsDeltaBytes int
+}
+
+type compressedLogBatcherSizeState struct {
+	metadata  plog.Logs
+	resources []compressedLogBatcherResourceSizeState
+	bytes     int
+}
+
+type compressedLogBatcherResourceSizeState struct {
+	resource plog.ResourceLogs
+	size     int
+	scopes   []compressedLogBatcherScopeSizeState
+}
+
+type compressedLogBatcherScopeSizeState struct {
+	scope plog.ScopeLogs
+	size  int
 }
 
 func (b *backendLogBatcher) runCompressed() {
@@ -526,13 +556,14 @@ func (b *backendLogBatcher) runCompressed() {
 	pendingRecords := 0
 	marshaler := &plog.ProtoMarshaler{}
 	unmarshaler := &plog.ProtoUnmarshaler{}
+	sizeState := newCompressedLogBatcherSizeState()
 	var nextReq *logBatcherRequest
 
 	for {
 		if nextReq != nil {
 			req := *nextReq
 			nextReq = nil
-			if b.handleCompressedRequest(req, marshaler, unmarshaler, &pending, &pendingRecords, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
+			if b.handleCompressedRequest(req, marshaler, unmarshaler, sizeState, &pending, &pendingRecords, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
 				return
 			}
 			continue
@@ -540,11 +571,11 @@ func (b *backendLogBatcher) runCompressed() {
 
 		select {
 		case req := <-b.requests:
-			if b.handleCompressedRequest(req, marshaler, unmarshaler, &pending, &pendingRecords, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
+			if b.handleCompressedRequest(req, marshaler, unmarshaler, sizeState, &pending, &pendingRecords, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
 				return
 			}
 		case <-timerC:
-			if err := b.flushCompressed(context.Background(), marshaler, unmarshaler, &pending, &pendingRecords, &pendingBytes, &pendingCompressedBytes, logFlushReasonTimeout, timer, &timerC); err != nil {
+			if err := b.flushCompressed(context.Background(), marshaler, unmarshaler, sizeState, &pending, &pendingRecords, &pendingBytes, &pendingCompressedBytes, logFlushReasonTimeout, timer, &timerC); err != nil {
 				b.logger.Warn("failed to flush compressed log batch", zap.String("reason", logFlushReasonTimeout), zap.Error(err))
 			}
 		}
@@ -555,6 +586,7 @@ func (b *backendLogBatcher) handleCompressedRequest(
 	req logBatcherRequest,
 	marshaler *plog.ProtoMarshaler,
 	unmarshaler *plog.ProtoUnmarshaler,
+	sizeState *compressedLogBatcherSizeState,
 	pending *[]compressedLogBatcherChunk,
 	pendingRecords *int,
 	pendingBytes *int,
@@ -565,7 +597,7 @@ func (b *backendLogBatcher) handleCompressedRequest(
 ) bool {
 	switch req.kind {
 	case logBatcherRequestEnqueue:
-		recordsAdded, bytesAdded, compressedBytesAdded, oldestEnqueue := b.drainEnqueueRequestsIntoCompressedChunks(pending, req, nextReq)
+		recordsAdded, bytesAdded, compressedBytesAdded, oldestEnqueue := b.drainEnqueueRequestsIntoCompressedChunks(marshaler, sizeState, pending, req, nextReq)
 		*pendingRecords += recordsAdded
 		*pendingBytes += bytesAdded
 		*pendingCompressedBytes += compressedBytesAdded
@@ -581,12 +613,12 @@ func (b *backendLogBatcher) handleCompressedRequest(
 		}
 		if *pendingRecords >= b.settings.maxRecords || *pendingBytes >= b.settings.maxBytes {
 			b.telemetry.overflowTotal.Add(context.Background(), 1, metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint))))
-			if err := b.flushCompressed(context.Background(), marshaler, unmarshaler, pending, pendingRecords, pendingBytes, pendingCompressedBytes, logFlushReasonSize, timer, timerC); err != nil {
+			if err := b.flushCompressed(context.Background(), marshaler, unmarshaler, sizeState, pending, pendingRecords, pendingBytes, pendingCompressedBytes, logFlushReasonSize, timer, timerC); err != nil {
 				b.logger.Warn("failed to flush compressed log batch", zap.String("reason", logFlushReasonSize), zap.Error(err))
 			}
 		}
 	case logBatcherRequestFlushAndStop:
-		err := b.flushCompressed(req.ctx, marshaler, unmarshaler, pending, pendingRecords, pendingBytes, pendingCompressedBytes, req.reason, timer, timerC)
+		err := b.flushCompressed(req.ctx, marshaler, unmarshaler, sizeState, pending, pendingRecords, pendingBytes, pendingCompressedBytes, req.reason, timer, timerC)
 		req.done <- err
 		return true
 	}
@@ -594,6 +626,8 @@ func (b *backendLogBatcher) handleCompressedRequest(
 }
 
 func (b *backendLogBatcher) drainEnqueueRequestsIntoCompressedChunks(
+	marshaler *plog.ProtoMarshaler,
+	sizeState *compressedLogBatcherSizeState,
 	pending *[]compressedLogBatcherChunk,
 	first logBatcherRequest,
 	nextReq **logBatcherRequest,
@@ -609,7 +643,7 @@ func (b *backendLogBatcher) drainEnqueueRequestsIntoCompressedChunks(
 			return
 		}
 		recordCount += count
-		bytes += req.compressedChunk.uncompressedBytes
+		bytes += sizeState.addChunk(req.compressedChunk, marshaler)
 		compressedBytes += req.compressedChunk.compressedBytes
 		if oldestEnqueue == 0 || req.enqueuedAtUnixNano < oldestEnqueue {
 			oldestEnqueue = req.enqueuedAtUnixNano
@@ -646,13 +680,143 @@ func newCompressedLogBatcherChunk(marshaler *plog.ProtoMarshaler, codec *queuePa
 	}
 	encoded = append([]byte(nil), encoded...)
 	encoded = encoded[:len(encoded):len(encoded)]
+	sizingMetadata, sizingResources := newCompressedLogBatcherSizing(req.logs, marshaler)
 	return compressedLogBatcherChunk{
 		payload:               encoded,
 		records:               req.logs.LogRecordCount(),
 		uncompressedBytes:     len(payload),
 		compressedBytes:       len(encoded),
 		oldestEnqueueUnixNano: req.enqueuedAtUnixNano,
+		sizingResources:       sizingResources,
+		sizingMetadata:        sizingMetadata,
 	}, nil
+}
+
+func newCompressedLogBatcherSizing(logs plog.Logs, marshaler *plog.ProtoMarshaler) (plog.Logs, []compressedLogBatcherResourceSizing) {
+	metadata := plog.NewLogs()
+	resources := make([]compressedLogBatcherResourceSizing, 0, logs.ResourceLogs().Len())
+	for i := 0; i < logs.ResourceLogs().Len(); i++ {
+		srcRL := logs.ResourceLogs().At(i)
+		dstRL := metadata.ResourceLogs().AppendEmpty()
+		srcRL.Resource().CopyTo(dstRL.Resource())
+		dstRL.SetSchemaUrl(srcRL.SchemaUrl())
+
+		resource := compressedLogBatcherResourceSizing{resource: dstRL}
+		for j := 0; j < srcRL.ScopeLogs().Len(); j++ {
+			srcSL := srcRL.ScopeLogs().At(j)
+			recordsDeltaBytes := 0
+			for k := 0; k < srcSL.LogRecords().Len(); k++ {
+				recordsDeltaBytes += logProtoDeltaSize(marshaler.LogRecordSize(srcSL.LogRecords().At(k)))
+			}
+			if recordsDeltaBytes == 0 {
+				continue
+			}
+
+			dstSL := dstRL.ScopeLogs().AppendEmpty()
+			srcSL.Scope().CopyTo(dstSL.Scope())
+			dstSL.SetSchemaUrl(srcSL.SchemaUrl())
+			resource.scopes = append(resource.scopes, compressedLogBatcherScopeSizing{
+				scope:             dstSL,
+				recordsDeltaBytes: recordsDeltaBytes,
+			})
+		}
+		resources = append(resources, resource)
+	}
+	return metadata, resources
+}
+
+func newCompressedLogBatcherSizeState() *compressedLogBatcherSizeState {
+	return &compressedLogBatcherSizeState{metadata: plog.NewLogs()}
+}
+
+func (s *compressedLogBatcherSizeState) reset() {
+	s.metadata = plog.NewLogs()
+	s.resources = nil
+	s.bytes = 0
+}
+
+func (s *compressedLogBatcherSizeState) addChunk(chunk compressedLogBatcherChunk, marshaler *plog.ProtoMarshaler) int {
+	before := s.bytes
+	for _, resource := range chunk.sizingResources {
+		s.addResource(resource, marshaler)
+	}
+	return s.bytes - before
+}
+
+func (s *compressedLogBatcherSizeState) addResource(resource compressedLogBatcherResourceSizing, marshaler *plog.ProtoMarshaler) {
+	if len(resource.scopes) == 0 {
+		return
+	}
+
+	resourceIndex := s.findResource(resource.resource)
+	resourceIsNew := resourceIndex == -1
+	if resourceIsNew {
+		dstRL := s.metadata.ResourceLogs().AppendEmpty()
+		resource.resource.Resource().CopyTo(dstRL.Resource())
+		dstRL.SetSchemaUrl(resource.resource.SchemaUrl())
+		s.resources = append(s.resources, compressedLogBatcherResourceSizeState{
+			resource: dstRL,
+			size:     marshaler.ResourceLogsSize(dstRL),
+		})
+		resourceIndex = len(s.resources) - 1
+	}
+
+	oldResourceSize := s.resources[resourceIndex].size
+	for _, scope := range resource.scopes {
+		s.addScope(resourceIndex, scope, marshaler)
+	}
+	if resourceIsNew {
+		s.bytes += logProtoDeltaSize(s.resources[resourceIndex].size)
+		return
+	}
+	s.bytes += logProtoDeltaSize(s.resources[resourceIndex].size) - logProtoDeltaSize(oldResourceSize)
+}
+
+func (s *compressedLogBatcherSizeState) addScope(resourceIndex int, scope compressedLogBatcherScopeSizing, marshaler *plog.ProtoMarshaler) {
+	scopeIndex := s.findScope(resourceIndex, scope.scope)
+	if scopeIndex == -1 {
+		dstSL := s.resources[resourceIndex].resource.ScopeLogs().AppendEmpty()
+		scope.scope.Scope().CopyTo(dstSL.Scope())
+		dstSL.SetSchemaUrl(scope.scope.SchemaUrl())
+		scopeSize := marshaler.ScopeLogsSize(dstSL) + scope.recordsDeltaBytes
+		s.resources[resourceIndex].scopes = append(s.resources[resourceIndex].scopes, compressedLogBatcherScopeSizeState{
+			scope: dstSL,
+			size:  scopeSize,
+		})
+		s.resources[resourceIndex].size += logProtoDeltaSize(scopeSize)
+		return
+	}
+
+	oldScopeSize := s.resources[resourceIndex].scopes[scopeIndex].size
+	s.resources[resourceIndex].scopes[scopeIndex].size += scope.recordsDeltaBytes
+	newScopeSize := s.resources[resourceIndex].scopes[scopeIndex].size
+	s.resources[resourceIndex].size += logProtoDeltaSize(newScopeSize) - logProtoDeltaSize(oldScopeSize)
+}
+
+func (s *compressedLogBatcherSizeState) findResource(resource plog.ResourceLogs) int {
+	for i, existing := range s.resources {
+		if resourceLogsMatches(existing.resource, resource) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (s *compressedLogBatcherSizeState) findScope(resourceIndex int, scope plog.ScopeLogs) int {
+	for i, existing := range s.resources[resourceIndex].scopes {
+		if scopeLogsMatches(existing.scope, scope) {
+			return i
+		}
+	}
+	return -1
+}
+
+func logProtoDeltaSize(newItemSize int) int {
+	return 1 + newItemSize + protoSov(uint64(newItemSize))
+}
+
+func protoSov(x uint64) int {
+	return (bits.Len64(x|1) + 6) / 7
 }
 
 func (b *backendLogBatcher) newCompressedLogBatcherChunk(logs plog.Logs, enqueuedAtUnixNano int64) (compressedLogBatcherChunk, error) {
@@ -721,6 +885,7 @@ func (b *backendLogBatcher) flushCompressed(
 	ctx context.Context,
 	sizer *plog.ProtoMarshaler,
 	unmarshaler *plog.ProtoUnmarshaler,
+	sizeState *compressedLogBatcherSizeState,
 	pending *[]compressedLogBatcherChunk,
 	pendingRecords *int,
 	pendingBytes *int,
@@ -746,6 +911,7 @@ func (b *backendLogBatcher) flushCompressed(
 	*pendingRecords = 0
 	*pendingBytes = 0
 	*pendingCompressedBytes = 0
+	sizeState.reset()
 	b.pendingRecords.Store(0)
 	b.pendingBytes.Store(0)
 	b.pendingCompressedBytes.Store(0)
@@ -757,7 +923,7 @@ func (b *backendLogBatcher) flushCompressed(
 		var window []compressedLogBatcherChunk
 		var records int
 		var oldestUnixNano int64
-		window, drainedChunks, records, oldestUnixNano = nextCompressedLogBatcherWindow(drainedChunks, b.settings.maxRecords, b.settings.maxBytes)
+		window, drainedChunks, records, oldestUnixNano = nextCompressedLogBatcherWindow(drainedChunks, b.settings.maxRecords, b.settings.maxBytes, sizer)
 
 		b.payloadCodecMu.Lock()
 		drained, err := mergeCompressedLogBatcherChunks(unmarshaler, b.payloadCodec, window)
@@ -789,23 +955,23 @@ func (b *backendLogBatcher) flushCompressed(
 	return errs
 }
 
-func nextCompressedLogBatcherWindow(chunks []compressedLogBatcherChunk, maxRecords, maxBytes int) ([]compressedLogBatcherChunk, []compressedLogBatcherChunk, int, int64) {
+func nextCompressedLogBatcherWindow(chunks []compressedLogBatcherChunk, maxRecords, maxBytes int, sizer *plog.ProtoMarshaler) ([]compressedLogBatcherChunk, []compressedLogBatcherChunk, int, int64) {
 	records := 0
-	bytes := 0
 	var oldestUnixNano int64
+	sizeState := newCompressedLogBatcherSizeState()
 	end := 0
 	for end < len(chunks) {
 		chunk := chunks[end]
-		if end > 0 && (records+chunk.records > maxRecords || bytes+chunk.uncompressedBytes > maxBytes) {
+		sizeState.addChunk(chunk, sizer)
+		if end > 0 && (records+chunk.records > maxRecords || sizeState.bytes > maxBytes) {
 			break
 		}
 		records += chunk.records
-		bytes += chunk.uncompressedBytes
 		if oldestUnixNano == 0 || chunk.oldestEnqueueUnixNano < oldestUnixNano {
 			oldestUnixNano = chunk.oldestEnqueueUnixNano
 		}
 		end++
-		if records >= maxRecords || bytes >= maxBytes {
+		if records >= maxRecords || sizeState.bytes >= maxBytes {
 			break
 		}
 	}

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -5,6 +5,7 @@ package loadbalancingexporter
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -131,6 +132,148 @@ func TestLogBatcherMaxBytesUsesMergedPayloadSize(t *testing.T) {
 	require.NoError(t, p.Shutdown(t.Context()))
 	require.Len(t, sink.AllLogs(), 1)
 	assert.Equal(t, 2, sink.AllLogs()[0].LogRecordCount())
+}
+
+func TestCompressedLogBatcherChunkDoesNotRetainUncompressedPayload(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	logs := compressibleLogs(16000, 2048)
+	chunk, err := newCompressedLogBatcherChunk(&plog.ProtoMarshaler{}, codec, logBatcherRequest{
+		logs:               logs,
+		enqueuedAtUnixNano: time.Now().UnixNano(),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, logs.LogRecordCount(), chunk.records)
+	require.Greater(t, chunk.uncompressedBytes, chunk.compressedBytes*100)
+	require.Len(t, chunk.payload, chunk.compressedBytes)
+	require.Equal(t, len(chunk.payload), cap(chunk.payload), "compressed payload must not retain the uncompressed marshal buffer")
+
+	decoded, err := decodeCompressedLogBatcherChunk(&plog.ProtoUnmarshaler{}, codec, chunk)
+	require.NoError(t, err)
+	require.Equal(t, logs.LogRecordCount(), decoded.LogRecordCount())
+}
+
+func TestCompressedLogBatcherFlushPreservesLogsAndSplitsByMaxRecords(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	var mu sync.Mutex
+	var batchSizes []int
+	var bodies []string
+
+	batcher, err := newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:         3,
+		maxBytes:           1 << 20,
+		flushInterval:      time.Hour,
+		payloadCompression: QueuePayloadCompressionZstd,
+	}, func(_ context.Context, _ *wrappedExporter, ld plog.Logs, _ string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		batchSizes = append(batchSizes, ld.LogRecordCount())
+		for i := 0; i < ld.ResourceLogs().Len(); i++ {
+			rl := ld.ResourceLogs().At(i)
+			for j := 0; j < rl.ScopeLogs().Len(); j++ {
+				records := rl.ScopeLogs().At(j).LogRecords()
+				for k := 0; k < records.Len(); k++ {
+					bodies = append(bodies, records.At(k).Body().Str())
+				}
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	exp := newWrappedExporter(newNopMockLogsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, sharedScopeLogsWithoutTraceIDs("one", "two")))
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, sharedScopeLogsWithoutTraceIDs("three", "four")))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(batchSizes) == 2
+	}, time.Second, 10*time.Millisecond)
+	require.NoError(t, batcher.Shutdown(t.Context()))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []int{2, 2}, batchSizes)
+	require.ElementsMatch(t, []string{"one", "two", "three", "four"}, bodies)
+}
+
+func TestCompressedLogBatcherEnqueueStoresCompressedRequests(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	sendStarted := make(chan struct{}, 1)
+	unblockSend := make(chan struct{})
+
+	batcher, err := newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:         1,
+		maxBytes:           1 << 20,
+		flushInterval:      time.Hour,
+		payloadCompression: QueuePayloadCompressionZstd,
+	}, func(context.Context, *wrappedExporter, plog.Logs, string) error {
+		select {
+		case sendStarted <- struct{}{}:
+		default:
+		}
+		<-unblockSend
+		return nil
+	})
+	require.NoError(t, err)
+	defer func() {
+		close(unblockSend)
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	}()
+
+	exp := newWrappedExporter(newNopMockLogsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, simpleLogs()))
+	select {
+	case <-sendStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected first batch to block in send")
+	}
+
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, compressibleLogs(16, 1024)))
+
+	batcher.mu.RLock()
+	backend := batcher.backends["endpoint-1:4317"]
+	batcher.mu.RUnlock()
+	require.NotNil(t, backend)
+
+	select {
+	case req := <-backend.requests:
+		require.Zero(t, req.logs.LogRecordCount())
+		require.Equal(t, 16, req.compressedChunk.records)
+		require.Positive(t, req.compressedChunk.compressedBytes)
+		require.Less(t, req.compressedChunk.compressedBytes, req.compressedChunk.uncompressedBytes)
+	case <-time.After(time.Second):
+		t.Fatal("expected queued request to stay in compressed form while backend send is blocked")
+	}
+}
+
+func TestCompressedLogBatcherSnapshotTracksCompressedPendingBytes(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	batcher, err := newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:         20000,
+		maxBytes:           64 << 20,
+		flushInterval:      time.Hour,
+		payloadCompression: QueuePayloadCompressionZstd,
+	}, func(context.Context, *wrappedExporter, plog.Logs, string) error {
+		return nil
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context()))) }()
+
+	exp := newWrappedExporter(newNopMockLogsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, compressibleLogs(256, 1024)))
+
+	require.Eventually(t, func() bool {
+		for _, pending := range batcher.snapshotPending().pending {
+			if pending.endpoint == "endpoint-1:4317" && pending.records == 256 {
+				return pending.compressedBytes > 0 && pending.bytes > pending.compressedBytes
+			}
+		}
+		return false
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestLogBatcherDoesNotBlockOtherBackends(t *testing.T) {
@@ -608,5 +751,20 @@ func logsWithTraceIDs(ids ...pcommon.TraceID) plog.Logs {
 func sizedLogWithID(id pcommon.TraceID, size int) plog.Logs {
 	logs := simpleLogWithID(id)
 	logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().SetStr(string(make([]byte, size)))
+	return logs
+}
+
+func compressibleLogs(records, bodySize int) plog.Logs {
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("resource", "shared")
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.Scope().SetName("shared-scope")
+	body := string(make([]byte, bodySize))
+	for i := range records {
+		rec := sl.LogRecords().AppendEmpty()
+		rec.Body().SetStr(body)
+		rec.SetTraceID(pcommon.TraceID([16]byte{byte(i >> 8), byte(i)}))
+	}
 	return logs
 }

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -200,6 +200,46 @@ func TestCompressedLogBatcherFlushPreservesLogsAndSplitsByMaxRecords(t *testing.
 	require.ElementsMatch(t, []string{"one", "two", "three", "four"}, bodies)
 }
 
+func TestCompressedLogBatcherMaxBytesUsesMergedPayloadSize(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	var calls atomic.Int64
+
+	first := sharedResourceScopeLog("first")
+	second := sharedResourceScopeLog("second")
+	sizer := &plog.ProtoMarshaler{}
+	separateBytes := sizer.LogsSize(first) + sizer.LogsSize(second)
+	mergedBytes := sizer.LogsSize(mergeLogs(sharedResourceScopeLog("first"), sharedResourceScopeLog("second")))
+	require.Greater(t, separateBytes, mergedBytes)
+
+	batcher, err := newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:         100,
+		maxBytes:           mergedBytes + 1,
+		flushInterval:      time.Hour,
+		payloadCompression: QueuePayloadCompressionZstd,
+	}, func(context.Context, *wrappedExporter, plog.Logs, string) error {
+		calls.Add(1)
+		return nil
+	})
+	require.NoError(t, err)
+	shutdown := false
+	t.Cleanup(func() {
+		if !shutdown {
+			require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+		}
+	})
+
+	exp := newWrappedExporter(newNopMockLogsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, sharedResourceScopeLog("first")))
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, sharedResourceScopeLog("second")))
+	require.Never(t, func() bool {
+		return calls.Load() > 0
+	}, 50*time.Millisecond, 5*time.Millisecond)
+
+	require.NoError(t, batcher.Shutdown(t.Context()))
+	shutdown = true
+	require.Equal(t, int64(1), calls.Load())
+}
+
 func TestCompressedLogBatcherEnqueueStoresCompressedRequests(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	sendStarted := make(chan struct{}, 1)

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -240,6 +240,127 @@ func TestCompressedLogBatcherMaxBytesUsesMergedPayloadSize(t *testing.T) {
 	require.Equal(t, int64(1), calls.Load())
 }
 
+func TestCompressedLogBatcherFlushSplitsOnMaxBytes(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	var mu sync.Mutex
+	var batchSizes []int
+	var bodies []string
+
+	sizer := &plog.ProtoMarshaler{}
+	firstTwo := mergeLogs(sharedResourceScopeLog("one"), sharedResourceScopeLog("two"))
+	allThree := mergeLogs(mergeLogs(sharedResourceScopeLog("one"), sharedResourceScopeLog("two")), sharedResourceScopeLog("three"))
+	maxBytes := sizer.LogsSize(firstTwo) + 1
+	require.Greater(t, sizer.LogsSize(allThree), maxBytes)
+
+	batcher, err := newLogBatcher(ts.Logger, ts.TelemetrySettings, logBatcherSettings{
+		maxRecords:         100,
+		maxBytes:           maxBytes,
+		flushInterval:      time.Hour,
+		payloadCompression: QueuePayloadCompressionZstd,
+	}, func(_ context.Context, _ *wrappedExporter, ld plog.Logs, _ string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		batchSizes = append(batchSizes, ld.LogRecordCount())
+		for i := 0; i < ld.ResourceLogs().Len(); i++ {
+			rl := ld.ResourceLogs().At(i)
+			for j := 0; j < rl.ScopeLogs().Len(); j++ {
+				records := rl.ScopeLogs().At(j).LogRecords()
+				for k := 0; k < records.Len(); k++ {
+					bodies = append(bodies, records.At(k).Body().Str())
+				}
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	exp := newWrappedExporter(newNopMockLogsExporter(), "endpoint-1:4317")
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, sharedResourceScopeLog("one")))
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, sharedResourceScopeLog("two")))
+	require.NoError(t, batcher.Enqueue(t.Context(), "endpoint-1:4317", exp, sharedResourceScopeLog("three")))
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(batchSizes) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []int{2, 1}, batchSizes)
+	require.ElementsMatch(t, []string{"one", "two", "three"}, bodies)
+}
+
+func TestCompressedLogBatcherFlushRecordsDecodeErrors(t *testing.T) {
+	telemetry := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetry.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	telemetrySettings := telemetry.NewTelemetrySettings()
+	batcherTelemetry, err := newLogBatcherTelemetry(telemetrySettings)
+	require.NoError(t, err)
+	t.Cleanup(batcherTelemetry.shutdown)
+
+	backend := &backendLogBatcher{
+		endpoint:     "endpoint-1:4317",
+		logger:       telemetrySettings.Logger,
+		settings:     logBatcherSettings{maxRecords: 100, maxBytes: 1 << 20, flushInterval: time.Hour},
+		telemetry:    batcherTelemetry,
+		payloadCodec: newQueuePayloadCodec(QueuePayloadCompressionZstd),
+		send: func(context.Context, *wrappedExporter, plog.Logs, string) error {
+			t.Fatal("send should not be called when a compressed chunk cannot be decoded")
+			return nil
+		},
+	}
+	t.Cleanup(func() { require.NoError(t, backend.payloadCodec.Close()) })
+
+	pending := []compressedLogBatcherChunk{{
+		payload:               []byte("not-a-valid-compressed-payload"),
+		records:               2,
+		uncompressedBytes:     100,
+		compressedBytes:       30,
+		oldestEnqueueUnixNano: time.Now().UnixNano(),
+	}}
+	pendingRecords := 2
+	pendingBytes := 100
+	pendingCompressedBytes := 30
+	timer := time.NewTimer(time.Hour)
+	require.True(t, timer.Stop())
+	var timerC <-chan time.Time
+
+	err = backend.flushCompressed(
+		t.Context(),
+		&plog.ProtoMarshaler{},
+		&plog.ProtoUnmarshaler{},
+		newCompressedLogBatcherSizeState(),
+		&pending,
+		&pendingRecords,
+		&pendingBytes,
+		&pendingCompressedBytes,
+		logFlushReasonSize,
+		timer,
+		&timerC,
+	)
+	require.Error(t, err)
+	require.Zero(t, pendingRecords)
+	require.Zero(t, pendingBytes)
+	require.Zero(t, pendingCompressedBytes)
+
+	require.Eventually(t, func() bool {
+		flushErrors, flushErr := telemetry.GetMetric("otelcol_loadbalancer_log_batch_flush_errors")
+		droppedRecords, droppedErr := telemetry.GetMetric("otelcol_loadbalancer_log_batch_dropped_records")
+		if flushErr != nil || droppedErr != nil {
+			return false
+		}
+		flushTotal, flushOK := sumInt64Metric(flushErrors)
+		droppedTotal, droppedOK := sumInt64Metric(droppedRecords)
+		return flushOK && droppedOK && flushTotal == 1 && droppedTotal == 2
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestCompressedLogBatcherEnqueueStoresCompressedRequests(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	sendStarted := make(chan struct{}, 1)
@@ -665,6 +786,18 @@ func findGaugePointValue(t *testing.T, dps []metricdata.DataPoint[int64], attrs 
 
 	t.Fatalf("gauge datapoint with attrs %v not found", attrs)
 	return 0
+}
+
+func sumInt64Metric(metric metricdata.Metrics) (int64, bool) {
+	sum, ok := metric.Data.(metricdata.Sum[int64])
+	if !ok {
+		return 0, false
+	}
+	var total int64
+	for _, dp := range sum.DataPoints {
+		total += dp.Value
+	}
+	return total, true
 }
 
 func TestLogBatcherRemoveRespectsContextWhileWaitingForInflight(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -60,13 +60,15 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 		logger:       params.Logger,
 	}
 	if cfg.(*Config).LogBatcher.Enabled {
+		logBatcherCfg := cfg.(*Config).LogBatcher
 		logExporter.batcher, err = newLogBatcher(
 			params.Logger,
 			params.TelemetrySettings,
 			logBatcherSettings{
-				maxRecords:    cfg.(*Config).LogBatcher.MaxRecords,
-				maxBytes:      cfg.(*Config).LogBatcher.MaxBytes,
-				flushInterval: cfg.(*Config).LogBatcher.FlushInterval,
+				maxRecords:         logBatcherCfg.MaxRecords,
+				maxBytes:           logBatcherCfg.MaxBytes,
+				flushInterval:      logBatcherCfg.FlushInterval,
+				payloadCompression: logBatcherCfg.PayloadCompression,
 			},
 			logExporter.consumeBatch,
 		)


### PR DESCRIPTION
exporter/loadbalancing: Compress log batcher chunks

Adds opt-in in-memory compression for loadbalancing exporter log batcher chunks so backend queue waits and pending batches do not retain full uncompressed OTLP payloads.

Description
- Add `log_batcher.payload_compression` with `none`, `snappy`, and `zstd` validation/defaults.
- Compress log batcher requests at enqueue time and decode bounded windows only when flushing.
- Add pending compressed-byte telemetry, tests, docs, and changelog entry.

Validation
- `make fmt`
- `make lint`
- `make test`
- `make chlog-validate`

Linear: SAW-7312

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in in-memory compression for `exporter/loadbalancingexporter` log batcher chunks to reduce memory under backpressure and enforce precise `max_bytes` with merged-size accounting. Adds pending compressed-bytes telemetry and safe handling of corrupted chunks. Addresses Linear SAW-7312.

- New Features
  - Config: `log_batcher.payload_compression` with `none`, `snappy`, or `zstd` (default `none`) and validation.
  - Behavior: requests compress at enqueue; flush decodes bounded windows by `max_records`/`max_bytes` and merges by move.
  - Size accounting: `max_bytes` uses merged-size estimation for exact windows in compressed mode.
  - Telemetry: `otelcol_loadbalancer_log_batch_pending_compressed_bytes` gauge.
  - Robustness: corrupted compressed payloads are dropped and counted in flush error/dropped record metrics.
  - Docs: README example updated with `payload_compression`.

- Migration
  - Off by default; no breaking changes.
  - To enable, set `payload_compression: zstd` under `log_batcher` for the load balancing exporter.

<sup>Written for commit f6ae2c4033ea4bbae3f0395531b0c75aa05f647c. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/49">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional in-memory compression for log batcher chunks via log_batcher.payload_compression (none, snappy, zstd; default: none). Queued and pending batches remain compressed until flush, reducing memory use.
  * New observable metric for pending compressed bytes to monitor memory usage.

* **Documentation**
  * Updated loadbalancing exporter docs with the payload_compression option and example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new optional compression path to the loadbalancing logs batcher, changing how pending batches are stored, sized, and flushed; bugs here could impact log delivery, batching boundaries, or memory usage under backpressure.
> 
> **Overview**
> Adds an opt-in `log_batcher.payload_compression` setting (`none`/`snappy`/`zstd`) to keep per-backend queued/pending log batches compressed in memory until flush, reducing retained heap when backends are slow.
> 
> Updates the log batcher to compress at enqueue, track pending *uncompressed vs compressed* bytes (new `otelcol_loadbalancer_log_batch_pending_compressed_bytes` gauge), and decode/merge bounded windows only during flush while still honoring `max_records`/`max_bytes` based on merged OTLP size; includes config validation/defaults, README + example update, changelog entry, and expanded tests covering reroute behavior, sizing/splitting, and decode-error drops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ae2c4033ea4bbae3f0395531b0c75aa05f647c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->