### PR TITLE
loadbalancingexporter: add endpoint active probes

### DIFF
--- a/.chloggen/saw-7374-loadbalancing-active-probe.yaml
+++ b/.chloggen/saw-7374-loadbalancing-active-probe.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add optional active TCP probes for loadbalancing exporter endpoint health.
+issues: [7374]
+subtext: |-
+  Set `endpoint_health.active_probe.enabled` to exclude per-pod-unreachable backends after configurable fall failures and recover them after configurable rise successes.
+change_logs: [user]

--- a/docs/superpowers/specs/2026-05-01-saw-7374-lb-reachability-design.md
+++ b/docs/superpowers/specs/2026-05-01-saw-7374-lb-reachability-design.md
@@ -57,8 +57,13 @@ Create an isolated Sawmills staging canary namespace/deployment that mimics the 
 
 Canary shape:
 
-- LB collector pods with current `endpoint_health` enabled.
-- Multiple backend endpoints behind the same resolver shape used by the LB exporter.
+- LB collector pods replaying the Gate 1 generated BigID LB config/version as the canary baseline.
+- Preserve the generated exporter shape from Gate 1, including `protocol.otlp`
+  timeout, `retry_on_failure`, `sending_queue`, log/metric batcher settings,
+  routing settings, resolver settings, `endpoint_health`, and
+  `forwarding_health.backend_usability`.
+- Change only isolated-resource details: namespace/resource names, backend endpoint targets, fault-injection targets, credentials/secrets needed for canary traffic, and labels/metadata.
+- Multiple backend endpoints behind the same resolver type and timing settings used by the BigID LB exporter.
 - A controlled subset of backend endpoints that times out from the LB pod while at least one other backend remains reachable.
 - Traffic directed only at the canary LB.
 
@@ -66,6 +71,7 @@ Validate current reactive `endpoint_health` before writing active-probe code.
 
 Pass/fail evidence must include:
 
+- A config diff/checksum showing the canary replayed the Gate 1 LB config with only the expected isolated-resource deltas.
 - `otelcol_loadbalancer_backend_quarantine_total` increments for the known-bad endpoint.
 - `otelcol_loadbalancer_backend_state{state="quarantined"}` is emitted for the bad endpoint.
 - Eligible backend count drops after quarantine trips / after the first endpoint-local failure.
@@ -78,6 +84,7 @@ Gate 2 outcomes:
 
 - If reactive quarantine is sufficient, close SAW-7374 with evidence and no exporter code.
 - If reactive quarantine is not sufficient because customer data must fail first and causes rejects/refusals before quarantine stabilizes routing, implement active local probing.
+- If the canary cannot replay the Gate 1 LB config/version with only isolated-resource deltas, Gate 2 is inconclusive and cannot close SAW-7374 without either replay parity or a documented config/rollout fix.
 
 Clean up the canary namespace and any temporary resources after the test.
 
@@ -117,6 +124,18 @@ The active probe state should feed the existing endpoint-health eligibility mode
 - If zero locally healthy backends remain, endpoint health should preserve fail-open behavior rather than blackholing telemetry.
 - `forwarding_health.backend_usability` remains the mechanism that drains a bad LB pod when locally eligible backends are below threshold.
 
+Config validation:
+
+- `type` must be a known probe type. Initially, only `tcp_connect` is valid.
+- `interval` and `timeout` must be positive durations.
+- `timeout` must be shorter than `interval`.
+- `jitter` must parse as a percentage from `0%` through `100%`.
+- `max_concurrency` must be positive.
+- `fall` and `rise` must be positive integers.
+- Both exporter config validation and collectors-service LaunchDarkly/generator
+  validation must reject invalid active-probe values before rendering a
+  collector config.
+
 Probe load controls:
 
 - Add jitter so LB pods do not probe endpoints in lockstep.
@@ -148,7 +167,7 @@ Config propagation repo: `collectors-service`.
 Likely generator changes:
 
 - Extend `LBEndpointHealthConfig` with `ActiveProbe`.
-- Validate durations, jitter, and concurrency.
+- Validate every active-probe field before rendering, including probe `type`, durations, jitter, concurrency, `fall`, and `rise`.
 - Version-gate active-probe rendering to the first collector version that contains the exporter change.
 - Add LaunchDarkly parsing/generator tests.
 
@@ -166,19 +185,27 @@ Use TDD for implementation.
 Exporter tests should prove:
 
 - active probe config loads and validates,
+- invalid probe `type`, `fall`, and `rise` values fail validation,
 - unhealthy local endpoints are excluded from routing when healthy alternatives exist,
+- after `rise` successful probes, a recovered endpoint is re-added to the eligible routing ring,
 - normal consistent hashing is preserved when all endpoints are healthy,
 - zero locally healthy endpoints fail open by default,
 - resolver-change and exporter-stopping reroute behavior remains intact,
 - probe loops stop cleanly on shutdown.
 
-Integration-style test should simulate multiple resolver backends where one endpoint times out from the LB pod. After active-probe `fall`, no customer telemetry should be sent to the unhealthy endpoint while another healthy backend exists.
+Integration-style test should simulate multiple resolver backends where one
+endpoint times out from the LB pod. After active-probe `fall`, no customer
+telemetry should be sent to the unhealthy endpoint while another healthy backend
+exists. After the endpoint becomes reachable again and reaches `rise` successful
+probes, the test must prove the endpoint is eligible again and the routing ring
+is rebuilt so traffic can return to it.
 
 Collectors-service tests should prove:
 
 - LaunchDarkly JSON parses into the new active-probe config,
 - rendered LB exporter config includes active-probe fields only for supported collector versions,
-- invalid intervals, timeouts, jitter, and concurrency fail generation clearly,
+- invalid intervals, timeouts, jitter, concurrency, `type`, `fall`, and `rise` fail generation clearly,
+- negative cases include at least `fall: 0`, `rise: -1`, and an unknown probe `type`,
 - omitted active-probe config preserves current output.
 
 ## Operational Safety

--- a/docs/superpowers/specs/2026-05-01-saw-7374-lb-reachability-design.md
+++ b/docs/superpowers/specs/2026-05-01-saw-7374-lb-reachability-design.md
@@ -77,13 +77,21 @@ Pass/fail evidence must include:
 - Eligible backend count drops after quarantine trips / after the first endpoint-local failure.
 - `otelcol_loadbalancer_backend_reroute_total{result="success"}` increases while a reachable backend exists.
 - `otelcol_loadbalancer_backend_reroute_total{result="failure"}` does not keep growing while a reachable backend exists.
-- After quarantine, there are no sustained reject logs or receiver refusals for the same locally unreachable endpoint.
+- The persistent partition remains in place for at least two
+  `endpoint_health.quarantine_duration` expiry cycles, plus resolver poll and
+  `forwarding_health.backend_usability` poll intervals.
+- Across those captured expiry cycles, there are no recurring reject logs or
+  receiver refusals when the exporter re-admits the same locally unreachable
+  endpoint.
 - `otelcol_loadbalancer_backend_fail_open_total` increments only when every candidate backend is bad or no eligible backend remains.
 
 Gate 2 outcomes:
 
 - If reactive quarantine is sufficient, close SAW-7374 with evidence and no exporter code.
 - If reactive quarantine is not sufficient because customer data must fail first and causes rejects/refusals before quarantine stabilizes routing, implement active local probing.
+- If persistent partial partition rejects/refusals recur after quarantine expiry
+  re-admits the bad endpoint, reactive quarantine is insufficient and active
+  local probing is required.
 - If the canary cannot replay the Gate 1 LB config/version with only isolated-resource deltas, Gate 2 is inconclusive and cannot close SAW-7374 without either replay parity or a documented config/rollout fix.
 
 Clean up the canary namespace and any temporary resources after the test.
@@ -121,6 +129,13 @@ The active probe state should feed the existing endpoint-health eligibility mode
 - A backend becomes locally unhealthy after `fall` failed probes.
 - A backend becomes locally healthy again after `rise` successful probes.
 - Healthy/unhealthy probe state must update the same eligible routing ring used by reactive quarantine.
+- Probe unhealthy/healthy transitions must update the existing
+  `otelcol_loadbalancer_backend_state` series so
+  `forwarding_health.backend_usability` sees the same eligible/quarantined
+  counts that routing uses.
+- Probe-driven exclusion and recovery must also use the existing
+  quarantine/unquarantine/fail-open signal family, with reason labels if needed,
+  rather than only emitting probe-specific metrics.
 - If zero locally healthy backends remain, endpoint health should preserve fail-open behavior rather than blackholing telemetry.
 - `forwarding_health.backend_usability` remains the mechanism that drains a bad LB pod when locally eligible backends are below threshold.
 
@@ -145,8 +160,13 @@ Probe load controls:
 
 Metrics:
 
-- Reuse existing backend state/quarantine/reroute/fail-open metrics where possible.
-- Add probe-specific metrics only if needed to debug probe behavior, such as probe failures and latency by low-cardinality reason/state.
+- Probe state changes must feed existing backend state/quarantine/unquarantine
+  and fail-open metrics used by routing and `forwarding_health`.
+- Add probe-specific metrics only as supplemental debugging signals, such as
+  probe failures and latency by low-cardinality reason/state.
+- If implementation cannot reuse those existing metrics directly, update
+  `forwarding_health.backend_usability` parsing in the same change so readiness
+  still derives from the active-probe-aware eligible backend set.
 
 ## Code Boundaries If Active Probe Is Needed
 
@@ -185,9 +205,13 @@ Use TDD for implementation.
 Exporter tests should prove:
 
 - active probe config loads and validates,
-- invalid probe `type`, `fall`, and `rise` values fail validation,
+- invalid probe `type`, `interval`, `timeout`, `timeout >= interval`,
+  `jitter`, `max_concurrency`, `fall`, and `rise` values fail exporter
+  validation,
 - unhealthy local endpoints are excluded from routing when healthy alternatives exist,
 - after `rise` successful probes, a recovered endpoint is re-added to the eligible routing ring,
+- probe state transitions update existing backend state/quarantine/unquarantine
+  and fail-open signals used by forwarding-health readiness,
 - normal consistent hashing is preserved when all endpoints are healthy,
 - zero locally healthy endpoints fail open by default,
 - resolver-change and exporter-stopping reroute behavior remains intact,

--- a/docs/superpowers/specs/2026-05-01-saw-7374-lb-reachability-design.md
+++ b/docs/superpowers/specs/2026-05-01-saw-7374-lb-reachability-design.md
@@ -1,0 +1,191 @@
+# SAW-7374 Collector LB Reachability Design
+
+## Goal
+
+Make collector load-balancer routing degrade safely when Kubernetes says backend pods are ready but an individual LB pod cannot reach some of those backend endpoints.
+
+The work is evidence-gated:
+
+1. Prove the real BigID staging configuration that was running during the May 1 failure.
+2. Reproduce the partial-reachability behavior in an isolated Sawmills staging canary.
+3. Implement active local probing only if existing reactive `endpoint_health` is insufficient.
+
+BigID staging is read-only for this task. Do not change its config, deploy into it, or inject failures there. Production is out of scope.
+
+## Current Behavior
+
+`loadbalancingexporter` already has `endpoint_health`.
+
+When enabled, it:
+
+- records resolver-present endpoints as present,
+- quarantines endpoints after endpoint-local export failures,
+- rebuilds the eligible routing ring without quarantined endpoints,
+- reroutes failed telemetry once when `reroute_on_failure` is enabled,
+- fails open if every resolver-present endpoint is quarantined,
+- emits backend state, quarantine, reroute, and fail-open metrics.
+
+`collectors-service` already renders the existing `endpoint_health` config through the LaunchDarkly-backed LB queue config path. `sawmills-collector` already has `forwarding_health.backend_usability` so LB readiness can fail when eligible backends fall below a configured threshold or fail-open/reroute failures grow.
+
+Do not add a separate `local_backend_health` surface. Any new behavior should extend `endpoint_health`.
+
+## Gate 1: BigID Staging Evidence
+
+Collect read-only evidence from the real BigID `staging-us-east-1` deployment/revision implicated by SAW-7374.
+
+Capture:
+
+- collector image/version,
+- Helm chart and revision,
+- actual generated LB collector config,
+- every rendered `endpoint_health` field,
+- `otlp_timeout`,
+- resolver settings, including DNS interval/timeout or any Kubernetes resolver behavior,
+- `forwarding_health.backend_usability`,
+- relevant LB logs and metrics around retries/rejects if still available.
+
+Source of truth must be the generated live config and runtime state for the impacted deployment/revision, not only LaunchDarkly defaults.
+
+Gate 1 outcomes:
+
+- If `endpoint_health` or backend-usability settings were disabled, missing, version-gated out, or misrendered, stop implementation and document a rollout/config fix.
+- If config was present and sane, continue to Gate 2.
+
+## Gate 2: Isolated Staging Canary
+
+Create an isolated Sawmills staging canary namespace/deployment that mimics the BigID failure mode without touching BigID.
+
+Canary shape:
+
+- LB collector pods with current `endpoint_health` enabled.
+- Multiple backend endpoints behind the same resolver shape used by the LB exporter.
+- A controlled subset of backend endpoints that times out from the LB pod while at least one other backend remains reachable.
+- Traffic directed only at the canary LB.
+
+Validate current reactive `endpoint_health` before writing active-probe code.
+
+Pass/fail evidence must include:
+
+- `otelcol_loadbalancer_backend_quarantine_total` increments for the known-bad endpoint.
+- `otelcol_loadbalancer_backend_state{state="quarantined"}` is emitted for the bad endpoint.
+- Eligible backend count drops after quarantine trips / after the first endpoint-local failure.
+- `otelcol_loadbalancer_backend_reroute_total{result="success"}` increases while a reachable backend exists.
+- `otelcol_loadbalancer_backend_reroute_total{result="failure"}` does not keep growing while a reachable backend exists.
+- After quarantine, there are no sustained reject logs or receiver refusals for the same locally unreachable endpoint.
+- `otelcol_loadbalancer_backend_fail_open_total` increments only when every candidate backend is bad or no eligible backend remains.
+
+Gate 2 outcomes:
+
+- If reactive quarantine is sufficient, close SAW-7374 with evidence and no exporter code.
+- If reactive quarantine is not sufficient because customer data must fail first and causes rejects/refusals before quarantine stabilizes routing, implement active local probing.
+
+Clean up the canary namespace and any temporary resources after the test.
+
+## Active Probe Design If Needed
+
+Extend `endpoint_health` with optional active local probing.
+
+Config shape:
+
+```yaml
+endpoint_health:
+  enabled: true
+  reroute_on_failure: true
+  active_probe:
+    enabled: true
+    type: tcp_connect
+    interval: 5s
+    timeout: 250ms
+    jitter: 20%
+    max_concurrency: 4
+    fall: 2
+    rise: 2
+```
+
+Default probe semantics:
+
+- Use `tcp_connect` to the exact backend export endpoint and port used by the loadbalancing exporter.
+- Do not use gRPC health checks by default.
+- Do not send telemetry writes as probes.
+- Keep the export path fail-open by default.
+
+The active probe state should feed the existing endpoint-health eligibility model:
+
+- A backend becomes locally unhealthy after `fall` failed probes.
+- A backend becomes locally healthy again after `rise` successful probes.
+- Healthy/unhealthy probe state must update the same eligible routing ring used by reactive quarantine.
+- If zero locally healthy backends remain, endpoint health should preserve fail-open behavior rather than blackholing telemetry.
+- `forwarding_health.backend_usability` remains the mechanism that drains a bad LB pod when locally eligible backends are below threshold.
+
+Probe load controls:
+
+- Add jitter so LB pods do not probe endpoints in lockstep.
+- Enforce `max_concurrency`.
+- Keep default interval conservative.
+- Allow faster intervals only by explicit per-customer/canary config.
+
+Metrics:
+
+- Reuse existing backend state/quarantine/reroute/fail-open metrics where possible.
+- Add probe-specific metrics only if needed to debug probe behavior, such as probe failures and latency by low-cardinality reason/state.
+
+## Code Boundaries If Active Probe Is Needed
+
+Primary repo: `sawmills-collector-contrib`.
+
+Likely exporter changes:
+
+- Extend `EndpointHealthConfig` and config schema.
+- Add validation/defaults for `active_probe`.
+- Add an endpoint health probe loop owned by `loadBalancer` lifecycle.
+- Feed probe state into the endpoint-health manager without duplicating routing state.
+- Rebuild the eligible ring when probe state changes.
+- Preserve resolver-change and exporter-stopping reroute behavior.
+- Preserve current behavior when `active_probe.enabled` is false.
+
+Config propagation repo: `collectors-service`.
+
+Likely generator changes:
+
+- Extend `LBEndpointHealthConfig` with `ActiveProbe`.
+- Validate durations, jitter, and concurrency.
+- Version-gate active-probe rendering to the first collector version that contains the exporter change.
+- Add LaunchDarkly parsing/generator tests.
+
+Runtime bundle repo: `sawmills-collector`.
+
+Likely release changes:
+
+- Bump the loadbalancingexporter fork after exporter merge.
+- Update the minimum collector version constant in collectors-service after release.
+
+## Testing
+
+Use TDD for implementation.
+
+Exporter tests should prove:
+
+- active probe config loads and validates,
+- unhealthy local endpoints are excluded from routing when healthy alternatives exist,
+- normal consistent hashing is preserved when all endpoints are healthy,
+- zero locally healthy endpoints fail open by default,
+- resolver-change and exporter-stopping reroute behavior remains intact,
+- probe loops stop cleanly on shutdown.
+
+Integration-style test should simulate multiple resolver backends where one endpoint times out from the LB pod. After active-probe `fall`, no customer telemetry should be sent to the unhealthy endpoint while another healthy backend exists.
+
+Collectors-service tests should prove:
+
+- LaunchDarkly JSON parses into the new active-probe config,
+- rendered LB exporter config includes active-probe fields only for supported collector versions,
+- invalid intervals, timeouts, jitter, and concurrency fail generation clearly,
+- omitted active-probe config preserves current output.
+
+## Operational Safety
+
+- No production changes in this task.
+- No BigID staging mutations.
+- Canary fault injection only in isolated Sawmills staging resources.
+- Feature disabled by default.
+- Rollout controlled by collectors-service / LaunchDarkly.
+- Document Gate 1 and Gate 2 evidence back on SAW-7374 before any code PR is considered complete.

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -79,7 +79,7 @@ The `loadbalancingexporter` will, irrespective of the chosen resolver (`static`,
 * When using `k8s`, `dns`, and likely future resolvers, topology changes are eventually reflected in the `loadbalancingexporter`. The `k8s` resolver will update more quickly than `dns`, but a window of time in which the true topology doesn't match the view of the `loadbalancingexporter` remains.
 * Resiliency options 1 (`timeout`, `retry_on_failure` and `sending_queue` settings in `loadbalancing` section) - are useful for highly elastic environment (like k8s), where list of resolved endpoints frequently changed due to deployments, scale-up or scale-down events. In case of permanent change of list of resolved exporters this options provide capability to re-route data into new set of healthy backends. Disabled by default.
 * Resiliency options 2 (`timeout`, `retry_on_failure` and `sending_queue` settings in `otlp` section) - are useful for temporary problems with specific backend, like network flukes. Persistent Queue is NOT supported here as all sub-exporter shares the same `sending_queue` configuration, including `storage`. Enabled by default.
-* The `endpoint_health` option can be enabled to quarantine a resolver-present backend after the first endpoint-local transport failure. When `reroute_on_failure` is enabled, the failed telemetry is rerouted once to another eligible backend, which can temporarily break routing affinity to preserve availability. If every resolver-present backend is quarantined, endpoint health fails open and keeps those endpoints eligible so traffic is not blackholed.
+* The `endpoint_health` option can be enabled to quarantine a resolver-present backend after the first endpoint-local transport failure. When `reroute_on_failure` is enabled, the failed telemetry is rerouted once to another eligible backend, which can temporarily break routing affinity to preserve availability. If every resolver-present backend is quarantined, endpoint health fails open and keeps those endpoints eligible so traffic is not blackholed. `endpoint_health.active_probe` can also be enabled to locally test backend reachability with TCP connects before customer telemetry is routed there.
 
 Unfortunately, data loss is still possible for any resolver type if all of the exporter's targets remains unavailable once redelivery is exhausted. Due consideration needs to be given to the exporter queue and retry configuration when running in a highly elastic environment.
 
@@ -131,6 +131,15 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `quarantine_duration` keeps a backend out of the eligible routing ring for this duration after an endpoint-local failure. Default: `30s`.
   * `reroute_on_failure` reroutes failed telemetry once to another eligible backend when the failure is endpoint-local. Default: `true`.
   * `max_reroute_attempts` limits endpoint-failure reroute attempts. Default: `1`.
+  * `active_probe` actively checks every resolver-present backend from the local exporter before routing customer telemetry to it. It is disabled by default and fails open if every backend is locally unhealthy.
+    * `enabled` turns active probing on or off. Default: `false`.
+    * `type` is the probe type. Only `tcp_connect` is currently supported. Default: `tcp_connect`.
+    * `interval` controls how often each exporter pod probes its resolved backend set. Default: `5s`.
+    * `timeout` is the per-probe timeout and must be shorter than `interval`. Default: `250ms`.
+    * `jitter` randomizes probe-cycle timing by this percentage from `0%` through `100%`. Default: `20%`.
+    * `max_concurrency` limits concurrent local probes per exporter pod. Default: `4`.
+    * `fall` is the number of consecutive failed probes required before a backend is excluded. Default: `2`.
+    * `rise` is the number of consecutive successful probes required before a backend is readmitted. Default: `2`.
 * The `log_routing` property controls log-specific routing behavior.
   * `ignore_trace_id` routes logs using an auto-generated `traceID` even when each log record has a `traceID`. Default: `false`.
 * The `log_batcher` property enables post-routing log batching per backend. It is `disabled` by default for backward compatibility.
@@ -158,6 +167,15 @@ exporters:
       quarantine_duration: 30s
       reroute_on_failure: true
       max_reroute_attempts: 1
+      active_probe:
+        enabled: true
+        type: tcp_connect
+        interval: 5s
+        timeout: 250ms
+        jitter: 20%
+        max_concurrency: 4
+        fall: 2
+        rise: 2
     log_batcher:
       enabled: true
       max_records: 512

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -6,6 +6,8 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
@@ -112,12 +114,38 @@ type MetricBatcherConfig struct {
 }
 
 const defaultEndpointHealthQuarantineDuration = 30 * time.Second
+const (
+	defaultEndpointHealthActiveProbeInterval       = 5 * time.Second
+	defaultEndpointHealthActiveProbeTimeout        = 250 * time.Millisecond
+	defaultEndpointHealthActiveProbeJitter         = "20%"
+	defaultEndpointHealthActiveProbeMaxConcurrency = 4
+	defaultEndpointHealthActiveProbeFall           = 2
+	defaultEndpointHealthActiveProbeRise           = 2
+)
+
+type EndpointHealthActiveProbeType string
+
+const (
+	EndpointHealthActiveProbeTypeTCPConnect EndpointHealthActiveProbeType = "tcp_connect"
+)
 
 type EndpointHealthConfig struct {
-	Enabled            bool          `mapstructure:"enabled"`
-	QuarantineDuration time.Duration `mapstructure:"quarantine_duration"`
-	RerouteOnFailure   bool          `mapstructure:"reroute_on_failure"`
-	MaxRerouteAttempts int           `mapstructure:"max_reroute_attempts"`
+	Enabled            bool                            `mapstructure:"enabled"`
+	QuarantineDuration time.Duration                   `mapstructure:"quarantine_duration"`
+	RerouteOnFailure   bool                            `mapstructure:"reroute_on_failure"`
+	MaxRerouteAttempts int                             `mapstructure:"max_reroute_attempts"`
+	ActiveProbe        EndpointHealthActiveProbeConfig `mapstructure:"active_probe"`
+}
+
+type EndpointHealthActiveProbeConfig struct {
+	Enabled        bool                          `mapstructure:"enabled"`
+	Type           EndpointHealthActiveProbeType `mapstructure:"type"`
+	Interval       time.Duration                 `mapstructure:"interval"`
+	Timeout        time.Duration                 `mapstructure:"timeout"`
+	Jitter         string                        `mapstructure:"jitter"`
+	MaxConcurrency int                           `mapstructure:"max_concurrency"`
+	Fall           int                           `mapstructure:"fall"`
+	Rise           int                           `mapstructure:"rise"`
 }
 
 func (q *QueueSettings) Unmarshal(conf *confmap.Conf) error {
@@ -263,6 +291,9 @@ func (c MetricBatcherConfig) Validate() error {
 }
 
 func (c EndpointHealthConfig) Validate() error {
+	if c.ActiveProbe.Enabled && !c.Enabled {
+		return errors.New("endpoint_health.active_probe requires endpoint_health.enabled=true")
+	}
 	if !c.Enabled {
 		return nil
 	}
@@ -272,7 +303,53 @@ func (c EndpointHealthConfig) Validate() error {
 	if c.MaxRerouteAttempts < 0 {
 		return errors.New("endpoint_health.max_reroute_attempts must be greater than or equal to 0")
 	}
+	return c.ActiveProbe.Validate()
+}
+
+func (c EndpointHealthActiveProbeConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.Type != EndpointHealthActiveProbeTypeTCPConnect {
+		return fmt.Errorf("endpoint_health.active_probe.type must be %q, found %q", EndpointHealthActiveProbeTypeTCPConnect, c.Type)
+	}
+	if c.Interval <= 0 {
+		return errors.New("endpoint_health.active_probe.interval must be greater than 0")
+	}
+	if c.Timeout <= 0 {
+		return errors.New("endpoint_health.active_probe.timeout must be greater than 0")
+	}
+	if c.Timeout >= c.Interval {
+		return errors.New("endpoint_health.active_probe.timeout must be shorter than endpoint_health.active_probe.interval")
+	}
+	if _, err := parseEndpointHealthActiveProbeJitter(c.Jitter); err != nil {
+		return err
+	}
+	if c.MaxConcurrency <= 0 {
+		return errors.New("endpoint_health.active_probe.max_concurrency must be greater than 0")
+	}
+	if c.Fall <= 0 {
+		return errors.New("endpoint_health.active_probe.fall must be greater than 0")
+	}
+	if c.Rise <= 0 {
+		return errors.New("endpoint_health.active_probe.rise must be greater than 0")
+	}
 	return nil
+}
+
+func parseEndpointHealthActiveProbeJitter(jitter string) (float64, error) {
+	value := strings.TrimSpace(jitter)
+	if value == "" {
+		value = "0%"
+	}
+	if !strings.HasSuffix(value, "%") {
+		return 0, errors.New("endpoint_health.active_probe.jitter must be a percentage from 0% through 100%")
+	}
+	percentage, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(value, "%")), 64)
+	if err != nil || percentage < 0 || percentage > 100 {
+		return 0, errors.New("endpoint_health.active_probe.jitter must be a percentage from 0% through 100%")
+	}
+	return percentage / 100, nil
 }
 
 // Protocol holds the individual protocol-specific settings. Only OTLP is supported at the moment.

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -6,6 +6,7 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -346,7 +347,7 @@ func parseEndpointHealthActiveProbeJitter(jitter string) (float64, error) {
 		return 0, errors.New("endpoint_health.active_probe.jitter must be a percentage from 0% through 100%")
 	}
 	percentage, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimSuffix(value, "%")), 64)
-	if err != nil || percentage < 0 || percentage > 100 {
+	if err != nil || math.IsNaN(percentage) || math.IsInf(percentage, 0) || percentage < 0 || percentage > 100 {
 		return 0, errors.New("endpoint_health.active_probe.jitter must be a percentage from 0% through 100%")
 	}
 	return percentage / 100, nil

--- a/exporter/loadbalancingexporter/config.schema.yaml
+++ b/exporter/loadbalancingexporter/config.schema.yaml
@@ -35,6 +35,8 @@ $defs:
   endpoint_health_config:
     type: object
     properties:
+      active_probe:
+        $ref: endpoint_health_active_probe_config
       enabled:
         type: boolean
       max_reroute_attempts:
@@ -46,6 +48,35 @@ $defs:
         description: Must be greater than 0 when endpoint_health.enabled is true.
       reroute_on_failure:
         type: boolean
+  endpoint_health_active_probe_config:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      fall:
+        type: integer
+        minimum: 1
+      interval:
+        type: string
+        format: duration
+        description: Must be greater than 0 when endpoint_health.active_probe.enabled is true.
+      jitter:
+        type: string
+        description: Percentage from 0% through 100%.
+      max_concurrency:
+        type: integer
+        minimum: 1
+      rise:
+        type: integer
+        minimum: 1
+      timeout:
+        type: string
+        format: duration
+        description: Must be greater than 0 and shorter than interval when endpoint_health.active_probe.enabled is true.
+      type:
+        type: string
+        enum:
+          - tcp_connect
   k_8_s_svc_resolver:
     description: K8sSvcResolver defines the configuration for the DNS resolver
     type: object

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -207,6 +207,11 @@ func TestConfigValidateEndpointHealthActiveProbe(t *testing.T) {
 			expectedErr: "endpoint_health.active_probe.jitter",
 		},
 		{
+			name:        "nan jitter",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Jitter = "NaN%" },
+			expectedErr: "endpoint_health.active_probe.jitter",
+		},
+		{
 			name:        "zero max concurrency",
 			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.MaxConcurrency = 0 },
 			expectedErr: "endpoint_health.active_probe.max_concurrency",

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -151,6 +151,90 @@ func TestConfigValidateEndpointHealth(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 }
 
+func TestConfigValidateEndpointHealthActiveProbe(t *testing.T) {
+	validProbe := EndpointHealthActiveProbeConfig{
+		Enabled:        true,
+		Type:           EndpointHealthActiveProbeTypeTCPConnect,
+		Interval:       5 * time.Second,
+		Timeout:        250 * time.Millisecond,
+		Jitter:         "20%",
+		MaxConcurrency: 4,
+		Fall:           2,
+		Rise:           2,
+	}
+
+	cfg := createDefaultConfig().(*Config)
+	require.False(t, cfg.EndpointHealth.ActiveProbe.Enabled)
+	cfg.EndpointHealth.ActiveProbe = validProbe
+	require.ErrorContains(t, cfg.Validate(), "endpoint_health.active_probe requires endpoint_health.enabled=true")
+
+	cfg.EndpointHealth.Enabled = true
+	require.NoError(t, cfg.Validate())
+
+	tests := []struct {
+		name        string
+		mutate      func(*EndpointHealthActiveProbeConfig)
+		expectedErr string
+	}{
+		{
+			name:        "unknown type",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Type = "grpc_health" },
+			expectedErr: "endpoint_health.active_probe.type",
+		},
+		{
+			name:        "zero interval",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Interval = 0 },
+			expectedErr: "endpoint_health.active_probe.interval",
+		},
+		{
+			name:        "zero timeout",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Timeout = 0 },
+			expectedErr: "endpoint_health.active_probe.timeout",
+		},
+		{
+			name:        "timeout not shorter than interval",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Timeout = c.Interval },
+			expectedErr: "endpoint_health.active_probe.timeout must be shorter than endpoint_health.active_probe.interval",
+		},
+		{
+			name:        "invalid jitter",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Jitter = "fast" },
+			expectedErr: "endpoint_health.active_probe.jitter",
+		},
+		{
+			name:        "jitter above one hundred percent",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Jitter = "101%" },
+			expectedErr: "endpoint_health.active_probe.jitter",
+		},
+		{
+			name:        "zero max concurrency",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.MaxConcurrency = 0 },
+			expectedErr: "endpoint_health.active_probe.max_concurrency",
+		},
+		{
+			name:        "zero fall",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Fall = 0 },
+			expectedErr: "endpoint_health.active_probe.fall",
+		},
+		{
+			name:        "zero rise",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Rise = 0 },
+			expectedErr: "endpoint_health.active_probe.rise",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			cfg.EndpointHealth.Enabled = true
+			cfg.EndpointHealth.ActiveProbe = validProbe
+			tt.mutate(&cfg.EndpointHealth.ActiveProbe)
+
+			require.ErrorContains(t, cfg.Validate(), tt.expectedErr)
+		})
+	}
+}
+
 func TestLoadConfigWithQueueCompression(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	conf := confmap.NewFromStringMap(map[string]any{
@@ -391,6 +475,16 @@ func TestLoadConfigWithEndpointHealth(t *testing.T) {
 			"quarantine_duration":  "10s",
 			"reroute_on_failure":   true,
 			"max_reroute_attempts": 1,
+			"active_probe": map[string]any{
+				"enabled":         true,
+				"type":            "tcp_connect",
+				"interval":        "5s",
+				"timeout":         "250ms",
+				"jitter":          "20%",
+				"max_concurrency": 4,
+				"fall":            2,
+				"rise":            2,
+			},
 		},
 	})
 
@@ -399,6 +493,14 @@ func TestLoadConfigWithEndpointHealth(t *testing.T) {
 	require.Equal(t, 10*time.Second, cfg.EndpointHealth.QuarantineDuration)
 	require.True(t, cfg.EndpointHealth.RerouteOnFailure)
 	require.Equal(t, 1, cfg.EndpointHealth.MaxRerouteAttempts)
+	require.True(t, cfg.EndpointHealth.ActiveProbe.Enabled)
+	require.Equal(t, EndpointHealthActiveProbeTypeTCPConnect, cfg.EndpointHealth.ActiveProbe.Type)
+	require.Equal(t, 5*time.Second, cfg.EndpointHealth.ActiveProbe.Interval)
+	require.Equal(t, 250*time.Millisecond, cfg.EndpointHealth.ActiveProbe.Timeout)
+	require.Equal(t, "20%", cfg.EndpointHealth.ActiveProbe.Jitter)
+	require.Equal(t, 4, cfg.EndpointHealth.ActiveProbe.MaxConcurrency)
+	require.Equal(t, 2, cfg.EndpointHealth.ActiveProbe.Fall)
+	require.Equal(t, 2, cfg.EndpointHealth.ActiveProbe.Rise)
 	require.NoError(t, cfg.Validate())
 }
 

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -212,6 +212,11 @@ func TestConfigValidateEndpointHealthActiveProbe(t *testing.T) {
 			expectedErr: "endpoint_health.active_probe.jitter",
 		},
 		{
+			name:        "infinite jitter",
+			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.Jitter = "Inf%" },
+			expectedErr: "endpoint_health.active_probe.jitter",
+		},
+		{
 			name:        "zero max concurrency",
 			mutate:      func(c *EndpointHealthActiveProbeConfig) { c.MaxConcurrency = 0 },
 			expectedErr: "endpoint_health.active_probe.max_concurrency",

--- a/exporter/loadbalancingexporter/endpoint_health.go
+++ b/exporter/loadbalancingexporter/endpoint_health.go
@@ -231,10 +231,14 @@ func (m *endpointHealthManager) markProbeFailure(endpoint string) endpointHealth
 		reason:        endpointFailureActiveProbe,
 	}
 	if state.probeUnhealthy {
-		state.failureReason = endpointFailureActiveProbe
+		if !state.hasActiveTransportQuarantine(now) {
+			state.failureReason = endpointFailureActiveProbe
+		}
 	} else if state.probeFailures >= m.settings.activeProbe.fall {
 		state.probeUnhealthy = true
-		state.failureReason = endpointFailureActiveProbe
+		if !state.hasActiveTransportQuarantine(now) {
+			state.failureReason = endpointFailureActiveProbe
+		}
 		state.lastStateChangeAt = now
 		decision.quarantined = true
 	}
@@ -409,6 +413,7 @@ func (m *endpointHealthManager) refreshExpiredQuarantines() endpointHealthRefres
 		}
 		if state.probeUnhealthy {
 			state.quarantinedUntil = time.Time{}
+			state.failureReason = endpointFailureActiveProbe
 			continue
 		}
 		recovered = append(recovered, endpointHealthRecovered{endpoint: state.endpoint, reason: state.failureReason})
@@ -465,7 +470,9 @@ func (m *endpointHealthManager) eligibleEndpointsLockedWithRefresh(now time.Time
 		if !state.quarantinedUntil.IsZero() {
 			if !state.quarantinedUntil.After(now) && refreshExpired {
 				state.quarantinedUntil = time.Time{}
-				if !state.probeUnhealthy {
+				if state.probeUnhealthy {
+					state.failureReason = endpointFailureActiveProbe
+				} else {
 					state.failureReason = ""
 					state.lastStateChangeAt = now
 				}
@@ -493,6 +500,13 @@ func (m *endpointHealthManager) eligibleEndpointsLockedWithRefresh(now time.Time
 		return present, true, failOpenStarted
 	}
 	return eligible, false, false
+}
+
+func (s *endpointHealthState) hasActiveTransportQuarantine(now time.Time) bool {
+	return !s.quarantinedUntil.IsZero() &&
+		s.quarantinedUntil.After(now) &&
+		s.failureReason != "" &&
+		s.failureReason != endpointFailureActiveProbe
 }
 
 func classifyEndpointFailure(err error) (endpointFailureReason, bool) {

--- a/exporter/loadbalancingexporter/endpoint_health.go
+++ b/exporter/loadbalancingexporter/endpoint_health.go
@@ -30,6 +30,7 @@ const (
 	endpointFailureDNS               endpointFailureReason = "dns"
 	endpointFailureUnknownTransport  endpointFailureReason = "unknown_transport"
 	endpointFailureExporterStopping  endpointFailureReason = "exporter_stopping"
+	endpointFailureActiveProbe       endpointFailureReason = "active_probe"
 )
 
 type endpointHealthSettings struct {
@@ -37,7 +38,14 @@ type endpointHealthSettings struct {
 	quarantineDuration time.Duration
 	rerouteOnFailure   bool
 	maxRerouteAttempts int
+	activeProbe        endpointHealthActiveProbeSettings
 	now                func() time.Time
+}
+
+type endpointHealthActiveProbeSettings struct {
+	enabled bool
+	fall    int
+	rise    int
 }
 
 type endpointHealthManager struct {
@@ -56,6 +64,9 @@ type endpointHealthState struct {
 	lastSeenAt        time.Time
 	lastFailedAt      time.Time
 	lastStateChangeAt time.Time
+	probeUnhealthy    bool
+	probeFailures     int
+	probeSuccesses    int
 }
 
 type endpointHealthReconcileResult struct {
@@ -114,7 +125,12 @@ func endpointHealthSettingsFromConfig(cfg EndpointHealthConfig) endpointHealthSe
 		quarantineDuration: quarantineDuration,
 		rerouteOnFailure:   cfg.RerouteOnFailure,
 		maxRerouteAttempts: cfg.MaxRerouteAttempts,
-		now:                time.Now,
+		activeProbe: endpointHealthActiveProbeSettings{
+			enabled: cfg.ActiveProbe.Enabled,
+			fall:    cfg.ActiveProbe.Fall,
+			rise:    cfg.ActiveProbe.Rise,
+		},
+		now: time.Now,
 	}
 }
 
@@ -192,6 +208,40 @@ func (m *endpointHealthManager) markFailure(endpoint string, err error) endpoint
 	return decision
 }
 
+func (m *endpointHealthManager) markProbeFailure(endpoint string) endpointHealthFailureDecision {
+	if !m.enabled() || !m.settings.activeProbe.enabled {
+		return endpointHealthFailureDecision{}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, exists := m.endpoints[endpoint]
+	if !exists || !state.present {
+		return endpointHealthFailureDecision{}
+	}
+
+	now := m.settings.now()
+	state.lastFailedAt = now
+	state.probeFailures++
+	state.probeSuccesses = 0
+
+	decision := endpointHealthFailureDecision{
+		endpointLocal: true,
+		reason:        endpointFailureActiveProbe,
+	}
+	if state.probeUnhealthy {
+		state.failureReason = endpointFailureActiveProbe
+	} else if state.probeFailures >= m.settings.activeProbe.fall {
+		state.probeUnhealthy = true
+		state.failureReason = endpointFailureActiveProbe
+		state.lastStateChangeAt = now
+		decision.quarantined = true
+	}
+	decision.eligible, decision.failOpen, decision.failOpenStarted = m.eligibleEndpointsLocked(now)
+	return decision
+}
+
 func (m *endpointHealthManager) markSuccess(endpoint string) bool {
 	return m.markSuccessDecision(endpoint).recovered
 }
@@ -203,7 +253,7 @@ func (m *endpointHealthManager) markSuccessDecision(endpoint string) endpointHea
 
 	m.mu.RLock()
 	state, ok := m.endpoints[endpoint]
-	if !ok || !state.present || (state.quarantinedUntil.IsZero() && state.failureReason == "") {
+	if !ok || !state.present || (state.quarantinedUntil.IsZero() && state.failureReason == "" && !state.probeUnhealthy) {
 		m.mu.RUnlock()
 		return endpointHealthSuccessDecision{}
 	}
@@ -216,10 +266,13 @@ func (m *endpointHealthManager) markSuccessDecision(endpoint string) endpointHea
 	if !ok || !state.present {
 		return endpointHealthSuccessDecision{}
 	}
-	if !state.quarantinedUntil.IsZero() || state.failureReason != "" {
+	if !state.quarantinedUntil.IsZero() || state.failureReason != "" || state.probeUnhealthy {
 		reason := state.failureReason
 		state.quarantinedUntil = time.Time{}
 		state.failureReason = ""
+		state.probeUnhealthy = false
+		state.probeFailures = 0
+		state.probeSuccesses = 0
 		state.lastStateChangeAt = m.settings.now()
 		eligible, _, _ := m.eligibleEndpointsLocked(state.lastStateChangeAt)
 		return endpointHealthSuccessDecision{
@@ -229,6 +282,42 @@ func (m *endpointHealthManager) markSuccessDecision(endpoint string) endpointHea
 		}
 	}
 	return endpointHealthSuccessDecision{}
+}
+
+func (m *endpointHealthManager) markProbeSuccess(endpoint string) endpointHealthSuccessDecision {
+	if !m.enabled() || !m.settings.activeProbe.enabled {
+		return endpointHealthSuccessDecision{}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	state, ok := m.endpoints[endpoint]
+	if !ok || !state.present {
+		return endpointHealthSuccessDecision{}
+	}
+	state.probeFailures = 0
+	if !state.probeUnhealthy {
+		state.probeSuccesses = 0
+		return endpointHealthSuccessDecision{}
+	}
+
+	state.probeSuccesses++
+	if state.probeSuccesses < m.settings.activeProbe.rise {
+		return endpointHealthSuccessDecision{}
+	}
+
+	reason := state.failureReason
+	state.probeUnhealthy = false
+	state.probeSuccesses = 0
+	state.failureReason = ""
+	state.lastStateChangeAt = m.settings.now()
+	eligible, _, _ := m.eligibleEndpointsLocked(state.lastStateChangeAt)
+	return endpointHealthSuccessDecision{
+		recovered: true,
+		reason:    reason,
+		eligible:  eligible,
+	}
 }
 
 func (m *endpointHealthManager) isPresent(endpoint string) bool {
@@ -277,6 +366,24 @@ func (m *endpointHealthManager) eligibleEndpointsNoRefresh() []string {
 
 	eligible, _, _ := m.eligibleEndpointsLockedWithRefresh(m.settings.now(), false)
 	return eligible
+}
+
+func (m *endpointHealthManager) presentEndpoints() []string {
+	if !m.enabled() {
+		return nil
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var endpoints []string
+	for _, state := range m.endpoints {
+		if state.present {
+			endpoints = append(endpoints, state.endpoint)
+		}
+	}
+	sort.Strings(endpoints)
+	return endpoints
 }
 
 func (m *endpointHealthManager) refreshExpiredQuarantines() endpointHealthRefreshResult {
@@ -344,14 +451,14 @@ func (m *endpointHealthManager) eligibleEndpointsLockedWithRefresh(now time.Time
 			continue
 		}
 		present = append(present, state.endpoint)
-		if !state.quarantinedUntil.IsZero() && !state.quarantinedUntil.After(now) && refreshExpired {
+		if !state.probeUnhealthy && !state.quarantinedUntil.IsZero() && !state.quarantinedUntil.After(now) && refreshExpired {
 			state.quarantinedUntil = time.Time{}
 			state.failureReason = ""
 			state.lastStateChangeAt = now
 		} else if !state.quarantinedUntil.IsZero() && (nextExpiry.IsZero() || state.quarantinedUntil.Before(nextExpiry)) {
 			nextExpiry = state.quarantinedUntil
 		}
-		if state.quarantinedUntil.IsZero() {
+		if state.quarantinedUntil.IsZero() && !state.probeUnhealthy {
 			eligible = append(eligible, state.endpoint)
 		}
 	}

--- a/exporter/loadbalancingexporter/endpoint_health.go
+++ b/exporter/loadbalancingexporter/endpoint_health.go
@@ -266,11 +266,13 @@ func (m *endpointHealthManager) markSuccessDecision(endpoint string) endpointHea
 	if !ok || !state.present {
 		return endpointHealthSuccessDecision{}
 	}
-	if !state.quarantinedUntil.IsZero() || state.failureReason != "" || state.probeUnhealthy {
+	if state.probeUnhealthy {
+		return endpointHealthSuccessDecision{}
+	}
+	if !state.quarantinedUntil.IsZero() || state.failureReason != "" {
 		reason := state.failureReason
 		state.quarantinedUntil = time.Time{}
 		state.failureReason = ""
-		state.probeUnhealthy = false
 		state.probeFailures = 0
 		state.probeSuccesses = 0
 		state.lastStateChangeAt = m.settings.now()
@@ -400,6 +402,10 @@ func (m *endpointHealthManager) refreshExpiredQuarantines() endpointHealthRefres
 		if !state.present || state.quarantinedUntil.IsZero() || state.quarantinedUntil.After(now) {
 			continue
 		}
+		if state.probeUnhealthy {
+			state.quarantinedUntil = time.Time{}
+			continue
+		}
 		recovered = append(recovered, endpointHealthRecovered{endpoint: state.endpoint, reason: state.failureReason})
 		state.quarantinedUntil = time.Time{}
 		state.failureReason = ""
@@ -451,12 +457,17 @@ func (m *endpointHealthManager) eligibleEndpointsLockedWithRefresh(now time.Time
 			continue
 		}
 		present = append(present, state.endpoint)
-		if !state.probeUnhealthy && !state.quarantinedUntil.IsZero() && !state.quarantinedUntil.After(now) && refreshExpired {
-			state.quarantinedUntil = time.Time{}
-			state.failureReason = ""
-			state.lastStateChangeAt = now
-		} else if !state.quarantinedUntil.IsZero() && (nextExpiry.IsZero() || state.quarantinedUntil.Before(nextExpiry)) {
-			nextExpiry = state.quarantinedUntil
+		if !state.quarantinedUntil.IsZero() {
+			if !state.quarantinedUntil.After(now) && refreshExpired {
+				state.quarantinedUntil = time.Time{}
+				if !state.probeUnhealthy {
+					state.failureReason = ""
+					state.lastStateChangeAt = now
+				}
+			}
+			if !state.quarantinedUntil.IsZero() && state.quarantinedUntil.After(now) && (nextExpiry.IsZero() || state.quarantinedUntil.Before(nextExpiry)) {
+				nextExpiry = state.quarantinedUntil
+			}
 		}
 		if state.quarantinedUntil.IsZero() && !state.probeUnhealthy {
 			eligible = append(eligible, state.endpoint)

--- a/exporter/loadbalancingexporter/endpoint_health.go
+++ b/exporter/loadbalancingexporter/endpoint_health.go
@@ -309,12 +309,17 @@ func (m *endpointHealthManager) markProbeSuccess(endpoint string) endpointHealth
 		return endpointHealthSuccessDecision{}
 	}
 
+	now := m.settings.now()
 	reason := state.failureReason
 	state.probeUnhealthy = false
 	state.probeSuccesses = 0
+	state.lastStateChangeAt = now
+	if !state.quarantinedUntil.IsZero() && state.quarantinedUntil.After(now) {
+		_, _, _ = m.eligibleEndpointsLocked(now)
+		return endpointHealthSuccessDecision{}
+	}
 	state.failureReason = ""
-	state.lastStateChangeAt = m.settings.now()
-	eligible, _, _ := m.eligibleEndpointsLocked(state.lastStateChangeAt)
+	eligible, _, _ := m.eligibleEndpointsLocked(now)
 	return endpointHealthSuccessDecision{
 		recovered: true,
 		reason:    reason,

--- a/exporter/loadbalancingexporter/endpoint_health_test.go
+++ b/exporter/loadbalancingexporter/endpoint_health_test.go
@@ -184,6 +184,7 @@ func TestEndpointHealthExpiredProbeQuarantineDoesNotRefreshForever(t *testing.T)
 
 	probeSuccess = manager.markProbeSuccess("endpoint-1")
 	require.True(t, probeSuccess.recovered)
+	require.Equal(t, endpointFailureActiveProbe, probeSuccess.reason)
 	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, manager.eligibleEndpoints())
 }
 
@@ -215,7 +216,7 @@ func TestEndpointHealthProbeRecoveryWaitsForActiveTransportQuarantine(t *testing
 	manager.mu.RUnlock()
 	require.False(t, probeUnhealthy)
 	require.True(t, quarantinedUntil.After(now))
-	require.NotEmpty(t, failureReason)
+	require.Equal(t, endpointFailureUnavailable, failureReason)
 
 	now = now.Add(31 * time.Second)
 	refresh := manager.refreshExpiredQuarantines()

--- a/exporter/loadbalancingexporter/endpoint_health_test.go
+++ b/exporter/loadbalancingexporter/endpoint_health_test.go
@@ -99,6 +99,39 @@ func TestEndpointHealthProbeFailureBelowFallDoesNotRecoverOnExportSuccess(t *tes
 	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, manager.eligibleEndpoints())
 }
 
+func TestEndpointHealthProbeUnhealthyRequiresRiseSuccessesForRecovery(t *testing.T) {
+	now := time.Unix(100, 0)
+	manager := newEndpointHealthManager(endpointHealthSettings{
+		enabled:            true,
+		quarantineDuration: 30 * time.Second,
+		activeProbe: endpointHealthActiveProbeSettings{
+			enabled: true,
+			fall:    2,
+			rise:    2,
+		},
+		now: func() time.Time { return now },
+	})
+	manager.reconcile([]string{"endpoint-1", "endpoint-2"})
+
+	manager.markProbeFailure("endpoint-1")
+	decision := manager.markProbeFailure("endpoint-1")
+	require.True(t, decision.quarantined)
+	require.Equal(t, []string{"endpoint-2"}, decision.eligible)
+
+	success := manager.markSuccessDecision("endpoint-1")
+	require.False(t, success.recovered)
+	require.Equal(t, []string{"endpoint-2"}, manager.eligibleEndpoints())
+
+	probeSuccess := manager.markProbeSuccess("endpoint-1")
+	require.False(t, probeSuccess.recovered)
+	require.Equal(t, []string{"endpoint-2"}, manager.eligibleEndpoints())
+
+	probeSuccess = manager.markProbeSuccess("endpoint-1")
+	require.True(t, probeSuccess.recovered)
+	require.Equal(t, endpointFailureActiveProbe, probeSuccess.reason)
+	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, manager.eligibleEndpoints())
+}
+
 func TestEndpointHealthQuarantineRefreshDueTracksNextExpiry(t *testing.T) {
 	now := time.Unix(100, 0)
 	manager := newEndpointHealthManager(endpointHealthSettings{
@@ -118,6 +151,40 @@ func TestEndpointHealthQuarantineRefreshDueTracksNextExpiry(t *testing.T) {
 	require.Equal(t, []endpointHealthRecovered{{endpoint: "endpoint-1", reason: endpointFailureUnavailable}}, refresh.recovered)
 	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, refresh.eligible)
 	require.False(t, manager.quarantineRefreshDue())
+}
+
+func TestEndpointHealthExpiredProbeQuarantineDoesNotRefreshForever(t *testing.T) {
+	now := time.Unix(100, 0)
+	manager := newEndpointHealthManager(endpointHealthSettings{
+		enabled:            true,
+		quarantineDuration: 30 * time.Second,
+		activeProbe: endpointHealthActiveProbeSettings{
+			enabled: true,
+			fall:    1,
+			rise:    2,
+		},
+		now: func() time.Time { return now },
+	})
+	manager.reconcile([]string{"endpoint-1", "endpoint-2"})
+	manager.markFailure("endpoint-1", status.Error(codes.Unavailable, "backend unavailable"))
+	manager.markProbeFailure("endpoint-1")
+
+	now = now.Add(31 * time.Second)
+	require.Equal(t, []string{"endpoint-2"}, manager.eligibleEndpoints())
+	require.False(t, manager.quarantineRefreshDue())
+
+	refresh := manager.refreshExpiredQuarantines()
+	require.Empty(t, refresh.recovered)
+	require.False(t, refresh.failOpenStarted)
+	require.Equal(t, []string{"endpoint-2"}, manager.eligibleEndpoints())
+
+	probeSuccess := manager.markProbeSuccess("endpoint-1")
+	require.False(t, probeSuccess.recovered)
+	require.Equal(t, []string{"endpoint-2"}, manager.eligibleEndpoints())
+
+	probeSuccess = manager.markProbeSuccess("endpoint-1")
+	require.True(t, probeSuccess.recovered)
+	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, manager.eligibleEndpoints())
 }
 
 func TestShouldRerouteDirectFailureAllowsAlreadyQuarantinedEndpoint(t *testing.T) {

--- a/exporter/loadbalancingexporter/endpoint_health_test.go
+++ b/exporter/loadbalancingexporter/endpoint_health_test.go
@@ -75,6 +75,30 @@ func TestEndpointHealthQuarantinesOnFirstEndpointLocalFailure(t *testing.T) {
 	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, manager.eligibleEndpoints())
 }
 
+func TestEndpointHealthProbeFailureBelowFallDoesNotRecoverOnExportSuccess(t *testing.T) {
+	now := time.Unix(100, 0)
+	manager := newEndpointHealthManager(endpointHealthSettings{
+		enabled:            true,
+		quarantineDuration: 30 * time.Second,
+		activeProbe: endpointHealthActiveProbeSettings{
+			enabled: true,
+			fall:    2,
+			rise:    2,
+		},
+		now: func() time.Time { return now },
+	})
+	manager.reconcile([]string{"endpoint-1", "endpoint-2"})
+
+	decision := manager.markProbeFailure("endpoint-1")
+	require.True(t, decision.endpointLocal)
+	require.False(t, decision.quarantined)
+	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, decision.eligible)
+
+	success := manager.markSuccessDecision("endpoint-1")
+	require.False(t, success.recovered)
+	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, manager.eligibleEndpoints())
+}
+
 func TestEndpointHealthQuarantineRefreshDueTracksNextExpiry(t *testing.T) {
 	now := time.Unix(100, 0)
 	manager := newEndpointHealthManager(endpointHealthSettings{

--- a/exporter/loadbalancingexporter/endpoint_health_test.go
+++ b/exporter/loadbalancingexporter/endpoint_health_test.go
@@ -187,6 +187,42 @@ func TestEndpointHealthExpiredProbeQuarantineDoesNotRefreshForever(t *testing.T)
 	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, manager.eligibleEndpoints())
 }
 
+func TestEndpointHealthProbeRecoveryWaitsForActiveTransportQuarantine(t *testing.T) {
+	now := time.Unix(100, 0)
+	manager := newEndpointHealthManager(endpointHealthSettings{
+		enabled:            true,
+		quarantineDuration: 30 * time.Second,
+		activeProbe: endpointHealthActiveProbeSettings{
+			enabled: true,
+			fall:    1,
+			rise:    1,
+		},
+		now: func() time.Time { return now },
+	})
+	manager.reconcile([]string{"endpoint-1", "endpoint-2"})
+	manager.markFailure("endpoint-1", status.Error(codes.Unavailable, "backend unavailable"))
+	manager.markProbeFailure("endpoint-1")
+
+	probeSuccess := manager.markProbeSuccess("endpoint-1")
+	require.False(t, probeSuccess.recovered)
+	require.Equal(t, []string{"endpoint-2"}, manager.eligibleEndpoints())
+
+	manager.mu.RLock()
+	state := manager.endpoints["endpoint-1"]
+	probeUnhealthy := state.probeUnhealthy
+	quarantinedUntil := state.quarantinedUntil
+	failureReason := state.failureReason
+	manager.mu.RUnlock()
+	require.False(t, probeUnhealthy)
+	require.True(t, quarantinedUntil.After(now))
+	require.NotEmpty(t, failureReason)
+
+	now = now.Add(31 * time.Second)
+	refresh := manager.refreshExpiredQuarantines()
+	require.Equal(t, []endpointHealthRecovered{{endpoint: "endpoint-1", reason: failureReason}}, refresh.recovered)
+	require.Equal(t, []string{"endpoint-1", "endpoint-2"}, refresh.eligible)
+}
+
 func TestShouldRerouteDirectFailureAllowsAlreadyQuarantinedEndpoint(t *testing.T) {
 	now := time.Unix(100, 0)
 	manager := newEndpointHealthManager(endpointHealthSettings{

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -72,6 +72,16 @@ func createDefaultConfig() component.Config {
 			QuarantineDuration: defaultEndpointHealthQuarantineDuration,
 			RerouteOnFailure:   true,
 			MaxRerouteAttempts: 1,
+			ActiveProbe: EndpointHealthActiveProbeConfig{
+				Enabled:        false,
+				Type:           EndpointHealthActiveProbeTypeTCPConnect,
+				Interval:       defaultEndpointHealthActiveProbeInterval,
+				Timeout:        defaultEndpointHealthActiveProbeTimeout,
+				Jitter:         defaultEndpointHealthActiveProbeJitter,
+				MaxConcurrency: defaultEndpointHealthActiveProbeMaxConcurrency,
+				Fall:           defaultEndpointHealthActiveProbeFall,
+				Rise:           defaultEndpointHealthActiveProbeRise,
+			},
 		},
 	}
 }

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -7,10 +7,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand/v2"
+	"net"
 	"slices"
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/attribute"
@@ -38,15 +41,20 @@ type loadBalancer struct {
 	res  resolver
 	ring *hashRing
 
-	componentFactory componentFactory
-	exporters        map[string]*wrappedExporter
-	onExporterRemove func(context.Context, string, *wrappedExporter) error
-	telemetry        *metadata.TelemetryBuilder
-	endpointHealth   *endpointHealthManager
+	componentFactory  componentFactory
+	exporters         map[string]*wrappedExporter
+	onExporterRemove  func(context.Context, string, *wrappedExporter) error
+	telemetry         *metadata.TelemetryBuilder
+	endpointHealth    *endpointHealthManager
+	activeProbe       EndpointHealthActiveProbeConfig
+	activeProbeJitter float64
+	activeProbeFunc   func(context.Context, string) error
 
 	stopped   bool
 	cleanupMu sync.Mutex
 	cleanupWG sync.WaitGroup
+	probeWG   sync.WaitGroup
+	probeStop context.CancelFunc
 
 	updateLock sync.RWMutex
 }
@@ -145,20 +153,35 @@ func newLoadBalancer(logger *zap.Logger, cfg component.Config, factory component
 		return nil, errNoResolver
 	}
 
+	activeProbeJitter := 0.0
+	if oCfg.EndpointHealth.ActiveProbe.Enabled {
+		var err error
+		activeProbeJitter, err = parseEndpointHealthActiveProbeJitter(oCfg.EndpointHealth.ActiveProbe.Jitter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &loadBalancer{
-		logger:           logger,
-		res:              res,
-		componentFactory: factory,
-		exporters:        map[string]*wrappedExporter{},
-		telemetry:        telemetry,
-		endpointHealth:   newEndpointHealthManager(endpointHealthSettingsFromConfig(oCfg.EndpointHealth)),
+		logger:            logger,
+		res:               res,
+		componentFactory:  factory,
+		exporters:         map[string]*wrappedExporter{},
+		telemetry:         telemetry,
+		endpointHealth:    newEndpointHealthManager(endpointHealthSettingsFromConfig(oCfg.EndpointHealth)),
+		activeProbe:       oCfg.EndpointHealth.ActiveProbe,
+		activeProbeJitter: activeProbeJitter,
 	}, nil
 }
 
 func (lb *loadBalancer) Start(ctx context.Context, host component.Host) error {
 	lb.res.onChange(lb.onBackendChanges)
 	lb.host = host
-	return lb.res.start(ctx)
+	if err := lb.res.start(ctx); err != nil {
+		return err
+	}
+	lb.startEndpointHealthActiveProbeLoop()
+	return nil
 }
 
 func (lb *loadBalancer) onBackendChanges(resolved []string) {
@@ -486,6 +509,66 @@ func (lb *loadBalancer) handleBackendFailureHealthOnly(ctx context.Context, endp
 	return decision
 }
 
+func (lb *loadBalancer) handleBackendProbeFailure(ctx context.Context, endpoint string, _ error) endpointHealthFailureDecision {
+	endpoint = endpointWithPort(endpoint)
+	decision := lb.endpointHealth.markProbeFailure(endpoint)
+	lb.recordEndpointFailureDecision(ctx, endpoint, decision)
+	if !shouldCommitEndpointHealthFailure(endpoint, decision) {
+		return decision
+	}
+
+	forceCreate := map[string]struct{}{}
+	if endpointListContains(decision.eligible, endpoint) {
+		forceCreate[endpoint] = struct{}{}
+	}
+	created := lb.createMissingExporters(ctx, decision.eligible, forceCreate)
+
+	lb.updateLock.Lock()
+	eligible := lb.endpointHealth.eligibleEndpointsNoRefresh()
+	lb.ring = newHashRing(eligible)
+
+	var removed []removedExporter
+	endpointEligible := endpointListContains(eligible, endpoint)
+	if exp, ok := lb.exporters[endpoint]; ok && (!endpointEligible || createdExporterExists(created, endpoint)) {
+		exp.markStopping()
+		delete(lb.exporters, endpoint)
+		removed = append(removed, removedExporter{endpoint: endpoint, exporter: exp})
+	}
+	duplicates := lb.installCreatedExportersLocked(created, eligible)
+	lb.updateLock.Unlock()
+
+	lb.shutdownCreatedExporters(ctx, duplicates)
+	if len(removed) > 0 {
+		lb.runCleanupAsync(func() {
+			lb.drainRemovedExporters(context.WithoutCancel(ctx), removed)
+		})
+	}
+	return decision
+}
+
+func (lb *loadBalancer) handleBackendProbeSuccess(ctx context.Context, endpoint string) endpointHealthSuccessDecision {
+	if !lb.endpointHealth.enabled() {
+		return endpointHealthSuccessDecision{}
+	}
+
+	endpoint = endpointWithPort(endpoint)
+	decision := lb.endpointHealth.markProbeSuccess(endpoint)
+	if !decision.recovered {
+		return decision
+	}
+	lb.recordEndpointUnquarantine(ctx, endpoint, decision.reason)
+	created := lb.createMissingExporters(ctx, decision.eligible, nil)
+
+	lb.updateLock.Lock()
+	eligible := lb.endpointHealth.eligibleEndpointsNoRefresh()
+	lb.ring = newHashRing(eligible)
+	duplicates := lb.installCreatedExportersLocked(created, eligible)
+	lb.updateLock.Unlock()
+
+	lb.shutdownCreatedExporters(ctx, duplicates)
+	return decision
+}
+
 func (lb *loadBalancer) cleanupBackendWithoutDrain(ctx context.Context, endpoint string) {
 	endpoint = endpointWithPort(endpoint)
 	lb.updateLock.Lock()
@@ -690,8 +773,131 @@ func (lb *loadBalancer) recordBackendReroute(ctx context.Context, signal string,
 	))
 }
 
+func (lb *loadBalancer) endpointHealthActiveProbeEnabled() bool {
+	return lb != nil && lb.endpointHealth.enabled() && lb.activeProbe.Enabled
+}
+
+func (lb *loadBalancer) startEndpointHealthActiveProbeLoop() {
+	if !lb.endpointHealthActiveProbeEnabled() {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	lb.probeStop = cancel
+	lb.probeWG.Add(1)
+	go func() {
+		defer lb.probeWG.Done()
+		lb.runEndpointHealthActiveProbeLoop(ctx)
+	}()
+}
+
+func (lb *loadBalancer) stopEndpointHealthActiveProbeLoop(ctx context.Context) error {
+	if lb.probeStop != nil {
+		lb.probeStop()
+	}
+	return waitForInflight(ctx, &lb.probeWG)
+}
+
+func (lb *loadBalancer) runEndpointHealthActiveProbeLoop(ctx context.Context) {
+	for {
+		lb.runEndpointHealthActiveProbeCycle(ctx)
+
+		timer := time.NewTimer(lb.nextEndpointHealthActiveProbeInterval())
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+func (lb *loadBalancer) runEndpointHealthActiveProbeCycle(ctx context.Context) {
+	if !lb.endpointHealthActiveProbeEnabled() {
+		return
+	}
+
+	endpoints := lb.endpointHealth.presentEndpoints()
+	if len(endpoints) == 0 {
+		return
+	}
+
+	maxConcurrency := lb.activeProbe.MaxConcurrency
+	if maxConcurrency <= 0 {
+		maxConcurrency = 1
+	}
+	sem := make(chan struct{}, maxConcurrency)
+	var wg sync.WaitGroup
+	for _, endpoint := range endpoints {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		}
+
+		wg.Add(1)
+		go func(endpoint string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			probeCtx, cancel := context.WithTimeout(ctx, lb.activeProbe.Timeout)
+			err := lb.probeEndpoint(probeCtx, endpoint)
+			cancel()
+			if ctx.Err() != nil {
+				return
+			}
+			if err != nil {
+				lb.handleBackendProbeFailure(ctx, endpoint, err)
+				return
+			}
+			lb.handleBackendProbeSuccess(ctx, endpoint)
+		}(endpoint)
+	}
+	wg.Wait()
+}
+
+func (lb *loadBalancer) probeEndpoint(ctx context.Context, endpoint string) error {
+	if lb.activeProbeFunc != nil {
+		return lb.activeProbeFunc(ctx, endpoint)
+	}
+	return probeEndpointTCPConnect(ctx, endpoint)
+}
+
+func probeEndpointTCPConnect(ctx context.Context, endpoint string) error {
+	dialer := net.Dialer{}
+	conn, err := dialer.DialContext(ctx, "tcp", endpointWithPort(endpoint))
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+func (lb *loadBalancer) nextEndpointHealthActiveProbeInterval() time.Duration {
+	interval := lb.activeProbe.Interval
+	if interval <= 0 {
+		interval = defaultEndpointHealthActiveProbeInterval
+	}
+	if lb.activeProbeJitter <= 0 {
+		return interval
+	}
+
+	scale := 1 + ((rand.Float64()*2 - 1) * lb.activeProbeJitter)
+	jittered := time.Duration(float64(interval) * scale)
+	if jittered <= 0 {
+		return time.Nanosecond
+	}
+	return jittered
+}
+
 func (lb *loadBalancer) Shutdown(ctx context.Context) error {
-	err := lb.res.shutdown(ctx)
+	err := lb.stopEndpointHealthActiveProbeLoop(ctx)
+	err = errors.Join(err, lb.res.shutdown(ctx))
 
 	lb.cleanupMu.Lock()
 	lb.stopped = true

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -784,11 +784,9 @@ func (lb *loadBalancer) startEndpointHealthActiveProbeLoop() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	lb.probeStop = cancel
-	lb.probeWG.Add(1)
-	go func() {
-		defer lb.probeWG.Done()
+	lb.probeWG.Go(func() {
 		lb.runEndpointHealthActiveProbeLoop(ctx)
-	}()
+	})
 }
 
 func (lb *loadBalancer) stopEndpointHealthActiveProbeLoop(ctx context.Context) error {

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -800,20 +800,21 @@ func (lb *loadBalancer) stopEndpointHealthActiveProbeLoop(ctx context.Context) e
 
 func (lb *loadBalancer) runEndpointHealthActiveProbeLoop(ctx context.Context) {
 	for {
-		lb.runEndpointHealthActiveProbeCycle(ctx)
-
-		timer := time.NewTimer(lb.nextEndpointHealthActiveProbeInterval())
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
+		if !lb.waitForNextEndpointHealthActiveProbeInterval(ctx) {
 			return
-		case <-timer.C:
 		}
+		lb.runEndpointHealthActiveProbeCycle(ctx)
+	}
+}
+
+func (lb *loadBalancer) waitForNextEndpointHealthActiveProbeInterval(ctx context.Context) bool {
+	timer := time.NewTimer(lb.nextEndpointHealthActiveProbeInterval())
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -439,6 +439,309 @@ func TestLoadBalancerEndpointHealthExcludesQuarantinedEndpoint(t *testing.T) {
 	}
 }
 
+func TestLoadBalancerEndpointHealthActiveProbeExcludesAndRecoversEndpoint(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+	cfg.EndpointHealth.ActiveProbe = EndpointHealthActiveProbeConfig{
+		Enabled:        true,
+		Type:           EndpointHealthActiveProbeTypeTCPConnect,
+		Interval:       time.Second,
+		Timeout:        100 * time.Millisecond,
+		Jitter:         "0%",
+		MaxConcurrency: 2,
+		Fall:           2,
+		Rise:           2,
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return mockComponent{}, nil
+	}
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+
+	p.onBackendChanges([]string{"endpoint-1", "endpoint-2"})
+	routingID := findRoutingIDForEndpoint(t, p.ring, "endpoint-1:4317")
+
+	decision := p.handleBackendProbeFailure(t.Context(), "endpoint-1:4317", errors.New("probe failed"))
+	require.False(t, decision.quarantined)
+	require.Contains(t, p.exporters, "endpoint-1:4317")
+
+	decision = p.handleBackendProbeFailure(t.Context(), "endpoint-1:4317", errors.New("probe failed"))
+	require.True(t, decision.quarantined)
+	require.NotContains(t, p.exporters, "endpoint-1:4317")
+
+	_, endpoint, err := p.exporterAndEndpoint([]byte(routingID))
+	require.NoError(t, err)
+	require.Equal(t, "endpoint-2:4317", endpoint)
+
+	success := p.handleBackendProbeSuccess(t.Context(), "endpoint-1:4317")
+	require.False(t, success.recovered)
+	require.NotContains(t, p.exporters, "endpoint-1:4317")
+
+	success = p.handleBackendProbeSuccess(t.Context(), "endpoint-1:4317")
+	require.True(t, success.recovered)
+	require.Contains(t, p.exporters, "endpoint-1:4317")
+
+	_, endpoint, err = p.exporterAndEndpoint([]byte(routingID))
+	require.NoError(t, err)
+	require.Equal(t, "endpoint-1:4317", endpoint)
+}
+
+func TestLoadBalancerEndpointHealthActiveProbeFailsOpenWhenEveryEndpointIsUnhealthy(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+	cfg.EndpointHealth.ActiveProbe = EndpointHealthActiveProbeConfig{
+		Enabled:        true,
+		Type:           EndpointHealthActiveProbeTypeTCPConnect,
+		Interval:       time.Second,
+		Timeout:        100 * time.Millisecond,
+		Jitter:         "0%",
+		MaxConcurrency: 2,
+		Fall:           1,
+		Rise:           1,
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return mockComponent{}, nil
+	}
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+
+	p.onBackendChanges([]string{"endpoint-1", "endpoint-2"})
+	endpoint1Original := p.exporters["endpoint-1:4317"]
+	endpoint2Original := p.exporters["endpoint-2:4317"]
+
+	decision := p.handleBackendProbeFailure(t.Context(), "endpoint-1:4317", errors.New("probe failed"))
+	require.True(t, decision.quarantined)
+	require.False(t, decision.failOpen)
+
+	decision = p.handleBackendProbeFailure(t.Context(), "endpoint-2:4317", errors.New("probe failed"))
+	require.True(t, decision.quarantined)
+	require.True(t, decision.failOpen)
+	require.Contains(t, decision.eligible, "endpoint-1:4317")
+	require.Contains(t, decision.eligible, "endpoint-2:4317")
+	require.NotSame(t, endpoint1Original, p.exporters["endpoint-1:4317"])
+	require.NotSame(t, endpoint2Original, p.exporters["endpoint-2:4317"])
+}
+
+func TestLoadBalancerEndpointHealthActiveProbeUpdatesExistingHealthMetrics(t *testing.T) {
+	ts, tb, telemetry := getTelemetryAssetsWithReader(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+	cfg.EndpointHealth.ActiveProbe = EndpointHealthActiveProbeConfig{
+		Enabled:        true,
+		Type:           EndpointHealthActiveProbeTypeTCPConnect,
+		Interval:       time.Second,
+		Timeout:        100 * time.Millisecond,
+		Jitter:         "0%",
+		MaxConcurrency: 2,
+		Fall:           1,
+		Rise:           1,
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return mockComponent{}, nil
+	}
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+
+	p.onBackendChanges([]string{"endpoint-1", "endpoint-2"})
+	p.handleBackendProbeFailure(t.Context(), "endpoint-1:4317", errors.New("probe failed"))
+	p.handleBackendProbeSuccess(t.Context(), "endpoint-1:4317")
+
+	metadatatest.AssertEqualLoadbalancerBackendQuarantineTotal(t, telemetry, []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("reason", "active_probe")),
+			Value:      1,
+		},
+	}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualLoadbalancerBackendUnquarantineTotal(t, telemetry, []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("reason", "active_probe")),
+			Value:      1,
+		},
+	}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualLoadbalancerBackendState(t, telemetry, []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("state", "eligible")),
+			Value:      1,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("state", "quarantined")),
+			Value:      0,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("state", "stale")),
+			Value:      0,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-2:4317"), attribute.String("state", "eligible")),
+			Value:      1,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-2:4317"), attribute.String("state", "quarantined")),
+			Value:      0,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-2:4317"), attribute.String("state", "stale")),
+			Value:      0,
+		},
+	}, metricdatatest.IgnoreTimestamp())
+}
+
+func TestLoadBalancerEndpointHealthActiveProbeCycleUsesTCPConnectAndRecoversEndpoint(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+	cfg.EndpointHealth.ActiveProbe = EndpointHealthActiveProbeConfig{
+		Enabled:        true,
+		Type:           EndpointHealthActiveProbeTypeTCPConnect,
+		Interval:       time.Second,
+		Timeout:        100 * time.Millisecond,
+		Jitter:         "0%",
+		MaxConcurrency: 2,
+		Fall:           1,
+		Rise:           1,
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return mockComponent{}, nil
+	}
+
+	reachable := listenTCPForProbe(t, "127.0.0.1:0")
+	unreachableAddr := reserveTCPAddr(t)
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+
+	p.onBackendChanges([]string{reachable.Addr().String(), unreachableAddr})
+	routingID := findRoutingIDForEndpoint(t, p.ring, unreachableAddr)
+
+	p.runEndpointHealthActiveProbeCycle(t.Context())
+
+	require.NotContains(t, p.exporters, unreachableAddr)
+	_, endpoint, err := p.exporterAndEndpoint([]byte(routingID))
+	require.NoError(t, err)
+	require.NotEqual(t, unreachableAddr, endpoint)
+
+	recovered := listenTCPForProbe(t, unreachableAddr)
+	defer recovered.Close()
+
+	p.runEndpointHealthActiveProbeCycle(t.Context())
+
+	require.Contains(t, p.exporters, unreachableAddr)
+	_, endpoint, err = p.exporterAndEndpoint([]byte(routingID))
+	require.NoError(t, err)
+	require.Equal(t, unreachableAddr, endpoint)
+}
+
+func TestLoadBalancerEndpointHealthActiveProbeCycleHonorsMaxConcurrency(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+	cfg.EndpointHealth.ActiveProbe = EndpointHealthActiveProbeConfig{
+		Enabled:        true,
+		Type:           EndpointHealthActiveProbeTypeTCPConnect,
+		Interval:       time.Second,
+		Timeout:        100 * time.Millisecond,
+		Jitter:         "0%",
+		MaxConcurrency: 2,
+		Fall:           1,
+		Rise:           1,
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return mockComponent{}, nil
+	}
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	p.onBackendChanges([]string{"endpoint-1", "endpoint-2", "endpoint-3", "endpoint-4"})
+
+	var active atomic.Int64
+	var maxActive atomic.Int64
+	started := make(chan struct{}, 4)
+	release := make(chan struct{})
+	p.activeProbeFunc = func(ctx context.Context, _ string) error {
+		current := active.Add(1)
+		for {
+			max := maxActive.Load()
+			if current <= max || maxActive.CompareAndSwap(max, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		select {
+		case <-release:
+		case <-ctx.Done():
+		}
+		active.Add(-1)
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.runEndpointHealthActiveProbeCycle(t.Context())
+	}()
+
+	requireProbeStarts(t, started, 2)
+	select {
+	case <-started:
+		t.Fatal("active_probe exceeded max_concurrency before a probe completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("active probe cycle did not finish")
+	}
+	require.LessOrEqual(t, maxActive.Load(), int64(2))
+}
+
+func TestLoadBalancerEndpointHealthActiveProbeLoopStopsOnShutdown(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+	cfg.EndpointHealth.ActiveProbe = EndpointHealthActiveProbeConfig{
+		Enabled:        true,
+		Type:           EndpointHealthActiveProbeTypeTCPConnect,
+		Interval:       time.Hour,
+		Timeout:        time.Minute,
+		Jitter:         "0%",
+		MaxConcurrency: 1,
+		Fall:           1,
+		Rise:           1,
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return mockComponent{}, nil
+	}
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	p.onBackendChanges([]string{"endpoint-1"})
+
+	probeStarted := make(chan struct{})
+	p.activeProbeFunc = func(ctx context.Context, _ string) error {
+		close(probeStarted)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	select {
+	case <-probeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected active probe loop to start")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, p.Shutdown(shutdownCtx))
+}
+
 func TestLoadBalancerEndpointHealthRemovesDNSStaleEndpoint(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := simpleConfig()
@@ -1088,6 +1391,38 @@ func enableEndpointHealth(cfg *Config) {
 	cfg.EndpointHealth.QuarantineDuration = time.Minute
 	cfg.EndpointHealth.RerouteOnFailure = true
 	cfg.EndpointHealth.MaxRerouteAttempts = 1
+}
+
+func listenTCPForProbe(t *testing.T, address string) net.Listener {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", address)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+	return listener
+}
+
+func reserveTCPAddr(t *testing.T) string {
+	t.Helper()
+
+	listener := listenTCPForProbe(t, "127.0.0.1:0")
+	address := listener.Addr().String()
+	require.NoError(t, listener.Close())
+	return address
+}
+
+func requireProbeStarts(t *testing.T, started <-chan struct{}, count int) {
+	t.Helper()
+
+	for range count {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("expected %d active probes to start", count)
+		}
+	}
 }
 
 type countingComponent struct {

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -665,8 +665,8 @@ func TestLoadBalancerEndpointHealthActiveProbeCycleHonorsMaxConcurrency(t *testi
 	p.activeProbeFunc = func(ctx context.Context, _ string) error {
 		current := active.Add(1)
 		for {
-			max := maxActive.Load()
-			if current <= max || maxActive.CompareAndSwap(max, current) {
+			observedMax := maxActive.Load()
+			if current <= observedMax || maxActive.CompareAndSwap(observedMax, current) {
 				break
 			}
 		}
@@ -738,7 +738,7 @@ func TestLoadBalancerEndpointHealthActiveProbeLoopStopsOnShutdown(t *testing.T) 
 		t.Fatal("expected active probe loop to start")
 	}
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	shutdownCtx, cancel := context.WithTimeout(t.Context(), time.Second)
 	defer cancel()
 	require.NoError(t, p.Shutdown(shutdownCtx))
 }
@@ -771,7 +771,7 @@ func TestLoadBalancerEndpointHealthActiveProbeLoopWaitsBeforeFirstCycle(t *testi
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan struct{})
 	go func() {
 		defer close(done)

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -708,7 +708,7 @@ func TestLoadBalancerEndpointHealthActiveProbeLoopStopsOnShutdown(t *testing.T) 
 	cfg.EndpointHealth.ActiveProbe = EndpointHealthActiveProbeConfig{
 		Enabled:        true,
 		Type:           EndpointHealthActiveProbeTypeTCPConnect,
-		Interval:       time.Hour,
+		Interval:       10 * time.Millisecond,
 		Timeout:        time.Minute,
 		Jitter:         "0%",
 		MaxConcurrency: 1,
@@ -724,8 +724,9 @@ func TestLoadBalancerEndpointHealthActiveProbeLoopStopsOnShutdown(t *testing.T) 
 	p.onBackendChanges([]string{"endpoint-1"})
 
 	probeStarted := make(chan struct{})
+	var startedOnce sync.Once
 	p.activeProbeFunc = func(ctx context.Context, _ string) error {
-		close(probeStarted)
+		startedOnce.Do(func() { close(probeStarted) })
 		<-ctx.Done()
 		return ctx.Err()
 	}
@@ -740,6 +741,57 @@ func TestLoadBalancerEndpointHealthActiveProbeLoopStopsOnShutdown(t *testing.T) 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	require.NoError(t, p.Shutdown(shutdownCtx))
+}
+
+func TestLoadBalancerEndpointHealthActiveProbeLoopWaitsBeforeFirstCycle(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+	cfg.EndpointHealth.ActiveProbe = EndpointHealthActiveProbeConfig{
+		Enabled:        true,
+		Type:           EndpointHealthActiveProbeTypeTCPConnect,
+		Interval:       200 * time.Millisecond,
+		Timeout:        50 * time.Millisecond,
+		Jitter:         "0%",
+		MaxConcurrency: 1,
+		Fall:           1,
+		Rise:           1,
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return mockComponent{}, nil
+	}
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	p.onBackendChanges([]string{"endpoint-1"})
+
+	probeStarted := make(chan struct{}, 1)
+	p.activeProbeFunc = func(context.Context, string) error {
+		probeStarted <- struct{}{}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		p.runEndpointHealthActiveProbeLoop(ctx)
+	}()
+
+	select {
+	case <-probeStarted:
+		cancel()
+		<-done
+		t.Fatal("active probe loop started before the first interval elapsed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("active probe loop did not stop after cancellation")
+	}
 }
 
 func TestLoadBalancerEndpointHealthRemovesDNSStaleEndpoint(t *testing.T) {

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -591,6 +591,68 @@ func TestLoadBalancerEndpointHealthActiveProbeUpdatesExistingHealthMetrics(t *te
 	}, metricdatatest.IgnoreTimestamp())
 }
 
+func TestLoadBalancerEndpointHealthProbeRecoveryKeepsActiveTransportQuarantineMetrics(t *testing.T) {
+	ts, tb, telemetry := getTelemetryAssetsWithReader(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+	cfg.EndpointHealth.ActiveProbe = EndpointHealthActiveProbeConfig{
+		Enabled:        true,
+		Type:           EndpointHealthActiveProbeTypeTCPConnect,
+		Interval:       time.Second,
+		Timeout:        100 * time.Millisecond,
+		Jitter:         "0%",
+		MaxConcurrency: 2,
+		Fall:           1,
+		Rise:           1,
+	}
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return mockComponent{}, nil
+	}
+	now := time.Unix(100, 0)
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	p.endpointHealth.settings.now = func() time.Time { return now }
+	p.onBackendChanges([]string{"endpoint-1", "endpoint-2"})
+
+	transportFailure := p.handleBackendFailure(t.Context(), "endpoint-1:4317", status.Error(codes.Unavailable, "unavailable"))
+	require.True(t, transportFailure.quarantined)
+	probeFailure := p.handleBackendProbeFailure(t.Context(), "endpoint-1:4317", errors.New("probe failed"))
+	require.True(t, probeFailure.quarantined)
+
+	probeSuccess := p.handleBackendProbeSuccess(t.Context(), "endpoint-1:4317")
+	require.False(t, probeSuccess.recovered)
+	require.NotContains(t, p.exporters, "endpoint-1:4317")
+	_, err = telemetry.GetMetric("otelcol_loadbalancer_backend_unquarantine_total")
+	require.Error(t, err)
+	metadatatest.AssertEqualLoadbalancerBackendState(t, telemetry, []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("state", "eligible")),
+			Value:      0,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("state", "quarantined")),
+			Value:      1,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("state", "stale")),
+			Value:      0,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-2:4317"), attribute.String("state", "eligible")),
+			Value:      1,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-2:4317"), attribute.String("state", "quarantined")),
+			Value:      0,
+		},
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-2:4317"), attribute.String("state", "stale")),
+			Value:      0,
+		},
+	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+}
+
 func TestLoadBalancerEndpointHealthActiveProbeCycleUsesTCPConnectAndRecoversEndpoint(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := simpleConfig()

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -651,6 +651,24 @@ func TestLoadBalancerEndpointHealthProbeRecoveryKeepsActiveTransportQuarantineMe
 			Value:      0,
 		},
 	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+
+	p.endpointHealth.mu.RLock()
+	state := p.endpointHealth.endpoints["endpoint-1:4317"]
+	quarantinedUntil := state.quarantinedUntil
+	failureReason := state.failureReason
+	p.endpointHealth.mu.RUnlock()
+	require.Equal(t, endpointFailureUnavailable, failureReason)
+
+	now = quarantinedUntil.Add(time.Nanosecond)
+	require.True(t, p.endpointHealth.quarantineRefreshDue())
+	p.refreshExpiredEndpointHealth(t.Context())
+	require.Contains(t, p.exporters, "endpoint-1:4317")
+	metadatatest.AssertEqualLoadbalancerBackendUnquarantineTotal(t, telemetry, []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("reason", string(endpointFailureUnavailable))),
+			Value:      1,
+		},
+	}, metricdatatest.IgnoreTimestamp())
 }
 
 func TestLoadBalancerEndpointHealthActiveProbeCycleUsesTCPConnectAndRecoversEndpoint(t *testing.T) {

--- a/exporter/loadbalancingexporter/testdata/config.yaml
+++ b/exporter/loadbalancingexporter/testdata/config.yaml
@@ -53,6 +53,15 @@ loadbalancing/6:
     quarantine_duration: 30s
     reroute_on_failure: true
     max_reroute_attempts: 1
+    active_probe:
+      enabled: true
+      type: tcp_connect
+      interval: 5s
+      timeout: 250ms
+      jitter: 20%
+      max_concurrency: 4
+      fall: 2
+      rise: 2
   protocol:
     otlp:
       timeout: 3s


### PR DESCRIPTION
loadbalancingexporter: Endpoint active probes

Adds active TCP reachability probes for endpoint_health so LB pods can exclude per-pod-unreachable backends before customer traffic hits them. SAW-7374.

Description
- Adds endpoint_health.active_probe config, validation, jittered probe loop, fall/rise transitions, and shutdown handling.
- Feeds probe unhealthy/healthy transitions through existing backend state/quarantine/fail-open metrics.
- Updates README, schema, sample config, and regression tests for exclusion, recovery, fail-open, and validation.

Tests
- go test ./... (from exporter/loadbalancingexporter)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new background probe loop that can dynamically remove/re-add backends and rebuild the routing ring, so misconfiguration or edge cases could impact traffic routing and exporter lifecycle. Feature is disabled by default, but when enabled it affects availability behavior and shutdown timing.
> 
> **Overview**
> Adds an **optional active reachability probe** under `endpoint_health` so each `loadbalancingexporter` pod can proactively exclude locally unreachable backends (TCP connect) and later re-admit them after configurable `fall`/`rise` thresholds, while preserving existing *fail-open* behavior when all backends are unhealthy.
> 
> Introduces new config/schema/defaults and validation for `endpoint_health.active_probe` (type, interval/timeout, jitter %, max concurrency, fall/rise), integrates probe-driven state into the existing quarantine/eligibility + metrics flow (`reason="active_probe"`), and adds a jittered, concurrency-limited probe loop that starts with the exporter and stops on shutdown, with expanded unit tests and docs/sample config/changelog updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e397d8813bb81b1b6940c0f4b0ea6667c338ab77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional TCP active probes to `loadbalancingexporter` under `endpoint_health` to exclude locally unreachable backends before routing, addressing SAW-7374. Recovery is tightened: probe success never overrides an active transport quarantine; readmission requires `rise` successes and the quarantine to expire, and export success/expiry won’t readmit while probes still mark the backend unhealthy; metrics preserve the original transport reason when applicable.

- **New Features**
  - `endpoint_health.active_probe` config with validation: `type: tcp_connect`, `interval`, `timeout < interval`, `jitter` (0–100%, non-finite rejected), `max_concurrency`, `fall`, `rise` (requires `endpoint_health.enabled=true`).
  - Jittered, concurrency-limited TCP-connect probe loop per LB pod; waits before first cycle, starts with the exporter, and stops cleanly on shutdown.
  - Probe failures/successes drive quarantine/readmit and rebuild the routing ring; fail-open when all endpoints are locally unhealthy.
  - Metrics reuse: transitions update `backend_state`, `backend_quarantine_total`, `backend_unquarantine_total`, and `backend_fail_open_total`, with reason reflecting the source (`active_probe` vs transport); README/schema/sample config updated; tests cover validation (incl. NaN/Inf jitter), exclusion/recovery, fail-open, concurrency, first-interval wait, reason preservation, and shutdown.

- **Migration**
  - Disabled by default; no change unless enabled.
  - Enable by setting `endpoint_health.enabled=true` and configuring `endpoint_health.active_probe` (default `type: tcp_connect`).
  - Keep using `forwarding_health.backend_usability` for readiness; exporter remains fail-open by default.

<sup>Written for commit e397d8813bb81b1b6940c0f4b0ea6667c338ab77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional active TCP probing for load balancer endpoint health checks with configurable intervals, timeouts, and recovery thresholds to safely exclude and recover unreachable backends.

* **Documentation**
  * Added design specifications and README documentation for active probe configuration and behavior.

* **Tests**
  * Added comprehensive test coverage for active probe health checking, endpoint exclusion/recovery, and concurrency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->