### PR TITLE
feat(loadbalancingexporter): add central compressed queue

### DIFF
--- a/.chloggen/loadbalancingexporter-central-compressed-queue.yaml
+++ b/.chloggen/loadbalancingexporter-central-compressed-queue.yaml
@@ -1,0 +1,8 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add opt-in central compressed queue support for load-balanced logs and metrics.
+issues: [54]
+subtext: |-
+  Adds `central_queue` with compressed-byte capacity, compressed OTLP queue storage,
+  and opt-in compressed pending chunks for the metric batcher.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -148,6 +148,15 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `max_bytes` flushes a backend batch when its serialized OTLP payload size before compression reaches this many bytes. Default: `1048576` (`1 MiB`).
   * `flush_interval` flushes a backend batch after this interval even if size limits are not reached. Default: `100ms`.
   * `payload_compression` compresses log batcher chunks while they are pending in memory. Supported values: `none`, `snappy`, `zstd`. Default: `none`.
+* The `metric_batcher` property enables post-routing metric batching per backend. It is `disabled` by default for backward compatibility.
+  * `payload_compression` compresses metric batcher chunks while they are pending in memory. Supported values: `none`, `snappy`, `zstd`. Default: `none`.
+* The `central_queue` property enables a single load-balancer queue per exporter instance for logs and metrics. It is `disabled` by default for backward compatibility.
+  * `enabled` turns the central compressed queue on or off.
+  * `max_compressed_bytes` sets the central queue capacity in compressed OTLP payload bytes and must be greater than zero when enabled.
+  * `payload_compression` controls queued payload compression. Supported values: `snappy`, `zstd`. Default: `zstd`.
+  * `max_uncompressed_batch_bytes` rejects any queued item whose uncompressed OTLP payload is larger than this guardrail. Default: `16777216` (`16 MiB`).
+  * `max_inflight_uncompressed_bytes` limits concurrently decompressed bytes while dispatching queue items. Default: `536870912` (`512 MiB`).
+  * Central queue mode is incompatible with `sending_queue.enabled=true`, `protocol.otlp.sending_queue`, `log_batcher.enabled=true`, and `metric_batcher.enabled=true`. Child OTLP exporter queues are disabled while central queue mode is active.
 
 Simple example
 
@@ -182,6 +191,12 @@ exporters:
       max_bytes: 1048576
       flush_interval: 100ms
       payload_compression: zstd
+    central_queue:
+      enabled: false
+      max_compressed_bytes: 4294967296
+      payload_compression: zstd
+      max_uncompressed_batch_bytes: 16777216
+      max_inflight_uncompressed_bytes: 536870912
     log_routing:
       ignore_trace_id: true
     routing_key: "service"

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -67,10 +67,6 @@ func (q *centralQueue) enqueueAt(item centralQueueItem, now time.Time) error {
 		q.settings.telemetry.recordRejected(context.Background(), int64(item.compressedBytes))
 		return errCentralQueueFull
 	}
-	item.routingKey = append([]byte(nil), item.routingKey...)
-	item.routingKey = item.routingKey[:len(item.routingKey):len(item.routingKey)]
-	item.payload = append([]byte(nil), item.payload...)
-	item.payload = item.payload[:len(item.payload):len(item.payload)]
 	if item.enqueuedAtUnixNano == 0 {
 		item.enqueuedAtUnixNano = now.UnixNano()
 	}

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -58,6 +58,10 @@ func (q *centralQueue) enqueueAt(item centralQueueItem, now time.Time) error {
 		q.settings.telemetry.recordRejected(context.Background(), int64(item.compressedBytes))
 		return errCentralQueueItemTooLarge
 	}
+	if q.settings.maxInflightUncompressedBytes > 0 && int64(item.uncompressedBytes) > q.settings.maxInflightUncompressedBytes {
+		q.settings.telemetry.recordRejected(context.Background(), int64(item.compressedBytes))
+		return errCentralQueueItemTooLarge
+	}
 
 	q.mu.Lock()
 	if q.stopped {

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -1,0 +1,195 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const centralQueueLeasePollInterval = 10 * time.Millisecond
+const (
+	centralQueueInitialRetryDelay = 100 * time.Millisecond
+	centralQueueMaxRetryDelay     = 5 * time.Second
+)
+
+type centralQueueSettings struct {
+	maxCompressedBytes           int64
+	maxInflightUncompressedBytes int64
+	maxUncompressedBatchBytes    int
+	telemetry                    *centralQueueTelemetry
+}
+
+type centralQueue struct {
+	settings centralQueueSettings
+
+	mu      sync.Mutex
+	items   []centralQueueItem
+	stopped bool
+
+	currentCompressedBytes int64
+	currentInflightBytes   int64
+}
+
+type centralQueueLease struct {
+	queue *centralQueue
+	item  centralQueueItem
+	once  sync.Once
+}
+
+func newCentralQueue(settings centralQueueSettings) *centralQueue {
+	return &centralQueue{settings: settings}
+}
+
+func (q *centralQueue) enqueue(item centralQueueItem) error {
+	return q.enqueueAt(item, time.Now())
+}
+
+func (q *centralQueue) requeue(item centralQueueItem, nextAttempt time.Time) error {
+	item.nextAttemptUnixNano = nextAttempt.UnixNano()
+	q.settings.telemetry.recordRetry(context.Background())
+	return q.enqueueAt(item, time.Now())
+}
+
+func (q *centralQueue) enqueueAt(item centralQueueItem, now time.Time) error {
+	if q.settings.maxUncompressedBatchBytes > 0 && item.uncompressedBytes > q.settings.maxUncompressedBatchBytes {
+		q.settings.telemetry.recordRejected(context.Background(), int64(item.compressedBytes))
+		return errCentralQueueItemTooLarge
+	}
+
+	q.mu.Lock()
+	if q.stopped {
+		q.mu.Unlock()
+		return errCentralQueueStopped
+	}
+	if q.currentCompressedBytes+int64(item.compressedBytes) > q.settings.maxCompressedBytes {
+		q.mu.Unlock()
+		q.settings.telemetry.recordRejected(context.Background(), int64(item.compressedBytes))
+		return errCentralQueueFull
+	}
+	item.routingKey = append([]byte(nil), item.routingKey...)
+	item.routingKey = item.routingKey[:len(item.routingKey):len(item.routingKey)]
+	item.payload = append([]byte(nil), item.payload...)
+	item.payload = item.payload[:len(item.payload):len(item.payload)]
+	if item.enqueuedAtUnixNano == 0 {
+		item.enqueuedAtUnixNano = now.UnixNano()
+	}
+	q.items = append(q.items, item)
+	q.currentCompressedBytes += int64(item.compressedBytes)
+	snapshot := q.snapshotLocked()
+	q.mu.Unlock()
+	q.settings.telemetry.record(context.Background(), snapshot)
+	return nil
+}
+
+func (q *centralQueue) lease(ctx context.Context) (*centralQueueLease, error) {
+	ticker := time.NewTicker(centralQueueLeasePollInterval)
+	defer ticker.Stop()
+
+	for {
+		if lease, err := q.tryLease(time.Now()); lease != nil || err != nil {
+			return lease, err
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.items) == 0 {
+		if q.stopped {
+			return nil, errCentralQueueStopped
+		}
+		return nil, nil
+	}
+
+	nowUnixNano := now.UnixNano()
+	readyInflightBlocked := false
+	for i, item := range q.items {
+		if item.nextAttemptUnixNano > nowUnixNano {
+			continue
+		}
+		if q.currentInflightBytes+int64(item.uncompressedBytes) > q.settings.maxInflightUncompressedBytes {
+			readyInflightBlocked = true
+			continue
+		}
+
+		q.items = removeCentralQueueItem(q.items, i)
+		q.currentCompressedBytes -= int64(item.compressedBytes)
+		q.currentInflightBytes += int64(item.uncompressedBytes)
+		snapshot := q.snapshotLocked()
+		q.settings.telemetry.record(context.Background(), snapshot)
+		return &centralQueueLease{queue: q, item: item}, nil
+	}
+	if readyInflightBlocked {
+		return nil, errCentralQueueInflightFull
+	}
+	return nil, nil
+}
+
+func removeCentralQueueItem(items []centralQueueItem, index int) []centralQueueItem {
+	copy(items[index:], items[index+1:])
+	items[len(items)-1] = centralQueueItem{}
+	return items[:len(items)-1]
+}
+
+func (l *centralQueueLease) done() {
+	l.once.Do(func() {
+		l.queue.mu.Lock()
+		l.queue.currentInflightBytes -= int64(l.item.uncompressedBytes)
+		snapshot := l.queue.snapshotLocked()
+		l.queue.mu.Unlock()
+		l.queue.settings.telemetry.record(context.Background(), snapshot)
+	})
+}
+
+func (q *centralQueue) stop() {
+	q.mu.Lock()
+	q.stopped = true
+	q.mu.Unlock()
+}
+
+func (q *centralQueue) compressedBytes() int64 {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.currentCompressedBytes
+}
+
+func (q *centralQueue) inflightUncompressedBytes() int64 {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.currentInflightBytes
+}
+
+func (q *centralQueue) len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.items)
+}
+
+func (q *centralQueue) snapshotLocked() centralQueueSnapshot {
+	return centralQueueSnapshot{
+		compressedBytes:      q.currentCompressedBytes,
+		compressedCapacity:   q.settings.maxCompressedBytes,
+		items:                int64(len(q.items)),
+		inflightUncompressed: q.currentInflightBytes,
+	}
+}
+
+func centralQueueRetryDelay(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	shift := min(attempt, 6)
+	delay := centralQueueInitialRetryDelay * time.Duration(1<<shift)
+	return min(delay, centralQueueMaxRetryDelay)
+}

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -47,12 +47,6 @@ func (q *centralQueue) enqueue(item centralQueueItem) error {
 	return q.enqueueAt(item, time.Now())
 }
 
-func (q *centralQueue) requeue(item centralQueueItem, nextAttempt time.Time) error {
-	item.nextAttemptUnixNano = nextAttempt.UnixNano()
-	q.settings.telemetry.recordRetry(context.Background())
-	return q.enqueueAt(item, time.Now())
-}
-
 func (q *centralQueue) enqueueAt(item centralQueueItem, now time.Time) error {
 	if q.settings.maxUncompressedBatchBytes > 0 && item.uncompressedBytes > q.settings.maxUncompressedBatchBytes {
 		q.settings.telemetry.recordRejected(context.Background(), int64(item.compressedBytes))
@@ -128,7 +122,6 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 		}
 
 		q.items = removeCentralQueueItem(q.items, i)
-		q.currentCompressedBytes -= int64(item.compressedBytes)
 		q.currentInflightBytes += int64(item.uncompressedBytes)
 		snapshot := q.snapshotLocked()
 		q.settings.telemetry.record(context.Background(), snapshot)
@@ -150,10 +143,33 @@ func (l *centralQueueLease) done() {
 	l.once.Do(func() {
 		l.queue.mu.Lock()
 		l.queue.currentInflightBytes -= int64(l.item.uncompressedBytes)
+		l.queue.currentCompressedBytes -= int64(l.item.compressedBytes)
 		snapshot := l.queue.snapshotLocked()
 		l.queue.mu.Unlock()
 		l.queue.settings.telemetry.record(context.Background(), snapshot)
 	})
+}
+
+func (l *centralQueueLease) requeue(nextAttempt time.Time) error {
+	var err error
+	l.once.Do(func() {
+		item := l.item
+		item.nextAttemptUnixNano = nextAttempt.UnixNano()
+		l.queue.settings.telemetry.recordRetry(context.Background())
+
+		l.queue.mu.Lock()
+		l.queue.currentInflightBytes -= int64(item.uncompressedBytes)
+		if l.queue.stopped {
+			l.queue.currentCompressedBytes -= int64(item.compressedBytes)
+			err = errCentralQueueStopped
+		} else {
+			l.queue.items = append(l.queue.items, item)
+		}
+		snapshot := l.queue.snapshotLocked()
+		l.queue.mu.Unlock()
+		l.queue.settings.telemetry.record(context.Background(), snapshot)
+	})
+	return err
 }
 
 func (q *centralQueue) stop() {

--- a/exporter/loadbalancingexporter/central_queue_item.go
+++ b/exporter/loadbalancingexporter/central_queue_item.go
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import "errors"
+
+type signalKind string
+
+const (
+	signalKindLogs    signalKind = "logs"
+	signalKindMetrics signalKind = "metrics"
+)
+
+var (
+	errCentralQueueFull         = errors.New("central queue is full")
+	errCentralQueueInflightFull = errors.New("central queue inflight uncompressed budget is full")
+	errCentralQueueStopped      = errors.New("central queue is stopped")
+	errCentralQueueItemTooLarge = errors.New("central queue item exceeds max uncompressed batch bytes")
+)
+
+type centralQueueItem struct {
+	signal              signalKind
+	routingKey          []byte
+	payload             []byte
+	compressedBytes     int
+	uncompressedBytes   int
+	count               int
+	enqueuedAtUnixNano  int64
+	attempt             int
+	nextAttemptUnixNano int64
+}

--- a/exporter/loadbalancingexporter/central_queue_logs.go
+++ b/exporter/loadbalancingexporter/central_queue_logs.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func newCentralQueueLogsItem(routingKey []byte, logs plog.Logs, codec *queuePayloadCodec, now time.Time) (centralQueueItem, error) {
+	marshaler := &plog.ProtoMarshaler{}
+	payload, err := marshaler.MarshalLogs(logs)
+	if err != nil {
+		return centralQueueItem{}, err
+	}
+	encoded, err := codec.Encode(payload)
+	if err != nil {
+		return centralQueueItem{}, err
+	}
+	encoded = append([]byte(nil), encoded...)
+	encoded = encoded[:len(encoded):len(encoded)]
+	return centralQueueItem{
+		signal:             signalKindLogs,
+		routingKey:         append([]byte(nil), routingKey...),
+		payload:            encoded,
+		compressedBytes:    len(encoded),
+		uncompressedBytes:  len(payload),
+		count:              logs.LogRecordCount(),
+		enqueuedAtUnixNano: now.UnixNano(),
+	}, nil
+}
+
+func decodeCentralQueueLogsItem(item centralQueueItem, codec *queuePayloadCodec) (plog.Logs, error) {
+	decoded, err := codec.Decode(item.payload)
+	if err != nil {
+		return plog.Logs{}, err
+	}
+	return (&plog.ProtoUnmarshaler{}).UnmarshalLogs(decoded)
+}

--- a/exporter/loadbalancingexporter/central_queue_logs_test.go
+++ b/exporter/loadbalancingexporter/central_queue_logs_test.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCentralQueueLogsItemDoesNotRetainUncompressedPayload(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	logs := compressibleLogs(16000, 2048)
+	item, err := newCentralQueueLogsItem([]byte("route-a"), logs, codec, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, signalKindLogs, item.signal)
+	require.Equal(t, logs.LogRecordCount(), item.count)
+	require.Greater(t, item.uncompressedBytes, item.compressedBytes*100)
+	require.Len(t, item.payload, item.compressedBytes)
+	require.Equal(t, len(item.payload), cap(item.payload))
+
+	decoded, err := decodeCentralQueueLogsItem(item, codec)
+	require.NoError(t, err)
+	require.Equal(t, logs.LogRecordCount(), decoded.LogRecordCount())
+}

--- a/exporter/loadbalancingexporter/central_queue_logs_test.go
+++ b/exporter/loadbalancingexporter/central_queue_logs_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
 )
 
 func TestCentralQueueLogsItemDoesNotRetainUncompressedPayload(t *testing.T) {
@@ -25,5 +27,5 @@ func TestCentralQueueLogsItemDoesNotRetainUncompressedPayload(t *testing.T) {
 
 	decoded, err := decodeCentralQueueLogsItem(item, codec)
 	require.NoError(t, err)
-	require.Equal(t, logs.LogRecordCount(), decoded.LogRecordCount())
+	require.NoError(t, plogtest.CompareLogs(logs, decoded))
 }

--- a/exporter/loadbalancingexporter/central_queue_metrics.go
+++ b/exporter/loadbalancingexporter/central_queue_metrics.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func newCentralQueueMetricsItem(routingKey []byte, md pmetric.Metrics, codec *queuePayloadCodec, now time.Time) (centralQueueItem, error) {
+	marshaler := &pmetric.ProtoMarshaler{}
+	payload, err := marshaler.MarshalMetrics(md)
+	if err != nil {
+		return centralQueueItem{}, err
+	}
+	encoded, err := codec.Encode(payload)
+	if err != nil {
+		return centralQueueItem{}, err
+	}
+	encoded = append([]byte(nil), encoded...)
+	encoded = encoded[:len(encoded):len(encoded)]
+	return centralQueueItem{
+		signal:             signalKindMetrics,
+		routingKey:         append([]byte(nil), routingKey...),
+		payload:            encoded,
+		compressedBytes:    len(encoded),
+		uncompressedBytes:  len(payload),
+		count:              md.DataPointCount(),
+		enqueuedAtUnixNano: now.UnixNano(),
+	}, nil
+}
+
+func decodeCentralQueueMetricsItem(item centralQueueItem, codec *queuePayloadCodec) (pmetric.Metrics, error) {
+	decoded, err := codec.Decode(item.payload)
+	if err != nil {
+		return pmetric.Metrics{}, err
+	}
+	return (&pmetric.ProtoUnmarshaler{}).UnmarshalMetrics(decoded)
+}

--- a/exporter/loadbalancingexporter/central_queue_metrics_test.go
+++ b/exporter/loadbalancingexporter/central_queue_metrics_test.go
@@ -38,7 +38,7 @@ func compressibleMetrics(points int) pmetric.Metrics {
 	metric := sm.Metrics().AppendEmpty()
 	metric.SetName("central.queue.test")
 	metric.SetEmptyGauge()
-	for i := 0; i < points; i++ {
+	for range points {
 		dp := metric.Gauge().DataPoints().AppendEmpty()
 		dp.SetIntValue(42)
 		dp.Attributes().PutStr("host.name", "same-host")

--- a/exporter/loadbalancingexporter/central_queue_metrics_test.go
+++ b/exporter/loadbalancingexporter/central_queue_metrics_test.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestCentralQueueMetricsItemDoesNotRetainUncompressedPayload(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	md := compressibleMetrics(4096)
+	item, err := newCentralQueueMetricsItem([]byte("route-a"), md, codec, time.Now())
+	require.NoError(t, err)
+	require.Equal(t, signalKindMetrics, item.signal)
+	require.Equal(t, md.DataPointCount(), item.count)
+	require.Greater(t, item.uncompressedBytes, item.compressedBytes)
+	require.Len(t, item.payload, item.compressedBytes)
+	require.Equal(t, len(item.payload), cap(item.payload))
+
+	decoded, err := decodeCentralQueueMetricsItem(item, codec)
+	require.NoError(t, err)
+	require.Equal(t, md.DataPointCount(), decoded.DataPointCount())
+}
+
+func compressibleMetrics(points int) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	rm := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().Attributes().PutStr("service.name", "central-queue-test")
+	sm := rm.ScopeMetrics().AppendEmpty()
+	sm.Scope().SetName("central-queue-test")
+	metric := sm.Metrics().AppendEmpty()
+	metric.SetName("central.queue.test")
+	metric.SetEmptyGauge()
+	for i := 0; i < points; i++ {
+		dp := metric.Gauge().DataPoints().AppendEmpty()
+		dp.SetIntValue(42)
+		dp.Attributes().PutStr("host.name", "same-host")
+		dp.Attributes().PutStr("deployment.environment", "test")
+	}
+	return md
+}

--- a/exporter/loadbalancingexporter/central_queue_metrics_test.go
+++ b/exporter/loadbalancingexporter/central_queue_metrics_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
 )
 
 func TestCentralQueueMetricsItemDoesNotRetainUncompressedPayload(t *testing.T) {
@@ -26,7 +28,7 @@ func TestCentralQueueMetricsItemDoesNotRetainUncompressedPayload(t *testing.T) {
 
 	decoded, err := decodeCentralQueueMetricsItem(item, codec)
 	require.NoError(t, err)
-	require.Equal(t, md.DataPointCount(), decoded.DataPointCount())
+	require.NoError(t, pmetrictest.CompareMetrics(md, decoded))
 }
 
 func compressibleMetrics(points int) pmetric.Metrics {

--- a/exporter/loadbalancingexporter/central_queue_telemetry.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry.go
@@ -1,0 +1,111 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+)
+
+type centralQueueTelemetry struct {
+	signalAttrs          metric.MeasurementOption
+	compressedBytes      metric.Int64Gauge
+	compressedCapacity   metric.Int64Gauge
+	saturation           metric.Float64Gauge
+	items                metric.Int64Gauge
+	rejectedBytes        metric.Int64Counter
+	retries              metric.Int64Counter
+	inflightUncompressed metric.Int64Gauge
+}
+
+type centralQueueSnapshot struct {
+	compressedBytes      int64
+	compressedCapacity   int64
+	items                int64
+	inflightUncompressed int64
+}
+
+func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signalKind) (*centralQueueTelemetry, error) {
+	meter := metadata.Meter(settings)
+	var err, errs error
+	t := &centralQueueTelemetry{
+		signalAttrs: metric.WithAttributeSet(attribute.NewSet(attribute.String("signal", string(signal)))),
+	}
+	t.compressedBytes, err = meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_compressed_bytes",
+		metric.WithDescription("Current compressed bytes in the central load-balancing queue."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	t.compressedCapacity, err = meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_compressed_capacity",
+		metric.WithDescription("Configured compressed byte capacity of the central load-balancing queue."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	t.saturation, err = meter.Float64Gauge(
+		"otelcol_loadbalancer_central_queue_saturation",
+		metric.WithDescription("Central load-balancing queue compressed byte saturation."),
+		metric.WithUnit("1"),
+	)
+	errs = errors.Join(errs, err)
+	t.items, err = meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_items",
+		metric.WithDescription("Current items in the central load-balancing queue."),
+		metric.WithUnit("{items}"),
+	)
+	errs = errors.Join(errs, err)
+	t.rejectedBytes, err = meter.Int64Counter(
+		"otelcol_loadbalancer_central_queue_rejected_compressed_bytes",
+		metric.WithDescription("Compressed bytes rejected by the central load-balancing queue."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	t.retries, err = meter.Int64Counter(
+		"otelcol_loadbalancer_central_queue_retries",
+		metric.WithDescription("Central load-balancing queue item retries."),
+		metric.WithUnit("{retries}"),
+	)
+	errs = errors.Join(errs, err)
+	t.inflightUncompressed, err = meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_inflight_uncompressed_bytes",
+		metric.WithDescription("Uncompressed bytes currently leased from the central load-balancing queue."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	return t, errs
+}
+
+func (t *centralQueueTelemetry) record(ctx context.Context, snapshot centralQueueSnapshot) {
+	if t == nil {
+		return
+	}
+	t.compressedBytes.Record(ctx, snapshot.compressedBytes, t.signalAttrs)
+	t.compressedCapacity.Record(ctx, snapshot.compressedCapacity, t.signalAttrs)
+	if snapshot.compressedCapacity > 0 {
+		t.saturation.Record(ctx, float64(snapshot.compressedBytes)/float64(snapshot.compressedCapacity), t.signalAttrs)
+	}
+	t.items.Record(ctx, snapshot.items, t.signalAttrs)
+	t.inflightUncompressed.Record(ctx, snapshot.inflightUncompressed, t.signalAttrs)
+}
+
+func (t *centralQueueTelemetry) recordRejected(ctx context.Context, compressedBytes int64) {
+	if t == nil || compressedBytes <= 0 {
+		return
+	}
+	t.rejectedBytes.Add(ctx, compressedBytes, t.signalAttrs)
+}
+
+func (t *centralQueueTelemetry) recordRetry(ctx context.Context) {
+	if t == nil {
+		return
+	}
+	t.retries.Add(ctx, 1, t.signalAttrs)
+}

--- a/exporter/loadbalancingexporter/central_queue_telemetry_test.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry_test.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
+	reader := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, reader.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	telemetry, err := newCentralQueueTelemetry(reader.NewTelemetrySettings(), signalKindLogs)
+	require.NoError(t, err)
+
+	telemetry.record(t.Context(), centralQueueSnapshot{
+		compressedBytes:      50,
+		compressedCapacity:   100,
+		items:                3,
+		inflightUncompressed: 80,
+	})
+	telemetry.recordRejected(t.Context(), 7)
+	telemetry.recordRetry(t.Context())
+
+	attrs := attribute.NewSet(attribute.String("signal", string(signalKindLogs)))
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_compressed_bytes", "By", attrs, 50)
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_compressed_capacity", "By", attrs, 100)
+	requireCentralQueueFloatGauge(t, reader, "otelcol_loadbalancer_central_queue_saturation", "1", attrs, 0.5)
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_items", "{items}", attrs, 3)
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_inflight_uncompressed_bytes", "By", attrs, 80)
+	requireCentralQueueIntSum(t, reader, "otelcol_loadbalancer_central_queue_rejected_compressed_bytes", "By", attrs, 7)
+	requireCentralQueueIntSum(t, reader, "otelcol_loadbalancer_central_queue_retries", "{retries}", attrs, 1)
+}
+
+func requireCentralQueueIntGauge(t *testing.T, reader *componenttest.Telemetry, name, unit string, attrs attribute.Set, value int64) {
+	t.Helper()
+	metric, err := reader.GetMetric(name)
+	require.NoError(t, err)
+	require.Equal(t, unit, metric.Unit)
+	gauge, ok := metric.Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	require.Len(t, gauge.DataPoints, 1)
+	require.Equal(t, attrs, gauge.DataPoints[0].Attributes)
+	require.Equal(t, value, gauge.DataPoints[0].Value)
+}
+
+func requireCentralQueueFloatGauge(t *testing.T, reader *componenttest.Telemetry, name, unit string, attrs attribute.Set, value float64) {
+	t.Helper()
+	metric, err := reader.GetMetric(name)
+	require.NoError(t, err)
+	require.Equal(t, unit, metric.Unit)
+	gauge, ok := metric.Data.(metricdata.Gauge[float64])
+	require.True(t, ok)
+	require.Len(t, gauge.DataPoints, 1)
+	require.Equal(t, attrs, gauge.DataPoints[0].Attributes)
+	require.Equal(t, value, gauge.DataPoints[0].Value)
+}
+
+func requireCentralQueueIntSum(t *testing.T, reader *componenttest.Telemetry, name, unit string, attrs attribute.Set, value int64) {
+	t.Helper()
+	metric, err := reader.GetMetric(name)
+	require.NoError(t, err)
+	require.Equal(t, unit, metric.Unit)
+	sum, ok := metric.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	require.Len(t, sum.DataPoints, 1)
+	require.Equal(t, attrs, sum.DataPoints[0].Attributes)
+	require.Equal(t, value, sum.DataPoints[0].Value)
+}

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCentralQueueAdmitsByCompressedBytes(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           10,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+	})
+
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 4, uncompressedBytes: 40, count: 1}))
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 6, uncompressedBytes: 60, count: 1}))
+	require.ErrorIs(t, q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 1, uncompressedBytes: 10, count: 1}), errCentralQueueFull)
+	require.EqualValues(t, 10, q.compressedBytes())
+}
+
+func TestCentralQueueLeaseReservesInflightUncompressedBytes(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 50,
+		maxUncompressedBatchBytes:    100,
+	})
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindMetrics, compressedBytes: 10, uncompressedBytes: 40, count: 1}))
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindMetrics, compressedBytes: 10, uncompressedBytes: 40, count: 1}))
+
+	lease, err := q.lease(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 40, q.inflightUncompressedBytes())
+
+	_, err = q.lease(t.Context())
+	require.ErrorIs(t, err, errCentralQueueInflightFull)
+
+	lease.done()
+	require.EqualValues(t, 0, q.inflightUncompressedBytes())
+}
+
+func TestCentralQueueRejectsOversizedUncompressedItem(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    50,
+	})
+
+	err := q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 10, uncompressedBytes: 51, count: 1})
+	require.ErrorIs(t, err, errCentralQueueItemTooLarge)
+	require.Zero(t, q.compressedBytes())
+}
+
+func TestCentralQueueLeaseReturnsContextErrorWhenEmpty(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := q.lease(ctx)
+	require.True(t, errors.Is(err, ctx.Err()))
+}
+
+func TestCentralQueueStopAllowsDrainingExistingItems(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+	})
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 10, uncompressedBytes: 10, count: 1}))
+	q.stop()
+
+	lease, err := q.lease(t.Context())
+	require.NoError(t, err)
+	lease.done()
+
+	_, err = q.lease(t.Context())
+	require.ErrorIs(t, err, errCentralQueueStopped)
+}

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -120,3 +120,21 @@ func TestCentralQueueStopAllowsDrainingExistingItems(t *testing.T) {
 	_, err = q.lease(t.Context())
 	require.ErrorIs(t, err, errCentralQueueStopped)
 }
+
+func requireCentralQueueFirstRetryDelay(t *testing.T, q *centralQueue) {
+	t.Helper()
+
+	var item centralQueueItem
+	require.Eventually(t, func() bool {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		if len(q.items) != 1 || q.items[0].attempt != 1 || q.items[0].nextAttemptUnixNano == 0 {
+			return false
+		}
+		item = q.items[0]
+		return true
+	}, time.Second, time.Millisecond)
+
+	retryAfterEnqueue := time.Unix(0, item.nextAttemptUnixNano).Sub(time.Unix(0, item.enqueuedAtUnixNano))
+	require.LessOrEqual(t, retryAfterEnqueue, centralQueueInitialRetryDelay+50*time.Millisecond)
+}

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -55,6 +55,18 @@ func TestCentralQueueRejectsOversizedUncompressedItem(t *testing.T) {
 	require.Zero(t, q.compressedBytes())
 }
 
+func TestCentralQueueRejectsItemLargerThanInflightBudget(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 50,
+		maxUncompressedBatchBytes:    100,
+	})
+
+	err := q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 10, uncompressedBytes: 51, count: 1})
+	require.ErrorIs(t, err, errCentralQueueItemTooLarge)
+	require.Zero(t, q.compressedBytes())
+}
+
 func TestCentralQueueLeaseReturnsContextErrorWhenEmpty(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:           100,

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -5,7 +5,6 @@ package loadbalancingexporter
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -66,7 +65,7 @@ func TestCentralQueueLeaseReturnsContextErrorWhenEmpty(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 	_, err := q.lease(ctx)
-	require.True(t, errors.Is(err, ctx.Err()))
+	require.ErrorIs(t, err, ctx.Err())
 }
 
 func TestCentralQueueStopAllowsDrainingExistingItems(t *testing.T) {

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -6,6 +6,7 @@ package loadbalancingexporter
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -41,6 +42,29 @@ func TestCentralQueueLeaseReservesInflightUncompressedBytes(t *testing.T) {
 
 	lease.done()
 	require.EqualValues(t, 0, q.inflightUncompressedBytes())
+}
+
+func TestCentralQueueLeaseReservesCompressedBytesUntilDoneOrRequeue(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           10,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+	})
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 10, uncompressedBytes: 40, count: 1}))
+
+	lease, err := q.lease(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 10, q.compressedBytes())
+	require.ErrorIs(t, q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 1, uncompressedBytes: 1, count: 1}), errCentralQueueFull)
+
+	require.NoError(t, lease.requeue(time.Now()))
+	require.Equal(t, 1, q.len())
+	require.EqualValues(t, 10, q.compressedBytes())
+
+	retryLease, err := q.lease(t.Context())
+	require.NoError(t, err)
+	retryLease.done()
+	require.Zero(t, q.compressedBytes())
 }
 
 func TestCentralQueueRejectsOversizedUncompressedItem(t *testing.T) {

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	TimeoutSettings           exporterhelper.TimeoutConfig `mapstructure:",squash"`
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 	QueueSettings             QueueSettings        `mapstructure:"sending_queue"`
+	CentralQueue              CentralQueueConfig   `mapstructure:"central_queue"`
 	LogBatcher                LogBatcherConfig     `mapstructure:"log_batcher"`
 	LogRouting                LogRoutingConfig     `mapstructure:"log_routing"`
 	MetricBatcher             MetricBatcherConfig  `mapstructure:"metric_batcher"`
@@ -60,6 +61,8 @@ type Config struct {
 	// Supports all attributes available (both resource and span), as well as the pseudo attributes "span.kind" and
 	// "span.name".
 	RoutingAttributes []string `mapstructure:"routing_attributes"`
+
+	protocolOTLPSendingQueueConfigured bool
 }
 
 func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
@@ -78,8 +81,11 @@ func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
 		return nil
 	}
 
-	if rawQueue, ok := otlpRaw["sending_queue"]; ok && rawQueue == nil {
-		cfg.Protocol.OTLP.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+	if rawQueue, ok := otlpRaw["sending_queue"]; ok {
+		cfg.protocolOTLPSendingQueueConfigured = rawQueue != nil
+		if rawQueue == nil {
+			cfg.Protocol.OTLP.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+		}
 	}
 
 	return nil
@@ -107,11 +113,12 @@ type LogRoutingConfig struct {
 }
 
 type MetricBatcherConfig struct {
-	Enabled                  bool          `mapstructure:"enabled"`
-	MaxDataPoints            int           `mapstructure:"max_datapoints"`
-	MaxBytes                 int           `mapstructure:"max_bytes"`
-	FlushInterval            time.Duration `mapstructure:"flush_interval"`
-	MaxRetryBufferMultiplier int           `mapstructure:"max_retry_buffer_multiplier"`
+	Enabled                  bool                    `mapstructure:"enabled"`
+	MaxDataPoints            int                     `mapstructure:"max_datapoints"`
+	MaxBytes                 int                     `mapstructure:"max_bytes"`
+	FlushInterval            time.Duration           `mapstructure:"flush_interval"`
+	MaxRetryBufferMultiplier int                     `mapstructure:"max_retry_buffer_multiplier"`
+	PayloadCompression       QueuePayloadCompression `mapstructure:"payload_compression"`
 }
 
 const defaultEndpointHealthQuarantineDuration = 30 * time.Second
@@ -213,6 +220,19 @@ const (
 	QueuePayloadCompressionZstd   QueuePayloadCompression = "zstd"
 )
 
+const (
+	defaultCentralQueueMaxUncompressedBatchBytes = 16 << 20
+	defaultCentralQueueMaxInflightBytes          = int64(512 << 20)
+)
+
+type CentralQueueConfig struct {
+	Enabled                      bool                    `mapstructure:"enabled"`
+	MaxCompressedBytes           int64                   `mapstructure:"max_compressed_bytes"`
+	PayloadCompression           QueuePayloadCompression `mapstructure:"payload_compression"`
+	MaxUncompressedBatchBytes    int                     `mapstructure:"max_uncompressed_batch_bytes"`
+	MaxInflightUncompressedBytes int64                   `mapstructure:"max_inflight_uncompressed_bytes"`
+}
+
 func (q QueueSettings) Validate() error {
 	if q.QueueConfig.HasValue() {
 		queueCfg := *q.QueueConfig.Get()
@@ -241,6 +261,21 @@ func (cfg *Config) Validate() error {
 	if err := cfg.QueueSettings.Validate(); err != nil {
 		return err
 	}
+	if err := cfg.CentralQueue.Validate(); err != nil {
+		return err
+	}
+	if cfg.CentralQueue.Enabled && cfg.QueueSettings.QueueConfig.HasValue() {
+		return errors.New("central_queue.enabled=true is incompatible with sending_queue.enabled=true")
+	}
+	if cfg.CentralQueue.Enabled && cfg.protocolOTLPSendingQueueConfigured {
+		return errors.New("central_queue.enabled=true is incompatible with protocol.otlp.sending_queue")
+	}
+	if cfg.CentralQueue.Enabled && cfg.LogBatcher.Enabled {
+		return errors.New("central_queue.enabled=true is incompatible with log_batcher.enabled=true")
+	}
+	if cfg.CentralQueue.Enabled && cfg.MetricBatcher.Enabled {
+		return errors.New("central_queue.enabled=true is incompatible with metric_batcher.enabled=true")
+	}
 	if err := cfg.LogBatcher.Validate(); err != nil {
 		return err
 	}
@@ -248,6 +283,30 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 	return cfg.EndpointHealth.Validate()
+}
+
+func (c CentralQueueConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.MaxCompressedBytes <= 0 {
+		return errors.New("central_queue.max_compressed_bytes must be greater than 0 when central_queue.enabled=true")
+	}
+	switch c.PayloadCompression {
+	case QueuePayloadCompressionSnappy, QueuePayloadCompressionZstd:
+		// Valid central queue payload compression value.
+	case "", QueuePayloadCompressionNone:
+		return errors.New("central_queue.payload_compression must be set to snappy or zstd when central_queue.enabled=true")
+	default:
+		return fmt.Errorf("central_queue.payload_compression must be one of [snappy, zstd], found %q", c.PayloadCompression)
+	}
+	if c.MaxUncompressedBatchBytes <= 0 {
+		return errors.New("central_queue.max_uncompressed_batch_bytes must be greater than 0 when central_queue.enabled=true")
+	}
+	if c.MaxInflightUncompressedBytes <= 0 {
+		return errors.New("central_queue.max_inflight_uncompressed_bytes must be greater than 0 when central_queue.enabled=true")
+	}
+	return nil
 }
 
 func (c LogBatcherConfig) Validate() error {
@@ -287,6 +346,12 @@ func (c MetricBatcherConfig) Validate() error {
 	}
 	if c.MaxRetryBufferMultiplier <= 0 {
 		return errors.New("metric_batcher.max_retry_buffer_multiplier must be greater than 0 when metric_batcher.enabled=true")
+	}
+	switch c.PayloadCompression {
+	case "", QueuePayloadCompressionNone, QueuePayloadCompressionSnappy, QueuePayloadCompressionZstd:
+		// Valid payload compression value.
+	default:
+		return fmt.Errorf("metric_batcher.payload_compression must be one of [none, snappy, zstd], found %q", c.PayloadCompression)
 	}
 	return nil
 }

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -306,6 +306,9 @@ func (c CentralQueueConfig) Validate() error {
 	if c.MaxInflightUncompressedBytes <= 0 {
 		return errors.New("central_queue.max_inflight_uncompressed_bytes must be greater than 0 when central_queue.enabled=true")
 	}
+	if int64(c.MaxUncompressedBatchBytes) > c.MaxInflightUncompressedBytes {
+		return errors.New("central_queue.max_uncompressed_batch_bytes must be less than or equal to central_queue.max_inflight_uncompressed_bytes")
+	}
 	return nil
 }
 

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -66,9 +66,18 @@ type Config struct {
 }
 
 func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
+	cfg.protocolOTLPSendingQueueConfigured = false
+
 	type rawConfig Config
 	if err := conf.Unmarshal((*rawConfig)(cfg)); err != nil {
 		return err
+	}
+
+	if !conf.IsSet("protocol::otlp::sending_queue") {
+		if cfg.CentralQueue.Enabled {
+			cfg.Protocol.OTLP.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+		}
+		return nil
 	}
 
 	protocolRaw, ok := conf.ToStringMap()["protocol"].(map[string]any)

--- a/exporter/loadbalancingexporter/config.schema.yaml
+++ b/exporter/loadbalancingexporter/config.schema.yaml
@@ -1,4 +1,26 @@
 $defs:
+  central_queue_config:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      max_compressed_bytes:
+        type: integer
+        minimum: 1
+        description: Must be greater than 0 when central_queue.enabled is true.
+      max_inflight_uncompressed_bytes:
+        type: integer
+        minimum: 1
+        description: Must be greater than 0 when central_queue.enabled is true.
+      max_uncompressed_batch_bytes:
+        type: integer
+        minimum: 1
+        description: Must be greater than 0 when central_queue.enabled is true.
+      payload_compression:
+        type: string
+        enum:
+          - snappy
+          - zstd
   aws_cloud_map_resolver:
     type: object
     properties:
@@ -98,6 +120,29 @@ $defs:
     properties:
       ignore_trace_id:
         type: boolean
+  metric_batcher_config:
+    type: object
+    properties:
+      enabled:
+        type: boolean
+      flush_interval:
+        type: string
+        format: duration
+      max_bytes:
+        type: integer
+        minimum: 1
+      max_datapoints:
+        type: integer
+        minimum: 1
+      max_retry_buffer_multiplier:
+        type: integer
+        minimum: 1
+      payload_compression:
+        type: string
+        enum:
+          - none
+          - snappy
+          - zstd
   protocol:
     description: Protocol holds the individual protocol-specific settings. Only OTLP is supported at the moment.
     type: object
@@ -131,10 +176,14 @@ $defs:
 description: Config defines configuration for the exporter.
 type: object
 properties:
+  central_queue:
+    $ref: central_queue_config
   endpoint_health:
     $ref: endpoint_health_config
   log_routing:
     $ref: log_routing_config
+  metric_batcher:
+    $ref: metric_batcher_config
   protocol:
     $ref: protocol
   resolver:

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -241,6 +241,58 @@ func TestCentralQueueRejectsChildOTLPQueue(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "central_queue.enabled=true is incompatible with protocol.otlp.sending_queue")
 }
 
+func TestCentralQueueAllowsChildOTLPQueueRemovalAcrossUnmarshal(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	withChildQueue := confmap.NewFromStringMap(map[string]any{
+		"protocol": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "localhost:4317",
+				"tls": map[string]any{
+					"insecure": true,
+				},
+				"sending_queue": map[string]any{
+					"enabled":    true,
+					"queue_size": 1000,
+				},
+			},
+		},
+		"resolver": map[string]any{
+			"static": map[string]any{
+				"hostnames": []string{"localhost:4317"},
+			},
+		},
+	})
+	withoutChildQueue := confmap.NewFromStringMap(map[string]any{
+		"central_queue": map[string]any{
+			"enabled":                         true,
+			"max_compressed_bytes":            1024,
+			"payload_compression":             "zstd",
+			"max_uncompressed_batch_bytes":    1024,
+			"max_inflight_uncompressed_bytes": 2048,
+		},
+		"protocol": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "localhost:4317",
+				"tls": map[string]any{
+					"insecure": true,
+				},
+			},
+		},
+		"resolver": map[string]any{
+			"static": map[string]any{
+				"hostnames": []string{"localhost:4317"},
+			},
+		},
+	})
+
+	require.NoError(t, withChildQueue.Unmarshal(cfg))
+	require.True(t, cfg.protocolOTLPSendingQueueConfigured)
+
+	require.NoError(t, withoutChildQueue.Unmarshal(cfg))
+	require.False(t, cfg.protocolOTLPSendingQueueConfigured)
+	require.NoError(t, cfg.Validate())
+}
+
 func TestCentralQueueRejectsIndependentBuffering(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -119,6 +119,159 @@ func TestConfigValidateMetricBatcher(t *testing.T) {
 
 	cfg.MetricBatcher.MaxRetryBufferMultiplier = 5
 	require.NoError(t, cfg.Validate())
+
+	cfg.MetricBatcher.PayloadCompression = QueuePayloadCompression("brotli")
+	require.ErrorContains(t, cfg.Validate(), "metric_batcher.payload_compression")
+
+	cfg.MetricBatcher.PayloadCompression = QueuePayloadCompressionSnappy
+	require.NoError(t, cfg.Validate())
+
+	cfg.MetricBatcher.PayloadCompression = QueuePayloadCompressionZstd
+	require.NoError(t, cfg.Validate())
+}
+
+func TestCentralQueueDefaultDisabled(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+
+	require.False(t, cfg.CentralQueue.Enabled)
+	require.Zero(t, cfg.CentralQueue.MaxCompressedBytes)
+	require.Equal(t, QueuePayloadCompressionZstd, cfg.CentralQueue.PayloadCompression)
+	require.Equal(t, 16<<20, cfg.CentralQueue.MaxUncompressedBatchBytes)
+	require.Equal(t, int64(512<<20), cfg.CentralQueue.MaxInflightUncompressedBytes)
+	require.NoError(t, cfg.Validate())
+}
+
+func TestCentralQueueValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(*CentralQueueConfig)
+		expectedErr string
+	}{
+		{
+			name:        "missing compressed budget",
+			mutate:      func(c *CentralQueueConfig) { c.MaxCompressedBytes = 0 },
+			expectedErr: "central_queue.max_compressed_bytes",
+		},
+		{
+			name:        "none compression",
+			mutate:      func(c *CentralQueueConfig) { c.PayloadCompression = QueuePayloadCompressionNone },
+			expectedErr: "central_queue.payload_compression",
+		},
+		{
+			name:        "empty compression",
+			mutate:      func(c *CentralQueueConfig) { c.PayloadCompression = "" },
+			expectedErr: "central_queue.payload_compression",
+		},
+		{
+			name:        "invalid compression",
+			mutate:      func(c *CentralQueueConfig) { c.PayloadCompression = QueuePayloadCompression("brotli") },
+			expectedErr: "central_queue.payload_compression",
+		},
+		{
+			name:        "missing batch budget",
+			mutate:      func(c *CentralQueueConfig) { c.MaxUncompressedBatchBytes = 0 },
+			expectedErr: "central_queue.max_uncompressed_batch_bytes",
+		},
+		{
+			name:        "missing inflight budget",
+			mutate:      func(c *CentralQueueConfig) { c.MaxInflightUncompressedBytes = 0 },
+			expectedErr: "central_queue.max_inflight_uncompressed_bytes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			cfg.CentralQueue.Enabled = true
+			cfg.CentralQueue.MaxCompressedBytes = 1024
+			tt.mutate(&cfg.CentralQueue)
+
+			require.ErrorContains(t, cfg.Validate(), tt.expectedErr)
+		})
+	}
+
+	cfg := createDefaultConfig().(*Config)
+	cfg.CentralQueue.Enabled = true
+	cfg.CentralQueue.MaxCompressedBytes = 1024
+	cfg.CentralQueue.PayloadCompression = QueuePayloadCompressionSnappy
+	require.NoError(t, cfg.Validate())
+
+	cfg.CentralQueue.PayloadCompression = QueuePayloadCompressionZstd
+	require.NoError(t, cfg.Validate())
+}
+
+func TestCentralQueueRejectsChildOTLPQueue(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	conf := confmap.NewFromStringMap(map[string]any{
+		"central_queue": map[string]any{
+			"enabled":                         true,
+			"max_compressed_bytes":            1024,
+			"payload_compression":             "zstd",
+			"max_uncompressed_batch_bytes":    1024,
+			"max_inflight_uncompressed_bytes": 2048,
+		},
+		"protocol": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "localhost:4317",
+				"tls": map[string]any{
+					"insecure": true,
+				},
+				"sending_queue": map[string]any{
+					"enabled":    true,
+					"queue_size": 1000,
+				},
+			},
+		},
+		"resolver": map[string]any{
+			"static": map[string]any{
+				"hostnames": []string{"localhost:4317"},
+			},
+		},
+	})
+
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.ErrorContains(t, cfg.Validate(), "central_queue.enabled=true is incompatible with protocol.otlp.sending_queue")
+}
+
+func TestCentralQueueRejectsIndependentBuffering(t *testing.T) {
+	tests := []struct {
+		name        string
+		mutate      func(*Config)
+		expectedErr string
+	}{
+		{
+			name: "top level sending queue",
+			mutate: func(cfg *Config) {
+				cfg.QueueSettings.QueueConfig = configoptional.Some(exporterhelper.NewDefaultQueueConfig())
+			},
+			expectedErr: "central_queue.enabled=true is incompatible with sending_queue.enabled=true",
+		},
+		{
+			name: "log batcher",
+			mutate: func(cfg *Config) {
+				cfg.LogBatcher.Enabled = true
+			},
+			expectedErr: "central_queue.enabled=true is incompatible with log_batcher.enabled=true",
+		},
+		{
+			name: "metric batcher",
+			mutate: func(cfg *Config) {
+				cfg.MetricBatcher.Enabled = true
+			},
+			expectedErr: "central_queue.enabled=true is incompatible with metric_batcher.enabled=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			cfg.CentralQueue.Enabled = true
+			cfg.CentralQueue.MaxCompressedBytes = 1024
+			tt.mutate(cfg)
+
+			require.ErrorContains(t, cfg.Validate(), tt.expectedErr)
+		})
+	}
 }
 
 func TestConfigValidateEndpointHealth(t *testing.T) {

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -177,6 +177,14 @@ func TestCentralQueueValidation(t *testing.T) {
 			mutate:      func(c *CentralQueueConfig) { c.MaxInflightUncompressedBytes = 0 },
 			expectedErr: "central_queue.max_inflight_uncompressed_bytes",
 		},
+		{
+			name: "batch budget exceeds inflight budget",
+			mutate: func(c *CentralQueueConfig) {
+				c.MaxUncompressedBatchBytes = 2048
+				c.MaxInflightUncompressedBytes = 1024
+			},
+			expectedErr: "central_queue.max_uncompressed_batch_bytes",
+		},
 	}
 
 	for _, tt := range tests {

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -53,6 +53,12 @@ func createDefaultConfig() component.Config {
 			QueueConfig:        configoptional.None[exporterhelper.QueueBatchConfig](),
 			PayloadCompression: QueuePayloadCompressionNone,
 		},
+		CentralQueue: CentralQueueConfig{
+			Enabled:                      false,
+			PayloadCompression:           QueuePayloadCompressionZstd,
+			MaxUncompressedBatchBytes:    defaultCentralQueueMaxUncompressedBatchBytes,
+			MaxInflightUncompressedBytes: defaultCentralQueueMaxInflightBytes,
+		},
 		LogBatcher: LogBatcherConfig{
 			Enabled:            false,
 			MaxRecords:         defaultLogBatchMaxRecords,
@@ -66,6 +72,7 @@ func createDefaultConfig() component.Config {
 			MaxBytes:                 defaultMetricBatchMaxBytes,
 			FlushInterval:            defaultMetricBatchFlushTimeout,
 			MaxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier,
+			PayloadCompression:       QueuePayloadCompressionNone,
 		},
 		EndpointHealth: EndpointHealthConfig{
 			Enabled:            false,
@@ -89,6 +96,9 @@ func createDefaultConfig() component.Config {
 func buildExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
 	oCfg := cfg.Protocol.OTLP
 	oCfg.ClientConfig.Endpoint = endpoint
+	if cfg.CentralQueue.Enabled {
+		oCfg.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+	}
 
 	return oCfg
 }

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -155,6 +155,17 @@ func TestBuildExporterConfig(t *testing.T) {
 	assert.Equal(t, defaultCfg.RetryConfig, exporterCfg.RetryConfig)
 }
 
+func TestBuildExporterConfigDisablesChildQueueInCentralQueueMode(t *testing.T) {
+	cfg := simpleConfig()
+	cfg.CentralQueue.Enabled = true
+	cfg.CentralQueue.MaxCompressedBytes = 1024
+	cfg.Protocol.OTLP.QueueConfig = configoptional.Some(exporterhelper.NewDefaultQueueConfig())
+
+	exporterCfg := buildExporterConfig(cfg, "the-endpoint")
+
+	require.False(t, exporterCfg.QueueConfig.HasValue())
+}
+
 func TestBuildExporterSettings(t *testing.T) {
 	otlpType := otlpexporter.NewFactory().Type()
 

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -262,7 +262,7 @@ func (e *logExporterImp) consumeCentralQueueLogItem(ctx context.Context, item ce
 	if err != nil {
 		return err
 	}
-	_, err = e.consumeBatchWithDecision(ctx, le, ld, logFlushReasonDirect, true, true, false)
+	_, err = e.consumeBatchWithDecision(ctx, le, ld, logFlushReasonDirect, true, false, false)
 	return err
 }
 

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -137,8 +137,10 @@ func (e *logExporterImp) Shutdown(ctx context.Context) error {
 	if e.centralQueue != nil {
 		e.centralQueue.stop()
 		waitErr := waitForInflight(ctx, &e.centralWG)
-		if waitErr != nil && e.centralCancel != nil {
+		if e.centralCancel != nil {
 			e.centralCancel()
+		}
+		if waitErr != nil {
 			cancelCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 			waitErr = errors.Join(waitErr, waitForInflight(cancelCtx, &e.centralWG))
 			cancel()

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -70,9 +70,9 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 	}
 	if cfg.(*Config).CentralQueue.Enabled {
 		centralCfg := cfg.(*Config).CentralQueue
-		centralTelemetry, err := newCentralQueueTelemetry(params.TelemetrySettings, signalKindLogs)
-		if err != nil {
-			return nil, err
+		centralTelemetry, telemetryErr := newCentralQueueTelemetry(params.TelemetrySettings, signalKindLogs)
+		if telemetryErr != nil {
+			return nil, telemetryErr
 		}
 		logExporter.centralQueue = newCentralQueue(centralQueueSettings{
 			maxCompressedBytes:           centralCfg.MaxCompressedBytes,

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -136,16 +136,16 @@ func (e *logExporterImp) Shutdown(ctx context.Context) error {
 	}
 	if e.centralQueue != nil {
 		e.centralQueue.stop()
-		waitErr := waitForInflight(ctx, &e.centralWG)
 		if e.centralCancel != nil {
 			e.centralCancel()
 		}
-		if waitErr != nil {
-			cancelCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-			waitErr = errors.Join(waitErr, waitForInflight(cancelCtx, &e.centralWG))
-			cancel()
+		waitCtx, cancel := context.WithTimeout(ctx, time.Second)
+		waitErr := waitForInflight(waitCtx, &e.centralWG)
+		cancel()
+		err = errors.Join(err, waitErr)
+		if waitErr == nil {
+			err = errors.Join(err, e.centralCodec.Close())
 		}
-		err = errors.Join(err, waitErr, e.centralCodec.Close())
 	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))
 	return err
@@ -175,7 +175,7 @@ func (e *logExporterImp) consumeLogsCentralQueue(_ context.Context, ld plog.Logs
 	var errs error
 	now := time.Now()
 	for routingKey, logs := range batches {
-		item, err := newCentralQueueLogsItem([]byte(routingKey), logs, e.centralCodec, now)
+		item, err := newCentralQueueLogsItem(routingKey[:], logs, e.centralCodec, now)
 		if err != nil {
 			errs = multierr.Append(errs, err)
 			continue
@@ -185,8 +185,8 @@ func (e *logExporterImp) consumeLogsCentralQueue(_ context.Context, ld plog.Logs
 	return errs
 }
 
-func (e *logExporterImp) groupLogsByRoutingKey(ld plog.Logs) map[string]plog.Logs {
-	batches := make(map[string]plog.Logs)
+func (e *logExporterImp) groupLogsByRoutingKey(ld plog.Logs) map[pcommon.TraceID]plog.Logs {
+	batches := make(map[pcommon.TraceID]plog.Logs)
 	emptyTraceFallbackKeys := make(map[[2]int]pcommon.TraceID)
 
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
@@ -196,11 +196,10 @@ func (e *logExporterImp) groupLogsByRoutingKey(ld plog.Logs) map[string]plog.Log
 			for k := 0; k < sl.LogRecords().Len(); k++ {
 				rec := sl.LogRecords().At(k)
 				balancingKey := e.routingKeyForLogRecord(rec, [2]int{i, j}, emptyTraceFallbackKeys)
-				route := string(balancingKey[:])
-				batch, ok := batches[route]
+				batch, ok := batches[balancingKey]
 				if !ok {
 					batch = plog.NewLogs()
-					batches[route] = batch
+					batches[balancingKey] = batch
 				}
 				insertLogRecord(batch, rl, sl, rec)
 			}

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -143,9 +143,10 @@ func (e *logExporterImp) Shutdown(ctx context.Context) error {
 		waitErr := waitForInflight(waitCtx, &e.centralWG)
 		cancel()
 		err = errors.Join(err, waitErr)
-		if waitErr == nil {
-			err = errors.Join(err, e.centralCodec.Close())
+		if waitErr != nil {
+			return err
 		}
+		err = errors.Join(err, e.centralCodec.Close())
 	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))
 	return err

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -244,9 +244,10 @@ func (e *logExporterImp) runCentralQueue(ctx context.Context) {
 			continue
 		}
 		item := lease.item
+		nextAttempt := time.Now().Add(centralQueueRetryDelay(item.attempt))
 		item.attempt++
 		lease.item = item
-		if requeueErr := lease.requeue(time.Now().Add(centralQueueRetryDelay(item.attempt))); requeueErr != nil {
+		if requeueErr := lease.requeue(nextAttempt); requeueErr != nil {
 			e.logger.Warn("failed to requeue central log queue item", zap.Error(requeueErr), zap.Error(err))
 		}
 	}

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"math/rand/v2"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -29,12 +30,16 @@ var _ exporter.Logs = (*logExporterImp)(nil)
 type logExporterImp struct {
 	loadBalancer *loadBalancer
 	batcher      *logBatcher
+	centralQueue *centralQueue
+	centralCodec *queuePayloadCodec
 
 	logger        *zap.Logger
 	started       atomic.Bool
 	telemetry     *metadata.TelemetryBuilder
 	ignoreTraceID bool
 	randomTraceID func() pcommon.TraceID
+	centralCancel context.CancelFunc
+	centralWG     sync.WaitGroup
 }
 
 // Create new logs exporter
@@ -62,6 +67,20 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 		logger:        params.Logger,
 		ignoreTraceID: cfg.(*Config).LogRouting.IgnoreTraceID,
 		randomTraceID: random,
+	}
+	if cfg.(*Config).CentralQueue.Enabled {
+		centralCfg := cfg.(*Config).CentralQueue
+		centralTelemetry, err := newCentralQueueTelemetry(params.TelemetrySettings, signalKindLogs)
+		if err != nil {
+			return nil, err
+		}
+		logExporter.centralQueue = newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           centralCfg.MaxCompressedBytes,
+			maxInflightUncompressedBytes: centralCfg.MaxInflightUncompressedBytes,
+			maxUncompressedBatchBytes:    centralCfg.MaxUncompressedBatchBytes,
+			telemetry:                    centralTelemetry,
+		})
+		logExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression)
 	}
 	if cfg.(*Config).LogBatcher.Enabled {
 		logBatcherCfg := cfg.(*Config).LogBatcher
@@ -97,6 +116,12 @@ func (e *logExporterImp) Start(ctx context.Context, host component.Host) error {
 		return err
 	}
 	e.started.Store(true)
+	if e.centralQueue != nil {
+		dispatchCtx, cancel := context.WithCancel(context.Background())
+		e.centralCancel = cancel
+		e.centralWG.Add(1)
+		go e.runCentralQueue(dispatchCtx)
+	}
 	return nil
 }
 
@@ -108,6 +133,17 @@ func (e *logExporterImp) Shutdown(ctx context.Context) error {
 	if e.batcher != nil {
 		err = e.batcher.Shutdown(ctx)
 	}
+	if e.centralQueue != nil {
+		e.centralQueue.stop()
+		waitErr := waitForInflight(ctx, &e.centralWG)
+		if waitErr != nil && e.centralCancel != nil {
+			e.centralCancel()
+			cancelCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+			waitErr = errors.Join(waitErr, waitForInflight(cancelCtx, &e.centralWG))
+			cancel()
+		}
+		err = errors.Join(err, waitErr, e.centralCodec.Close())
+	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))
 	return err
 }
@@ -115,6 +151,9 @@ func (e *logExporterImp) Shutdown(ctx context.Context) error {
 func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	if !e.started.Load() {
 		return errExporterIsStopping
+	}
+	if e.centralQueue != nil {
+		return e.consumeLogsCentralQueue(ctx, ld)
 	}
 	if e.batcher == nil {
 		var errs error
@@ -126,6 +165,96 @@ func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	}
 
 	return e.consumeLogsBatched(ctx, ld)
+}
+
+func (e *logExporterImp) consumeLogsCentralQueue(_ context.Context, ld plog.Logs) error {
+	batches := e.groupLogsByRoutingKey(ld)
+	var errs error
+	now := time.Now()
+	for routingKey, logs := range batches {
+		item, err := newCentralQueueLogsItem([]byte(routingKey), logs, e.centralCodec, now)
+		if err != nil {
+			errs = multierr.Append(errs, err)
+			continue
+		}
+		errs = multierr.Append(errs, e.centralQueue.enqueue(item))
+	}
+	return errs
+}
+
+func (e *logExporterImp) groupLogsByRoutingKey(ld plog.Logs) map[string]plog.Logs {
+	batches := make(map[string]plog.Logs)
+	emptyTraceFallbackKeys := make(map[[2]int]pcommon.TraceID)
+
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rl := ld.ResourceLogs().At(i)
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				rec := sl.LogRecords().At(k)
+				balancingKey := e.routingKeyForLogRecord(rec, [2]int{i, j}, emptyTraceFallbackKeys)
+				route := string(balancingKey[:])
+				batch, ok := batches[route]
+				if !ok {
+					batch = plog.NewLogs()
+					batches[route] = batch
+				}
+				insertLogRecord(batch, rl, sl, rec)
+			}
+		}
+	}
+
+	return batches
+}
+
+func (e *logExporterImp) runCentralQueue(ctx context.Context) {
+	defer e.centralWG.Done()
+	for {
+		lease, err := e.centralQueue.lease(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, errCentralQueueStopped) {
+				return
+			}
+			if errors.Is(err, errCentralQueueInflightFull) {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(centralQueueLeasePollInterval):
+					continue
+				}
+			}
+			e.logger.Warn("failed to lease central log queue item", zap.Error(err))
+			continue
+		}
+
+		err = e.consumeCentralQueueLogItem(ctx, lease.item)
+		lease.done()
+		if err == nil {
+			continue
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		item := lease.item
+		item.attempt++
+		if requeueErr := e.centralQueue.requeue(item, time.Now().Add(centralQueueRetryDelay(item.attempt))); requeueErr != nil {
+			e.logger.Warn("failed to requeue central log queue item", zap.Error(requeueErr), zap.Error(err))
+		}
+	}
+}
+
+func (e *logExporterImp) consumeCentralQueueLogItem(ctx context.Context, item centralQueueItem) error {
+	ld, err := decodeCentralQueueLogsItem(item, e.centralCodec)
+	if err != nil {
+		e.logger.Warn("dropping invalid central log queue payload", zap.Error(err))
+		return nil
+	}
+	le, _, err := e.loadBalancer.exporterAndEndpoint(item.routingKey)
+	if err != nil {
+		return err
+	}
+	_, err = e.consumeBatchWithDecision(ctx, le, ld, logFlushReasonDirect, true, true, false)
+	return err
 }
 
 // endpointBatch holds logs grouped for a single backend endpoint,

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -229,20 +229,23 @@ func (e *logExporterImp) runCentralQueue(ctx context.Context) {
 		}
 
 		err = e.consumeCentralQueueLogItem(ctx, lease.item)
-		lease.done()
 		if err == nil {
+			lease.done()
 			continue
 		}
 		if ctx.Err() != nil {
+			lease.done()
 			return
 		}
 		if consumererror.IsPermanent(err) {
 			e.logger.Warn("dropping central log queue item after permanent export error", zap.Error(err))
+			lease.done()
 			continue
 		}
 		item := lease.item
 		item.attempt++
-		if requeueErr := e.centralQueue.requeue(item, time.Now().Add(centralQueueRetryDelay(item.attempt))); requeueErr != nil {
+		lease.item = item
+		if requeueErr := lease.requeue(time.Now().Add(centralQueueRetryDelay(item.attempt))); requeueErr != nil {
 			e.logger.Warn("failed to requeue central log queue item", zap.Error(requeueErr), zap.Error(err))
 		}
 	}

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -13,6 +13,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -234,6 +235,10 @@ func (e *logExporterImp) runCentralQueue(ctx context.Context) {
 		}
 		if ctx.Err() != nil {
 			return
+		}
+		if consumererror.IsPermanent(err) {
+			e.logger.Warn("dropping central log queue item after permanent export error", zap.Error(err))
+			continue
 		}
 		item := lease.item
 		item.attempt++

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -298,6 +298,61 @@ func TestLogsCentralQueueDropsPermanentExportError(t *testing.T) {
 	require.NoError(t, waitErr)
 }
 
+func TestLogsCentralQueueDoesNotDrainSynchronously(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := endpoint2Config()
+	enableEndpointHealth(cfg)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(context.Context, plog.Logs) error {
+			if endpoint == "endpoint-1:4317" {
+				return status.Error(codes.Unavailable, "backend unavailable")
+			}
+			return nil
+		}), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.endpointHealth.reconcile([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.ring = newHashRing([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1:4317", "endpoint-2:4317"})
+
+	releaseDrain := make(chan struct{})
+	var releaseDrainOnce sync.Once
+	t.Cleanup(func() { releaseDrainOnce.Do(func() { close(releaseDrain) }) })
+	lb.onExporterRemove = func(context.Context, string, *wrappedExporter) error {
+		<-releaseDrain
+		return nil
+	}
+
+	routeForEndpoint1 := findRoutingIDForEndpoint(t, lb.ring, "endpoint-1:4317")
+	item, err := newCentralQueueLogsItem([]byte(routeForEndpoint1), simpleLogs(), codec, time.Now())
+	require.NoError(t, err)
+
+	p := &logExporterImp{
+		centralCodec: codec,
+		loadBalancer: lb,
+		logger:       ts.Logger,
+		telemetry:    tb,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.consumeCentralQueueLogItem(t.Context(), item)
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		releaseDrainOnce.Do(func() { close(releaseDrain) })
+	case <-time.After(200 * time.Millisecond):
+		releaseDrainOnce.Do(func() { close(releaseDrain) })
+		t.Fatal("central log queue consume blocked on removed exporter drain")
+	}
+}
+
 func TestConsumeLogsEmitsOnlyParentExporterMetrics(t *testing.T) {
 	ctx := t.Context()
 	shutdownCtx := context.Background() //nolint:usetesting // Context must outlive test for cleanup

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -206,6 +207,47 @@ func TestConsumeLogsCentralQueueEnqueuesCompressedByRoutingKey(t *testing.T) {
 	decoded, err := decodeCentralQueueLogsItem(lease.item, codec)
 	require.NoError(t, err)
 	require.Equal(t, logs.LogRecordCount(), decoded.LogRecordCount())
+}
+
+func TestLogsCentralQueueDropsPermanentExportError(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	endpoint := "endpoint-1:4317"
+	var calls atomic.Int64
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: &loadBalancer{
+			ring: newHashRing([]string{endpoint}),
+			exporters: map[string]*wrappedExporter{endpoint: newWrappedExporter(newMockLogsExporter(func(context.Context, plog.Logs) error {
+				calls.Add(1)
+				return consumererror.NewPermanent(errors.New("bad logs"))
+			}), endpoint)},
+			endpointHealth: newEndpointHealthManager(endpointHealthSettings{}),
+		},
+		telemetry: tb,
+		logger:    ts.Logger,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	p.centralWG.Add(1)
+	go p.runCentralQueue(ctx)
+	item, err := newCentralQueueLogsItem([]byte("route-a"), simpleLogs(), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(item))
+
+	require.Eventually(t, func() bool {
+		return calls.Load() == 1 && p.centralQueue.len() == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	cancel()
+	waitErr := waitForInflight(t.Context(), &p.centralWG)
+	require.NoError(t, waitErr)
 }
 
 func TestConsumeLogsEmitsOnlyParentExporterMetrics(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -176,6 +176,38 @@ func TestConsumeLogs(t *testing.T) {
 	assert.NoError(t, res)
 }
 
+func TestConsumeLogsCentralQueueEnqueuesCompressedByRoutingKey(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		randomTraceID: func() pcommon.TraceID {
+			return pcommon.TraceID{1}
+		},
+	}
+	p.started.Store(true)
+
+	logs := simpleLogs()
+	require.NoError(t, p.ConsumeLogs(t.Context(), logs))
+	require.Equal(t, 1, p.centralQueue.len())
+	require.Greater(t, p.centralQueue.compressedBytes(), int64(0))
+
+	lease, err := p.centralQueue.lease(t.Context())
+	require.NoError(t, err)
+	defer lease.done()
+	require.Equal(t, signalKindLogs, lease.item.signal)
+	require.Equal(t, len(lease.item.payload), cap(lease.item.payload))
+
+	decoded, err := decodeCentralQueueLogsItem(lease.item, codec)
+	require.NoError(t, err)
+	require.Equal(t, logs.LogRecordCount(), decoded.LogRecordCount())
+}
+
 func TestConsumeLogsEmitsOnlyParentExporterMetrics(t *testing.T) {
 	ctx := t.Context()
 	shutdownCtx := context.Background() //nolint:usetesting // Context must outlive test for cleanup

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -202,11 +202,59 @@ func TestConsumeLogsCentralQueueEnqueuesCompressedByRoutingKey(t *testing.T) {
 	require.NoError(t, err)
 	defer lease.done()
 	require.Equal(t, signalKindLogs, lease.item.signal)
+	expectedRoutingKey := logs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).TraceID()
+	require.Equal(t, expectedRoutingKey[:], lease.item.routingKey)
 	require.Equal(t, len(lease.item.payload), cap(lease.item.payload))
 
 	decoded, err := decodeCentralQueueLogsItem(lease.item, codec)
 	require.NoError(t, err)
-	require.Equal(t, logs.LogRecordCount(), decoded.LogRecordCount())
+	require.NoError(t, plogtest.CompareLogs(logs, decoded))
+}
+
+func TestLogsCentralQueueShutdownCancelsBeforeWaiting(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+
+	endpoint := "endpoint-1:4317"
+	consumeStarted := make(chan struct{})
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: &loadBalancer{
+			ring: newHashRing([]string{endpoint}),
+			exporters: map[string]*wrappedExporter{endpoint: newWrappedExporter(newMockLogsExporter(func(ctx context.Context, _ plog.Logs) error {
+				close(consumeStarted)
+				<-ctx.Done()
+				return ctx.Err()
+			}), endpoint)},
+			endpointHealth: newEndpointHealthManager(endpointHealthSettings{}),
+			res:            &mockResolver{},
+		},
+		telemetry: tb,
+		logger:    ts.Logger,
+	}
+	p.started.Store(true)
+	dispatchCtx, cancel := context.WithCancel(t.Context())
+	p.centralCancel = cancel
+	p.centralWG.Add(1)
+	go p.runCentralQueue(dispatchCtx)
+
+	item, err := newCentralQueueLogsItem([]byte("route-a"), simpleLogs(), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(item))
+	select {
+	case <-consumeStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected central queue consume to start")
+	}
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer shutdownCancel()
+	require.NoError(t, p.Shutdown(shutdownCtx))
 }
 
 func TestLogsCentralQueueDropsPermanentExportError(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -195,7 +195,7 @@ func TestConsumeLogsCentralQueueEnqueuesCompressedByRoutingKey(t *testing.T) {
 	logs := simpleLogs()
 	require.NoError(t, p.ConsumeLogs(t.Context(), logs))
 	require.Equal(t, 1, p.centralQueue.len())
-	require.Greater(t, p.centralQueue.compressedBytes(), int64(0))
+	require.Positive(t, p.centralQueue.compressedBytes())
 
 	lease, err := p.centralQueue.lease(t.Context())
 	require.NoError(t, err)

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -298,6 +298,43 @@ func TestLogsCentralQueueDropsPermanentExportError(t *testing.T) {
 	require.NoError(t, waitErr)
 }
 
+func TestLogsCentralQueueFirstRetryUsesInitialDelay(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	endpoint := "endpoint-1:4317"
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: &loadBalancer{
+			ring: newHashRing([]string{endpoint}),
+			exporters: map[string]*wrappedExporter{endpoint: newWrappedExporter(newMockLogsExporter(func(context.Context, plog.Logs) error {
+				return status.Error(codes.Unavailable, "backend unavailable")
+			}), endpoint)},
+			endpointHealth: newEndpointHealthManager(endpointHealthSettings{}),
+			res:            &mockResolver{},
+		},
+		telemetry: tb,
+		logger:    ts.Logger,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	p.centralWG.Add(1)
+	go p.runCentralQueue(ctx)
+	item, err := newCentralQueueLogsItem([]byte("route-a"), simpleLogs(), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(item))
+
+	requireCentralQueueFirstRetryDelay(t, p.centralQueue)
+	cancel()
+	require.NoError(t, waitForInflight(t.Context(), &p.centralWG))
+}
+
 func TestLogsCentralQueueDoesNotDrainSynchronously(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := endpoint2Config()

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -257,6 +257,34 @@ func TestLogsCentralQueueShutdownCancelsBeforeWaiting(t *testing.T) {
 	require.NoError(t, p.Shutdown(shutdownCtx))
 }
 
+func TestLogsCentralQueueShutdownTimeoutSkipsLoadBalancerShutdown(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	var resolverShutdown atomic.Bool
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: &loadBalancer{
+			res: &mockResolver{onShutdown: func(context.Context) error {
+				resolverShutdown.Store(true)
+				return nil
+			}},
+		},
+	}
+	p.started.Store(true)
+	p.centralWG.Add(1)
+	t.Cleanup(p.centralWG.Done)
+
+	shutdownCtx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	require.Error(t, p.Shutdown(shutdownCtx))
+	require.False(t, resolverShutdown.Load())
+}
+
 func TestLogsCentralQueueDropsPermanentExportError(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -175,6 +175,9 @@ func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pme
 		return false, errMetricBatcherExporterStopping
 	default:
 	}
+	if cap(backend.requests) > 0 && len(backend.requests) >= cap(backend.requests) {
+		return false, nil
+	}
 
 	enqueuedAtUnixNano := time.Now().UnixNano()
 	req := metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md, enqueuedAtUnixNano: enqueuedAtUnixNano}
@@ -541,6 +544,8 @@ type compressedMetricBatcherChunk struct {
 	oldestEnqueueUnixNano int64
 }
 
+// newCompressedMetricBatcherChunk requires callers to serialize concurrent use of codec.
+// Production callers use backendMetricBatcher.payloadCodecMu; tests use private codecs.
 func newCompressedMetricBatcherChunk(marshaler *pmetric.ProtoMarshaler, codec *queuePayloadCodec, req metricBatcherRequest) (compressedMetricBatcherChunk, error) {
 	payload, err := marshaler.MarshalMetrics(req.md)
 	if err != nil {
@@ -570,6 +575,8 @@ func (b *backendMetricBatcher) newCompressedMetricBatcherChunk(md pmetric.Metric
 	})
 }
 
+// decodeCompressedMetricBatcherChunk requires callers to serialize concurrent use of codec.
+// Production callers hold backendMetricBatcher.payloadCodecMu around merge/decode paths.
 func decodeCompressedMetricBatcherChunk(unmarshaler *pmetric.ProtoUnmarshaler, codec *queuePayloadCodec, chunk compressedMetricBatcherChunk) (pmetric.Metrics, error) {
 	payload, err := codec.Decode(chunk.payload)
 	if err != nil {
@@ -828,14 +835,16 @@ func (b *backendMetricBatcher) flushCompressed(
 			}
 			if !retryUsesDrainedChunks {
 				clearCompressedMetricBatcherChunks(drainedChunks)
+				*pending = append((*pending)[:0], retryChunks...)
+			} else {
+				*pending = retryChunks
 			}
-			*pending = append((*pending)[:0], retryChunks...)
 			*pendingDataPoints = retryDataPoints
 			*pendingBytes = retryBytes
 			*pendingCompressedBytes = retryCompressedBytes
 			b.pendingDataPoints.Store(int64(retryDataPoints))
 			b.pendingBytes.Store(int64(retryBytes))
-			b.pendingCompressedBytes.Store(int64(*pendingCompressedBytes))
+			b.pendingCompressedBytes.Store(int64(retryCompressedBytes))
 			b.oldestEnqueue.Store(oldestUnixNano)
 			if *timerC == nil {
 				delay := b.settings.flushInterval * time.Duration(1<<min(b.flushFailures-1, 4))

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -44,6 +44,7 @@ type metricBatcherSettings struct {
 	maxBytes                 int
 	flushInterval            time.Duration
 	maxRetryBufferMultiplier int
+	payloadCompression       QueuePayloadCompression
 }
 
 type (
@@ -67,6 +68,7 @@ type metricBatcher struct {
 type metricBatcherRequest struct {
 	kind               metricBatcherRequestKind
 	md                 pmetric.Metrics
+	compressedChunk    compressedMetricBatcherChunk
 	ctx                context.Context
 	reason             string
 	done               chan error
@@ -96,27 +98,32 @@ type backendMetricBatcher struct {
 	done     chan struct{}
 	inflight sync.WaitGroup
 
-	pendingDataPoints atomic.Int64
-	pendingBytes      atomic.Int64
-	oldestEnqueue     atomic.Int64
+	pendingDataPoints      atomic.Int64
+	pendingBytes           atomic.Int64
+	pendingCompressedBytes atomic.Int64
+	oldestEnqueue          atomic.Int64
 
 	flushFailures int
+
+	payloadCodecMu sync.Mutex
+	payloadCodec   *queuePayloadCodec
 }
 
 type metricBatcherTelemetry struct {
-	logger                *zap.Logger
-	meter                 metric.Meter
-	batchDataPoints       metric.Int64Histogram
-	batchBytes            metric.Int64Histogram
-	flushTotal            metric.Int64Counter
-	flushErrors           metric.Int64Counter
-	flushOldestPointAge   metric.Int64Histogram
-	droppedDataPoints     metric.Int64Counter
-	overflowTotal         metric.Int64Counter
-	pendingDataPoints     metric.Int64ObservableGauge
-	pendingBytes          metric.Int64ObservableGauge
-	pendingOldestPointAge metric.Int64ObservableGauge
-	pendingOldestPointMax metric.Int64ObservableGauge
+	logger                 *zap.Logger
+	meter                  metric.Meter
+	batchDataPoints        metric.Int64Histogram
+	batchBytes             metric.Int64Histogram
+	flushTotal             metric.Int64Counter
+	flushErrors            metric.Int64Counter
+	flushOldestPointAge    metric.Int64Histogram
+	droppedDataPoints      metric.Int64Counter
+	overflowTotal          metric.Int64Counter
+	pendingDataPoints      metric.Int64ObservableGauge
+	pendingBytes           metric.Int64ObservableGauge
+	pendingCompressedBytes metric.Int64ObservableGauge
+	pendingOldestPointAge  metric.Int64ObservableGauge
+	pendingOldestPointMax  metric.Int64ObservableGauge
 
 	mu            sync.Mutex
 	registrations []metric.Registration
@@ -170,8 +177,17 @@ func (b *metricBatcher) TryEnqueue(endpoint string, exp *wrappedExporter, md pme
 	}
 
 	enqueuedAtUnixNano := time.Now().UnixNano()
+	req := metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md, enqueuedAtUnixNano: enqueuedAtUnixNano}
+	if backend.payloadCodec != nil {
+		compressedChunk, err := backend.newCompressedMetricBatcherChunk(md, enqueuedAtUnixNano)
+		if err != nil {
+			return false, err
+		}
+		req.md = pmetric.NewMetrics()
+		req.compressedChunk = compressedChunk
+	}
 	select {
-	case backend.requests <- metricBatcherRequest{kind: metricBatcherRequestEnqueue, md: md, enqueuedAtUnixNano: enqueuedAtUnixNano}:
+	case backend.requests <- req:
 		return true, nil
 	case <-backend.done:
 		return false, errMetricBatcherExporterStopping
@@ -240,6 +256,7 @@ type metricBatcherPending struct {
 	endpoint        string
 	datapoints      int64
 	bytes           int64
+	compressedBytes int64
 	oldestAgeMillis int64
 }
 
@@ -258,6 +275,7 @@ func (b *metricBatcher) snapshotPending() metricBatcherSnapshot {
 	for endpoint, backend := range b.backends {
 		datapoints := backend.pendingDataPoints.Load()
 		bytes := backend.pendingBytes.Load()
+		compressedBytes := backend.pendingCompressedBytes.Load()
 		var oldestAgeMillis int64
 		if datapoints > 0 {
 			oldestAgeMillis = ageMillisFromUnixNano(now, backend.oldestEnqueue.Load())
@@ -269,6 +287,7 @@ func (b *metricBatcher) snapshotPending() metricBatcherSnapshot {
 			endpoint:        endpoint,
 			datapoints:      datapoints,
 			bytes:           bytes,
+			compressedBytes: compressedBytes,
 			oldestAgeMillis: oldestAgeMillis,
 		})
 	}
@@ -328,19 +347,27 @@ func newBackendMetricBatcher(
 	drainErr metricBatcherDrainFailureFunc,
 ) *backendMetricBatcher {
 	backend := &backendMetricBatcher{
-		endpoint:  endpoint,
-		exp:       exp,
-		logger:    logger.With(zap.String("endpoint", endpoint)),
-		settings:  settings,
-		telemetry: telemetry,
-		send:      send,
-		drainErr:  drainErr,
-		requests:  make(chan metricBatcherRequest, 16),
-		done:      make(chan struct{}),
+		endpoint:     endpoint,
+		exp:          exp,
+		logger:       logger.With(zap.String("endpoint", endpoint)),
+		settings:     settings,
+		telemetry:    telemetry,
+		send:         send,
+		drainErr:     drainErr,
+		requests:     make(chan metricBatcherRequest, 16),
+		done:         make(chan struct{}),
+		payloadCodec: newMetricBatcherPayloadCodec(settings.payloadCompression),
 	}
 
 	go backend.run()
 	return backend
+}
+
+func newMetricBatcherPayloadCodec(compression QueuePayloadCompression) *queuePayloadCodec {
+	if compression == "" || compression == QueuePayloadCompressionNone {
+		return nil
+	}
+	return newQueuePayloadCodec(compression)
 }
 
 func (b *backendMetricBatcher) stopAndFlush(ctx context.Context, reason string) error {
@@ -374,6 +401,15 @@ func (b *backendMetricBatcher) exporter() *wrappedExporter {
 
 func (b *backendMetricBatcher) run() {
 	defer close(b.done)
+	if b.payloadCodec != nil {
+		defer func() {
+			if err := b.payloadCodec.Close(); err != nil {
+				b.logger.Warn("failed to close metric batcher payload codec", zap.Error(err))
+			}
+		}()
+		b.runCompressed()
+		return
+	}
 
 	timer := time.NewTimer(time.Hour)
 	if !timer.Stop() {
@@ -495,6 +531,311 @@ func (b *backendMetricBatcher) drainEnqueueRequestsIntoPending(
 	}
 
 	return dataPointCount, bytes, oldestEnqueue
+}
+
+type compressedMetricBatcherChunk struct {
+	payload               []byte
+	dataPoints            int
+	uncompressedBytes     int
+	compressedBytes       int
+	oldestEnqueueUnixNano int64
+}
+
+func newCompressedMetricBatcherChunk(marshaler *pmetric.ProtoMarshaler, codec *queuePayloadCodec, req metricBatcherRequest) (compressedMetricBatcherChunk, error) {
+	payload, err := marshaler.MarshalMetrics(req.md)
+	if err != nil {
+		return compressedMetricBatcherChunk{}, err
+	}
+	encoded, err := codec.Encode(payload)
+	if err != nil {
+		return compressedMetricBatcherChunk{}, err
+	}
+	encoded = append([]byte(nil), encoded...)
+	encoded = encoded[:len(encoded):len(encoded)]
+	return compressedMetricBatcherChunk{
+		payload:               encoded,
+		dataPoints:            req.md.DataPointCount(),
+		uncompressedBytes:     len(payload),
+		compressedBytes:       len(encoded),
+		oldestEnqueueUnixNano: req.enqueuedAtUnixNano,
+	}, nil
+}
+
+func (b *backendMetricBatcher) newCompressedMetricBatcherChunk(md pmetric.Metrics, enqueuedAtUnixNano int64) (compressedMetricBatcherChunk, error) {
+	b.payloadCodecMu.Lock()
+	defer b.payloadCodecMu.Unlock()
+	return newCompressedMetricBatcherChunk(&pmetric.ProtoMarshaler{}, b.payloadCodec, metricBatcherRequest{
+		md:                 md,
+		enqueuedAtUnixNano: enqueuedAtUnixNano,
+	})
+}
+
+func decodeCompressedMetricBatcherChunk(unmarshaler *pmetric.ProtoUnmarshaler, codec *queuePayloadCodec, chunk compressedMetricBatcherChunk) (pmetric.Metrics, error) {
+	payload, err := codec.Decode(chunk.payload)
+	if err != nil {
+		return pmetric.Metrics{}, err
+	}
+	return unmarshaler.UnmarshalMetrics(payload)
+}
+
+func (b *backendMetricBatcher) runCompressed() {
+	timer := time.NewTimer(time.Hour)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+
+	pending := make([]compressedMetricBatcherChunk, 0, cap(b.requests))
+	pendingBytes := 0
+	pendingCompressedBytes := 0
+	pendingDataPoints := 0
+	unmarshaler := &pmetric.ProtoUnmarshaler{}
+	var nextReq *metricBatcherRequest
+
+	for {
+		if nextReq != nil {
+			req := *nextReq
+			nextReq = nil
+			if b.handleCompressedRequest(req, unmarshaler, &pending, &pendingDataPoints, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
+				return
+			}
+			continue
+		}
+
+		select {
+		case req := <-b.requests:
+			if b.handleCompressedRequest(req, unmarshaler, &pending, &pendingDataPoints, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
+				return
+			}
+		case <-timerC:
+			if err := b.flushCompressed(context.Background(), unmarshaler, &pending, &pendingDataPoints, &pendingBytes, &pendingCompressedBytes, metricFlushReasonTimeout, timer, &timerC); err != nil {
+				b.logger.Warn("failed to flush compressed metric batch", zap.String("reason", metricFlushReasonTimeout), zap.Error(err))
+			}
+		}
+	}
+}
+
+func (b *backendMetricBatcher) handleCompressedRequest(
+	req metricBatcherRequest,
+	unmarshaler *pmetric.ProtoUnmarshaler,
+	pending *[]compressedMetricBatcherChunk,
+	pendingDataPoints *int,
+	pendingBytes *int,
+	pendingCompressedBytes *int,
+	nextReq **metricBatcherRequest,
+	timer *time.Timer,
+	timerC *<-chan time.Time,
+) bool {
+	switch req.kind {
+	case metricBatcherRequestEnqueue:
+		dps, bytes, compressedBytes, oldestEnqueue := b.drainEnqueueRequestsIntoCompressedChunks(pending, req, nextReq)
+		*pendingDataPoints += dps
+		*pendingBytes += bytes
+		*pendingCompressedBytes += compressedBytes
+		if *pendingDataPoints > 0 && b.oldestEnqueue.Load() == 0 {
+			b.oldestEnqueue.Store(oldestEnqueue)
+		}
+		b.pendingDataPoints.Store(int64(*pendingDataPoints))
+		b.pendingBytes.Store(int64(*pendingBytes))
+		b.pendingCompressedBytes.Store(int64(*pendingCompressedBytes))
+		if *pendingDataPoints > 0 && *timerC == nil {
+			timer.Reset(b.settings.flushInterval)
+			*timerC = timer.C
+		}
+		if *pendingDataPoints >= b.settings.maxDataPoints || *pendingBytes >= b.settings.maxBytes {
+			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
+			b.telemetry.overflowTotal.Add(context.Background(), 1, attrs)
+			if err := b.flushCompressed(context.Background(), unmarshaler, pending, pendingDataPoints, pendingBytes, pendingCompressedBytes, metricFlushReasonSize, timer, timerC); err != nil {
+				b.logger.Warn("failed to flush compressed metric batch", zap.String("reason", metricFlushReasonSize), zap.Error(err))
+			}
+		}
+	case metricBatcherRequestFlushAndStop:
+		err := b.flushCompressed(req.ctx, unmarshaler, pending, pendingDataPoints, pendingBytes, pendingCompressedBytes, req.reason, timer, timerC)
+		req.done <- err
+		return true
+	}
+	return false
+}
+
+func (b *backendMetricBatcher) drainEnqueueRequestsIntoCompressedChunks(
+	pending *[]compressedMetricBatcherChunk,
+	first metricBatcherRequest,
+	nextReq **metricBatcherRequest,
+) (int, int, int, int64) {
+	dataPointCount := 0
+	bytes := 0
+	compressedBytes := 0
+	var oldestEnqueue int64
+
+	appendRequest := func(req metricBatcherRequest) {
+		count := req.compressedChunk.dataPoints
+		if count == 0 {
+			return
+		}
+		dataPointCount += count
+		bytes += req.compressedChunk.uncompressedBytes
+		compressedBytes += req.compressedChunk.compressedBytes
+		if oldestEnqueue == 0 || req.enqueuedAtUnixNano < oldestEnqueue {
+			oldestEnqueue = req.enqueuedAtUnixNano
+		}
+		*pending = append(*pending, req.compressedChunk)
+	}
+
+	appendRequest(first)
+
+	for i := 0; i < cap(b.requests); i++ {
+		select {
+		case req := <-b.requests:
+			if req.kind != metricBatcherRequestEnqueue {
+				*nextReq = &req
+				return dataPointCount, bytes, compressedBytes, oldestEnqueue
+			}
+			appendRequest(req)
+		default:
+			return dataPointCount, bytes, compressedBytes, oldestEnqueue
+		}
+	}
+
+	return dataPointCount, bytes, compressedBytes, oldestEnqueue
+}
+
+func (b *backendMetricBatcher) flushCompressed(
+	ctx context.Context,
+	unmarshaler *pmetric.ProtoUnmarshaler,
+	pending *[]compressedMetricBatcherChunk,
+	pendingDataPoints *int,
+	pendingBytes *int,
+	pendingCompressedBytes *int,
+	reason string,
+	timer *time.Timer,
+	timerC *<-chan time.Time,
+) error {
+	if !timer.Stop() && *timerC != nil {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	*timerC = nil
+
+	if *pendingDataPoints == 0 {
+		return nil
+	}
+
+	drainedChunks := *pending
+	datapoints := *pendingDataPoints
+	bytes := *pendingBytes
+	oldestUnixNano := b.oldestEnqueue.Load()
+	oldestAgeMillis := ageMillisFromUnixNano(time.Now(), oldestUnixNano)
+	*pending = (*pending)[:0]
+	*pendingDataPoints = 0
+	*pendingBytes = 0
+	*pendingCompressedBytes = 0
+	b.pendingDataPoints.Store(0)
+	b.pendingBytes.Store(0)
+	b.pendingCompressedBytes.Store(0)
+	b.oldestEnqueue.Store(0)
+
+	b.payloadCodecMu.Lock()
+	drained, err := mergeCompressedMetricBatcherChunks(unmarshaler, b.payloadCodec, drainedChunks)
+	b.payloadCodecMu.Unlock()
+	attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
+	flushAttrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint), attribute.String("reason", reason)))
+	b.telemetry.batchDataPoints.Record(ctx, int64(datapoints), attrs)
+	b.telemetry.batchBytes.Record(ctx, int64(bytes), attrs)
+	b.telemetry.flushTotal.Add(ctx, 1, flushAttrs)
+	if err != nil {
+		b.telemetry.flushErrors.Add(ctx, 1, attrs)
+		b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
+		clearCompressedMetricBatcherChunks(drainedChunks)
+		return err
+	}
+
+	var rerouteMetrics pmetric.Metrics
+	if b.drainErr != nil && reason != metricFlushReasonShutdown {
+		rerouteMetrics = pmetric.NewMetrics()
+		drained.CopyTo(rerouteMetrics)
+	}
+	exp := b.exporter()
+	if exp != nil && exp.isStopping() && b.drainErr != nil && reason != metricFlushReasonShutdown {
+		err = metricBatcherRerouteableError{err: errMetricBatcherExporterStopping, data: rerouteMetrics}
+	} else {
+		err = b.send(ctx, exp, drained, reason)
+	}
+	if err != nil {
+		b.telemetry.flushErrors.Add(ctx, 1, attrs)
+		if b.drainErr != nil && reason != metricFlushReasonShutdown {
+			var rerouteable metricBatcherRerouteableError
+			if errors.As(err, &rerouteable) {
+				rerouteErr := b.drainErr(ctx, rerouteable.Data(), reason)
+				rerouteable.RecordReroute(ctx, rerouteErr)
+				if rerouteErr == nil {
+					b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
+					clearCompressedMetricBatcherChunks(drainedChunks)
+					return nil
+				}
+				err = errors.Join(err, rerouteErr)
+			}
+		}
+		if reason == metricFlushReasonSize || reason == metricFlushReasonTimeout {
+			*pending = append((*pending)[:0], drainedChunks...)
+			*pendingDataPoints = datapoints
+			*pendingBytes = bytes
+			*pendingCompressedBytes = compressedMetricBatcherChunksCompressedBytes(drainedChunks)
+			b.pendingDataPoints.Store(int64(datapoints))
+			b.pendingBytes.Store(int64(bytes))
+			b.pendingCompressedBytes.Store(int64(*pendingCompressedBytes))
+			b.oldestEnqueue.Store(oldestUnixNano)
+			if *timerC == nil {
+				b.flushFailures++
+				delay := b.settings.flushInterval * time.Duration(1<<min(b.flushFailures-1, 4))
+				delay = min(delay, maxMetricBatchRetryBackoff)
+				timer.Reset(delay)
+				*timerC = timer.C
+			}
+			return err
+		}
+		b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
+		clearCompressedMetricBatcherChunks(drainedChunks)
+	} else {
+		b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
+		b.flushFailures = 0
+		clearCompressedMetricBatcherChunks(drainedChunks)
+	}
+	return err
+}
+
+func mergeCompressedMetricBatcherChunks(unmarshaler *pmetric.ProtoUnmarshaler, codec *queuePayloadCodec, chunks []compressedMetricBatcherChunk) (pmetric.Metrics, error) {
+	if len(chunks) == 0 {
+		return pmetric.NewMetrics(), nil
+	}
+
+	merged, err := decodeCompressedMetricBatcherChunk(unmarshaler, codec, chunks[0])
+	if err != nil {
+		return pmetric.Metrics{}, err
+	}
+	for i := 1; i < len(chunks); i++ {
+		md, err := decodeCompressedMetricBatcherChunk(unmarshaler, codec, chunks[i])
+		if err != nil {
+			return pmetric.Metrics{}, err
+		}
+		mergeMetricChunksByMove(merged, md)
+	}
+	return merged, nil
+}
+
+func clearCompressedMetricBatcherChunks(chunks []compressedMetricBatcherChunk) {
+	for i := range chunks {
+		chunks[i] = compressedMetricBatcherChunk{}
+	}
+}
+
+func compressedMetricBatcherChunksCompressedBytes(chunks []compressedMetricBatcherChunk) int {
+	compressedBytes := 0
+	for _, chunk := range chunks {
+		compressedBytes += chunk.compressedBytes
+	}
+	return compressedBytes
 }
 
 func (b *backendMetricBatcher) flush(
@@ -815,6 +1156,12 @@ func newMetricBatcherTelemetry(settings component.TelemetrySettings) (*metricBat
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
+	t.pendingCompressedBytes, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_metric_batch_pending_compressed_bytes",
+		metric.WithDescription("Current compressed OTLP bytes per pending metric backend batch."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
 	t.pendingOldestPointAge, err = meter.Int64ObservableGauge(
 		"otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age",
 		metric.WithDescription("Age in ms of the oldest pending metric datapoint per backend batch."),
@@ -838,11 +1185,12 @@ func (t *metricBatcherTelemetry) start(snapshot func() metricBatcherSnapshot) er
 			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", pending.endpoint)))
 			observer.ObserveInt64(t.pendingDataPoints, pending.datapoints, attrs)
 			observer.ObserveInt64(t.pendingBytes, pending.bytes, attrs)
+			observer.ObserveInt64(t.pendingCompressedBytes, pending.compressedBytes, attrs)
 			observer.ObserveInt64(t.pendingOldestPointAge, pending.oldestAgeMillis, attrs)
 		}
 		observer.ObserveInt64(t.pendingOldestPointMax, state.maxOldestAgeMillis)
 		return nil
-	}, t.pendingDataPoints, t.pendingBytes, t.pendingOldestPointAge, t.pendingOldestPointMax)
+	}, t.pendingDataPoints, t.pendingBytes, t.pendingCompressedBytes, t.pendingOldestPointAge, t.pendingOldestPointMax)
 	if err != nil {
 		return err
 	}

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -801,6 +801,7 @@ func (b *backendMetricBatcher) flushCompressed(
 					return errors.Join(err, rerouteErr, retryErr)
 				}
 				retryUsesDrainedChunks = false
+				datapoints = retryDataPoints
 				err = errors.Join(err, rerouteErr)
 			}
 		}

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -749,6 +749,7 @@ func (b *backendMetricBatcher) flushCompressed(
 	b.telemetry.flushTotal.Add(ctx, 1, flushAttrs)
 	if err != nil {
 		b.telemetry.flushErrors.Add(ctx, 1, attrs)
+		b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
 		b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
 		clearCompressedMetricBatcherChunks(drainedChunks)
 		return err
@@ -772,13 +773,17 @@ func (b *backendMetricBatcher) flushCompressed(
 		retryDataPoints := datapoints
 		retryBytes := bytes
 		retryCompressedBytes := compressedMetricBatcherChunksCompressedBytes(drainedChunks)
+		rerouteAttempted := false
 		if b.drainErr != nil && reason != metricFlushReasonShutdown {
 			var rerouteable metricBatcherRerouteableError
 			if errors.As(err, &rerouteable) {
+				rerouteAttempted = true
 				rerouteErr := b.drainErr(ctx, rerouteable.Data(), reason)
 				rerouteable.RecordReroute(ctx, rerouteErr)
 				if rerouteErr == nil {
 					b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
+					*retryingSince = time.Time{}
+					b.flushFailures = 0
 					clearCompressedMetricBatcherChunks(drainedChunks)
 					return nil
 				}
@@ -791,7 +796,7 @@ func (b *backendMetricBatcher) flushCompressed(
 				retryChunks, retryDataPoints, retryBytes, retryCompressedBytes, retryErr = b.compressedMetricBatcherRetryChunks(retryMetrics, oldestUnixNano)
 				if retryErr != nil {
 					b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
-					b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
+					b.telemetry.droppedDataPoints.Add(ctx, int64(retryDataPoints), attrs)
 					clearCompressedMetricBatcherChunks(drainedChunks)
 					return errors.Join(err, rerouteErr, retryErr)
 				}
@@ -839,7 +844,25 @@ func (b *backendMetricBatcher) flushCompressed(
 			}
 			return err
 		}
+		if !rerouteAttempted && b.drainErr != nil && (reason == metricFlushReasonResolverChange || reason == metricFlushReasonShutdown) {
+			rerouteErr := b.drainErr(ctx, drained, reason)
+			if rerouteErr == nil {
+				b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
+				*retryingSince = time.Time{}
+				b.flushFailures = 0
+				clearCompressedMetricBatcherChunks(drainedChunks)
+				return nil
+			}
+			var rerouteMetricsErr consumererror.Metrics
+			if errors.As(rerouteErr, &rerouteMetricsErr) {
+				datapoints = rerouteMetricsErr.Data().DataPointCount()
+			}
+			err = errors.Join(err, rerouteErr)
+		}
+		b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
 		b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
+		*retryingSince = time.Time{}
+		b.flushFailures = 0
 		clearCompressedMetricBatcherChunks(drainedChunks)
 	} else {
 		b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
@@ -851,12 +874,14 @@ func (b *backendMetricBatcher) flushCompressed(
 }
 
 func (b *backendMetricBatcher) compressedMetricBatcherRetryChunks(md pmetric.Metrics, oldestUnixNano int64) ([]compressedMetricBatcherChunk, int, int, int, error) {
-	if md.DataPointCount() == 0 {
+	dataPoints := md.DataPointCount()
+	if dataPoints == 0 {
 		return nil, 0, 0, 0, nil
 	}
+	bytes := (&pmetric.ProtoMarshaler{}).MetricsSize(md)
 	chunk, err := b.newCompressedMetricBatcherChunk(md, oldestUnixNano)
 	if err != nil {
-		return nil, 0, 0, 0, err
+		return nil, dataPoints, bytes, 0, err
 	}
 	return []compressedMetricBatcherChunk{chunk}, chunk.dataPoints, chunk.uncompressedBytes, chunk.compressedBytes, nil
 }

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -591,12 +591,13 @@ func (b *backendMetricBatcher) runCompressed() {
 	pendingDataPoints := 0
 	unmarshaler := &pmetric.ProtoUnmarshaler{}
 	var nextReq *metricBatcherRequest
+	retryingSince := time.Time{}
 
 	for {
 		if nextReq != nil {
 			req := *nextReq
 			nextReq = nil
-			if b.handleCompressedRequest(req, unmarshaler, &pending, &pendingDataPoints, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
+			if b.handleCompressedRequest(req, unmarshaler, &pending, &pendingDataPoints, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC, &retryingSince) {
 				return
 			}
 			continue
@@ -604,11 +605,11 @@ func (b *backendMetricBatcher) runCompressed() {
 
 		select {
 		case req := <-b.requests:
-			if b.handleCompressedRequest(req, unmarshaler, &pending, &pendingDataPoints, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC) {
+			if b.handleCompressedRequest(req, unmarshaler, &pending, &pendingDataPoints, &pendingBytes, &pendingCompressedBytes, &nextReq, timer, &timerC, &retryingSince) {
 				return
 			}
 		case <-timerC:
-			if err := b.flushCompressed(context.Background(), unmarshaler, &pending, &pendingDataPoints, &pendingBytes, &pendingCompressedBytes, metricFlushReasonTimeout, timer, &timerC); err != nil {
+			if err := b.flushCompressed(context.Background(), unmarshaler, &pending, &pendingDataPoints, &pendingBytes, &pendingCompressedBytes, metricFlushReasonTimeout, timer, &timerC, &retryingSince); err != nil {
 				b.logger.Warn("failed to flush compressed metric batch", zap.String("reason", metricFlushReasonTimeout), zap.Error(err))
 			}
 		}
@@ -625,6 +626,7 @@ func (b *backendMetricBatcher) handleCompressedRequest(
 	nextReq **metricBatcherRequest,
 	timer *time.Timer,
 	timerC *<-chan time.Time,
+	retryingSince *time.Time,
 ) bool {
 	switch req.kind {
 	case metricBatcherRequestEnqueue:
@@ -645,12 +647,12 @@ func (b *backendMetricBatcher) handleCompressedRequest(
 		if *pendingDataPoints >= b.settings.maxDataPoints || *pendingBytes >= b.settings.maxBytes {
 			attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", b.endpoint)))
 			b.telemetry.overflowTotal.Add(context.Background(), 1, attrs)
-			if err := b.flushCompressed(context.Background(), unmarshaler, pending, pendingDataPoints, pendingBytes, pendingCompressedBytes, metricFlushReasonSize, timer, timerC); err != nil {
+			if err := b.flushCompressed(context.Background(), unmarshaler, pending, pendingDataPoints, pendingBytes, pendingCompressedBytes, metricFlushReasonSize, timer, timerC, retryingSince); err != nil {
 				b.logger.Warn("failed to flush compressed metric batch", zap.String("reason", metricFlushReasonSize), zap.Error(err))
 			}
 		}
 	case metricBatcherRequestFlushAndStop:
-		err := b.flushCompressed(req.ctx, unmarshaler, pending, pendingDataPoints, pendingBytes, pendingCompressedBytes, req.reason, timer, timerC)
+		err := b.flushCompressed(req.ctx, unmarshaler, pending, pendingDataPoints, pendingBytes, pendingCompressedBytes, req.reason, timer, timerC, retryingSince)
 		req.done <- err
 		return true
 	}
@@ -709,6 +711,7 @@ func (b *backendMetricBatcher) flushCompressed(
 	reason string,
 	timer *time.Timer,
 	timerC *<-chan time.Time,
+	retryingSince *time.Time,
 ) error {
 	if !timer.Stop() && *timerC != nil {
 		select {
@@ -764,6 +767,11 @@ func (b *backendMetricBatcher) flushCompressed(
 	}
 	if err != nil {
 		b.telemetry.flushErrors.Add(ctx, 1, attrs)
+		retryChunks := drainedChunks
+		retryUsesDrainedChunks := true
+		retryDataPoints := datapoints
+		retryBytes := bytes
+		retryCompressedBytes := compressedMetricBatcherChunksCompressedBytes(drainedChunks)
 		if b.drainErr != nil && reason != metricFlushReasonShutdown {
 			var rerouteable metricBatcherRerouteableError
 			if errors.As(err, &rerouteable) {
@@ -774,20 +782,56 @@ func (b *backendMetricBatcher) flushCompressed(
 					clearCompressedMetricBatcherChunks(drainedChunks)
 					return nil
 				}
+				retryMetrics := rerouteMetrics
+				var rerouteMetricsErr consumererror.Metrics
+				if errors.As(rerouteErr, &rerouteMetricsErr) {
+					retryMetrics = rerouteMetricsErr.Data()
+				}
+				var retryErr error
+				retryChunks, retryDataPoints, retryBytes, retryCompressedBytes, retryErr = b.compressedMetricBatcherRetryChunks(retryMetrics, oldestUnixNano)
+				if retryErr != nil {
+					b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
+					b.telemetry.droppedDataPoints.Add(ctx, int64(datapoints), attrs)
+					clearCompressedMetricBatcherChunks(drainedChunks)
+					return errors.Join(err, rerouteErr, retryErr)
+				}
+				retryUsesDrainedChunks = false
 				err = errors.Join(err, rerouteErr)
 			}
 		}
 		if reason == metricFlushReasonSize || reason == metricFlushReasonTimeout {
-			*pending = append((*pending)[:0], drainedChunks...)
-			*pendingDataPoints = datapoints
-			*pendingBytes = bytes
-			*pendingCompressedBytes = compressedMetricBatcherChunksCompressedBytes(drainedChunks)
-			b.pendingDataPoints.Store(int64(datapoints))
-			b.pendingBytes.Store(int64(bytes))
+			now := time.Now()
+			if retryingSince.IsZero() {
+				*retryingSince = now
+			}
+
+			b.flushFailures++
+			overCap := isBeyondRetryCap(retryDataPoints, b.settings.maxDataPoints, b.settings.maxRetryBufferMultiplier) || isBeyondRetryCap(retryBytes, b.settings.maxBytes, b.settings.maxRetryBufferMultiplier)
+			overAge := now.Sub(*retryingSince) >= metricBatcherMaxRetryAge
+			if overCap || overAge {
+				b.logger.Error("dropping compressed metric batch after retry limits exceeded", zap.String("endpoint", b.endpoint), zap.String("reason", reason), zap.Int("failures", b.flushFailures), zap.Int("datapoints", retryDataPoints), zap.Int("bytes", retryBytes), zap.Int("compressed_bytes", retryCompressedBytes), zap.Bool("over_cap", overCap), zap.Bool("over_age", overAge), zap.Duration("retry_age", now.Sub(*retryingSince)), zap.Error(err))
+				b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
+				b.telemetry.droppedDataPoints.Add(ctx, int64(retryDataPoints), attrs)
+				*retryingSince = time.Time{}
+				b.flushFailures = 0
+				clearCompressedMetricBatcherChunks(drainedChunks)
+				if !retryUsesDrainedChunks {
+					clearCompressedMetricBatcherChunks(retryChunks)
+				}
+				return err
+			}
+			if !retryUsesDrainedChunks {
+				clearCompressedMetricBatcherChunks(drainedChunks)
+			}
+			*pending = append((*pending)[:0], retryChunks...)
+			*pendingDataPoints = retryDataPoints
+			*pendingBytes = retryBytes
+			*pendingCompressedBytes = retryCompressedBytes
+			b.pendingDataPoints.Store(int64(retryDataPoints))
+			b.pendingBytes.Store(int64(retryBytes))
 			b.pendingCompressedBytes.Store(int64(*pendingCompressedBytes))
 			b.oldestEnqueue.Store(oldestUnixNano)
 			if *timerC == nil {
-				b.flushFailures++
 				delay := b.settings.flushInterval * time.Duration(1<<min(b.flushFailures-1, 4))
 				delay = min(delay, maxMetricBatchRetryBackoff)
 				timer.Reset(delay)
@@ -800,9 +844,21 @@ func (b *backendMetricBatcher) flushCompressed(
 	} else {
 		b.telemetry.flushOldestPointAge.Record(ctx, oldestAgeMillis, flushAttrs)
 		b.flushFailures = 0
+		*retryingSince = time.Time{}
 		clearCompressedMetricBatcherChunks(drainedChunks)
 	}
 	return err
+}
+
+func (b *backendMetricBatcher) compressedMetricBatcherRetryChunks(md pmetric.Metrics, oldestUnixNano int64) ([]compressedMetricBatcherChunk, int, int, int, error) {
+	if md.DataPointCount() == 0 {
+		return nil, 0, 0, 0, nil
+	}
+	chunk, err := b.newCompressedMetricBatcherChunk(md, oldestUnixNano)
+	if err != nil {
+		return nil, 0, 0, 0, err
+	}
+	return []compressedMetricBatcherChunk{chunk}, chunk.dataPoints, chunk.uncompressedBytes, chunk.compressedBytes, nil
 }
 
 func mergeCompressedMetricBatcherChunks(unmarshaler *pmetric.ProtoUnmarshaler, codec *queuePayloadCodec, chunks []compressedMetricBatcherChunk) (pmetric.Metrics, error) {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -1244,7 +1244,7 @@ func TestCompressedMetricBatcherRetriesRemainCompressed(t *testing.T) {
 	backend := &backendMetricBatcher{
 		endpoint:     "endpoint-1:4317",
 		logger:       ts.Logger,
-		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour, maxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier},
 		telemetry:    telemetry,
 		payloadCodec: codec,
 		send: func(context.Context, *wrappedExporter, pmetric.Metrics, string) error {
@@ -1297,7 +1297,7 @@ func TestCompressedMetricBatcherRerouteFailureRetriesOnlyFailedMetrics(t *testin
 	backend := &backendMetricBatcher{
 		endpoint:     "endpoint-1:4317",
 		logger:       ts.Logger,
-		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour, maxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier},
 		telemetry:    telemetry,
 		payloadCodec: codec,
 		send: func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
@@ -1356,7 +1356,7 @@ func TestCompressedMetricBatcherRerouteSuccessClearsRetryState(t *testing.T) {
 	backend := &backendMetricBatcher{
 		endpoint:     "endpoint-1:4317",
 		logger:       ts.Logger,
-		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour, maxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier},
 		telemetry:    telemetry,
 		payloadCodec: codec,
 		send: func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
@@ -1414,7 +1414,7 @@ func TestCompressedMetricBatcherResolverChangeFallsBackToDrainErr(t *testing.T) 
 	backend := &backendMetricBatcher{
 		endpoint:     "endpoint-1:4317",
 		logger:       ts.Logger,
-		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour, maxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier},
 		telemetry:    telemetry,
 		payloadCodec: codec,
 		send: func(context.Context, *wrappedExporter, pmetric.Metrics, string) error {
@@ -1472,7 +1472,7 @@ func TestCompressedMetricBatcherNonRetryDropRecordsOldestAge(t *testing.T) {
 	backend := &backendMetricBatcher{
 		endpoint:     "endpoint-1:4317",
 		logger:       componenttest.NewNopTelemetrySettings().Logger,
-		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour, maxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier},
 		telemetry:    telemetry,
 		payloadCodec: codec,
 		send: func(context.Context, *wrappedExporter, pmetric.Metrics, string) error {
@@ -1529,7 +1529,7 @@ func TestCompressedMetricBatcherNonRetryRerouteFailureDropsFailedSubset(t *testi
 	backend := &backendMetricBatcher{
 		endpoint:     "endpoint-1:4317",
 		logger:       componenttest.NewNopTelemetrySettings().Logger,
-		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour, maxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier},
 		telemetry:    telemetry,
 		payloadCodec: codec,
 		send: func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
@@ -1588,7 +1588,7 @@ func TestCompressedMetricBatcherRetryRecompressFailureDropsFailedSubset(t *testi
 	backend := &backendMetricBatcher{
 		endpoint:     "endpoint-1:4317",
 		logger:       componenttest.NewNopTelemetrySettings().Logger,
-		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour, maxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier},
 		telemetry:    telemetry,
 		payloadCodec: codec,
 		send: func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
@@ -1649,7 +1649,7 @@ func TestCompressedMetricBatcherDropsAfterRetryAge(t *testing.T) {
 	backend := &backendMetricBatcher{
 		endpoint:     "endpoint-1:4317",
 		logger:       ts.Logger,
-		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour, maxRetryBufferMultiplier: defaultMetricBatchRetryBufferMultiplier},
 		telemetry:    telemetry,
 		payloadCodec: codec,
 		send: func(context.Context, *wrappedExporter, pmetric.Metrics, string) error {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -1344,6 +1344,237 @@ func TestCompressedMetricBatcherRerouteFailureRetriesOnlyFailedMetrics(t *testin
 	require.Equal(t, failedRerouteData.DataPointCount(), pendingDataPoints)
 }
 
+func TestCompressedMetricBatcherRerouteSuccessClearsRetryState(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	telemetry, err := newMetricBatcherTelemetry(ts.TelemetrySettings)
+	require.NoError(t, err)
+	t.Cleanup(telemetry.shutdown)
+
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	var reroutes atomic.Int64
+	backend := &backendMetricBatcher{
+		endpoint:     "endpoint-1:4317",
+		logger:       ts.Logger,
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		telemetry:    telemetry,
+		payloadCodec: codec,
+		send: func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
+			return metricBatcherRerouteableError{err: status.Error(codes.Unavailable, "backend down"), data: md}
+		},
+		drainErr: func(context.Context, pmetric.Metrics, string) error {
+			reroutes.Add(1)
+			return nil
+		},
+		flushFailures: 3,
+	}
+	chunk, err := newCompressedMetricBatcherChunk(&pmetric.ProtoMarshaler{}, codec, metricBatcherRequest{
+		md:                 singleDataPointMetric("original"),
+		enqueuedAtUnixNano: time.Now().UnixNano(),
+	})
+	require.NoError(t, err)
+	pending := []compressedMetricBatcherChunk{chunk}
+	pendingDataPoints := chunk.dataPoints
+	pendingBytes := chunk.uncompressedBytes
+	pendingCompressedBytes := chunk.compressedBytes
+	timer := time.NewTimer(time.Hour)
+	require.True(t, timer.Stop())
+	var timerC <-chan time.Time
+	retryingSince := time.Now().Add(-time.Second)
+
+	err = backend.flushCompressed(
+		t.Context(),
+		&pmetric.ProtoUnmarshaler{},
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&pendingCompressedBytes,
+		metricFlushReasonSize,
+		timer,
+		&timerC,
+		&retryingSince,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(1), reroutes.Load())
+	require.True(t, retryingSince.IsZero())
+	require.Zero(t, backend.flushFailures)
+	require.Empty(t, pending)
+}
+
+func TestCompressedMetricBatcherResolverChangeFallsBackToDrainErr(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	telemetry, err := newMetricBatcherTelemetry(ts.TelemetrySettings)
+	require.NoError(t, err)
+	t.Cleanup(telemetry.shutdown)
+
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	var reroutedDataPoints atomic.Int64
+	backend := &backendMetricBatcher{
+		endpoint:     "endpoint-1:4317",
+		logger:       ts.Logger,
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		telemetry:    telemetry,
+		payloadCodec: codec,
+		send: func(context.Context, *wrappedExporter, pmetric.Metrics, string) error {
+			return errors.New("resolver changed")
+		},
+		drainErr: func(_ context.Context, md pmetric.Metrics, reason string) error {
+			require.Equal(t, metricFlushReasonResolverChange, reason)
+			reroutedDataPoints.Add(int64(md.DataPointCount()))
+			return nil
+		},
+	}
+	chunk, err := newCompressedMetricBatcherChunk(&pmetric.ProtoMarshaler{}, codec, metricBatcherRequest{
+		md:                 singleDataPointMetric("original"),
+		enqueuedAtUnixNano: time.Now().UnixNano(),
+	})
+	require.NoError(t, err)
+	pending := []compressedMetricBatcherChunk{chunk}
+	pendingDataPoints := chunk.dataPoints
+	pendingBytes := chunk.uncompressedBytes
+	pendingCompressedBytes := chunk.compressedBytes
+	timer := time.NewTimer(time.Hour)
+	require.True(t, timer.Stop())
+	var timerC <-chan time.Time
+	retryingSince := time.Time{}
+
+	err = backend.flushCompressed(
+		t.Context(),
+		&pmetric.ProtoUnmarshaler{},
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&pendingCompressedBytes,
+		metricFlushReasonResolverChange,
+		timer,
+		&timerC,
+		&retryingSince,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(1), reroutedDataPoints.Load())
+	require.Empty(t, pending)
+}
+
+func TestCompressedMetricBatcherNonRetryDropRecordsOldestAge(t *testing.T) {
+	telemetryReader := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetryReader.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	telemetry, err := newMetricBatcherTelemetry(telemetryReader.NewTelemetrySettings())
+	require.NoError(t, err)
+	t.Cleanup(telemetry.shutdown)
+
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	backend := &backendMetricBatcher{
+		endpoint:     "endpoint-1:4317",
+		logger:       componenttest.NewNopTelemetrySettings().Logger,
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		telemetry:    telemetry,
+		payloadCodec: codec,
+		send: func(context.Context, *wrappedExporter, pmetric.Metrics, string) error {
+			return errors.New("resolver changed")
+		},
+	}
+	chunk, err := newCompressedMetricBatcherChunk(&pmetric.ProtoMarshaler{}, codec, metricBatcherRequest{
+		md:                 singleDataPointMetric("original"),
+		enqueuedAtUnixNano: time.Now().Add(-time.Second).UnixNano(),
+	})
+	require.NoError(t, err)
+	pending := []compressedMetricBatcherChunk{chunk}
+	pendingDataPoints := chunk.dataPoints
+	pendingBytes := chunk.uncompressedBytes
+	pendingCompressedBytes := chunk.compressedBytes
+	timer := time.NewTimer(time.Hour)
+	require.True(t, timer.Stop())
+	var timerC <-chan time.Time
+	retryingSince := time.Time{}
+
+	err = backend.flushCompressed(
+		t.Context(),
+		&pmetric.ProtoUnmarshaler{},
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&pendingCompressedBytes,
+		metricFlushReasonResolverChange,
+		timer,
+		&timerC,
+		&retryingSince,
+	)
+
+	require.ErrorContains(t, err, "resolver changed")
+	flushMetric, err := telemetryReader.GetMetric("otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age")
+	require.NoError(t, err)
+	flushHistogram, ok := flushMetric.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	require.Len(t, flushHistogram.DataPoints, 1)
+	require.Equal(t, uint64(1), flushHistogram.DataPoints[0].Count)
+}
+
+func TestCompressedMetricBatcherRetryRecompressFailureDropsFailedSubset(t *testing.T) {
+	telemetryReader := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetryReader.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	telemetry, err := newMetricBatcherTelemetry(telemetryReader.NewTelemetrySettings())
+	require.NoError(t, err)
+	t.Cleanup(telemetry.shutdown)
+
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	backend := &backendMetricBatcher{
+		endpoint:     "endpoint-1:4317",
+		logger:       componenttest.NewNopTelemetrySettings().Logger,
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		telemetry:    telemetry,
+		payloadCodec: codec,
+		send: func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
+			return metricBatcherRerouteableError{err: status.Error(codes.Unavailable, "backend down"), data: md}
+		},
+	}
+	backend.drainErr = func(context.Context, pmetric.Metrics, string) error {
+		backend.payloadCodec = newQueuePayloadCodec(QueuePayloadCompression("invalid"))
+		return consumererror.NewMetrics(errors.New("reroute failed"), singleDataPointMetric("failed-subset"))
+	}
+	chunk, err := newCompressedMetricBatcherChunk(&pmetric.ProtoMarshaler{}, codec, metricBatcherRequest{
+		md:                 compressibleMetrics(16),
+		enqueuedAtUnixNano: time.Now().UnixNano(),
+	})
+	require.NoError(t, err)
+	pending := []compressedMetricBatcherChunk{chunk}
+	pendingDataPoints := chunk.dataPoints
+	pendingBytes := chunk.uncompressedBytes
+	pendingCompressedBytes := chunk.compressedBytes
+	timer := time.NewTimer(time.Hour)
+	require.True(t, timer.Stop())
+	var timerC <-chan time.Time
+	retryingSince := time.Time{}
+
+	err = backend.flushCompressed(
+		t.Context(),
+		&pmetric.ProtoUnmarshaler{},
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&pendingCompressedBytes,
+		metricFlushReasonSize,
+		timer,
+		&timerC,
+		&retryingSince,
+	)
+
+	require.ErrorContains(t, err, "reroute failed")
+	droppedMetric, err := telemetryReader.GetMetric("otelcol_loadbalancer_metric_batch_dropped_datapoints")
+	require.NoError(t, err)
+	droppedDataPoints, ok := sumInt64Metric(droppedMetric)
+	require.True(t, ok)
+	require.Equal(t, int64(1), droppedDataPoints)
+}
+
 func TestCompressedMetricBatcherDropsAfterRetryAge(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	telemetry, err := newMetricBatcherTelemetry(ts.TelemetrySettings)

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -1263,6 +1263,7 @@ func TestCompressedMetricBatcherRetriesRemainCompressed(t *testing.T) {
 	timer := time.NewTimer(time.Hour)
 	require.True(t, timer.Stop())
 	var timerC <-chan time.Time
+	retryingSince := time.Time{}
 
 	err = backend.flushCompressed(
 		t.Context(),
@@ -1274,6 +1275,7 @@ func TestCompressedMetricBatcherRetriesRemainCompressed(t *testing.T) {
 		metricFlushReasonSize,
 		timer,
 		&timerC,
+		&retryingSince,
 	)
 
 	require.ErrorContains(t, err, "temporary failure")
@@ -1281,6 +1283,122 @@ func TestCompressedMetricBatcherRetriesRemainCompressed(t *testing.T) {
 	require.Equal(t, chunk.dataPoints, pending[0].dataPoints)
 	require.Equal(t, chunk.compressedBytes, pending[0].compressedBytes)
 	require.NotEmpty(t, pending[0].payload)
+}
+
+func TestCompressedMetricBatcherRerouteFailureRetriesOnlyFailedMetrics(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	telemetry, err := newMetricBatcherTelemetry(ts.TelemetrySettings)
+	require.NoError(t, err)
+	t.Cleanup(telemetry.shutdown)
+
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	failedRerouteData := singleDataPointMetric("failed-reroute")
+	backend := &backendMetricBatcher{
+		endpoint:     "endpoint-1:4317",
+		logger:       ts.Logger,
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		telemetry:    telemetry,
+		payloadCodec: codec,
+		send: func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
+			return metricBatcherRerouteableError{err: status.Error(codes.Unavailable, "backend down"), data: md}
+		},
+		drainErr: func(context.Context, pmetric.Metrics, string) error {
+			return consumererror.NewMetrics(errors.New("reroute failed"), failedRerouteData)
+		},
+	}
+	chunk, err := newCompressedMetricBatcherChunk(&pmetric.ProtoMarshaler{}, codec, metricBatcherRequest{
+		md:                 singleDataPointMetric("original"),
+		enqueuedAtUnixNano: time.Now().UnixNano(),
+	})
+	require.NoError(t, err)
+	pending := []compressedMetricBatcherChunk{chunk}
+	pendingDataPoints := chunk.dataPoints
+	pendingBytes := chunk.uncompressedBytes
+	pendingCompressedBytes := chunk.compressedBytes
+	timer := time.NewTimer(time.Hour)
+	require.True(t, timer.Stop())
+	var timerC <-chan time.Time
+	retryingSince := time.Time{}
+
+	err = backend.flushCompressed(
+		t.Context(),
+		&pmetric.ProtoUnmarshaler{},
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&pendingCompressedBytes,
+		metricFlushReasonSize,
+		timer,
+		&timerC,
+		&retryingSince,
+	)
+
+	require.ErrorContains(t, err, "reroute failed")
+	require.Len(t, pending, 1)
+	require.Positive(t, pending[0].compressedBytes)
+	retryMetrics, err := decodeCompressedMetricBatcherChunk(&pmetric.ProtoUnmarshaler{}, codec, pending[0])
+	require.NoError(t, err)
+	require.True(t, metricNameExists(retryMetrics, "failed-reroute"))
+	require.False(t, metricNameExists(retryMetrics, "original"))
+	require.Equal(t, failedRerouteData.DataPointCount(), pendingDataPoints)
+}
+
+func TestCompressedMetricBatcherDropsAfterRetryAge(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	telemetry, err := newMetricBatcherTelemetry(ts.TelemetrySettings)
+	require.NoError(t, err)
+	t.Cleanup(telemetry.shutdown)
+
+	oldMaxRetryAge := metricBatcherMaxRetryAge
+	metricBatcherMaxRetryAge = 0
+	t.Cleanup(func() { metricBatcherMaxRetryAge = oldMaxRetryAge })
+
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	backend := &backendMetricBatcher{
+		endpoint:     "endpoint-1:4317",
+		logger:       ts.Logger,
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		telemetry:    telemetry,
+		payloadCodec: codec,
+		send: func(context.Context, *wrappedExporter, pmetric.Metrics, string) error {
+			return errors.New("temporary failure")
+		},
+	}
+	chunk, err := newCompressedMetricBatcherChunk(&pmetric.ProtoMarshaler{}, codec, metricBatcherRequest{
+		md:                 compressibleMetrics(16),
+		enqueuedAtUnixNano: time.Now().UnixNano(),
+	})
+	require.NoError(t, err)
+	pending := []compressedMetricBatcherChunk{chunk}
+	pendingDataPoints := chunk.dataPoints
+	pendingBytes := chunk.uncompressedBytes
+	pendingCompressedBytes := chunk.compressedBytes
+	timer := time.NewTimer(time.Hour)
+	require.True(t, timer.Stop())
+	var timerC <-chan time.Time
+	retryingSince := time.Now().Add(-time.Second)
+
+	err = backend.flushCompressed(
+		t.Context(),
+		&pmetric.ProtoUnmarshaler{},
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&pendingCompressedBytes,
+		metricFlushReasonSize,
+		timer,
+		&timerC,
+		&retryingSince,
+	)
+
+	require.ErrorContains(t, err, "temporary failure")
+	require.Empty(t, pending)
+	require.Zero(t, pendingDataPoints)
+	require.Zero(t, pendingBytes)
+	require.Zero(t, pendingCompressedBytes)
+	require.True(t, retryingSince.IsZero())
 }
 
 func singleDataPointMetric(name string) pmetric.Metrics {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -1515,6 +1515,65 @@ func TestCompressedMetricBatcherNonRetryDropRecordsOldestAge(t *testing.T) {
 	require.Equal(t, uint64(1), flushHistogram.DataPoints[0].Count)
 }
 
+func TestCompressedMetricBatcherNonRetryRerouteFailureDropsFailedSubset(t *testing.T) {
+	telemetryReader := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, telemetryReader.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	telemetry, err := newMetricBatcherTelemetry(telemetryReader.NewTelemetrySettings())
+	require.NoError(t, err)
+	t.Cleanup(telemetry.shutdown)
+
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	backend := &backendMetricBatcher{
+		endpoint:     "endpoint-1:4317",
+		logger:       componenttest.NewNopTelemetrySettings().Logger,
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		telemetry:    telemetry,
+		payloadCodec: codec,
+		send: func(_ context.Context, _ *wrappedExporter, md pmetric.Metrics, _ string) error {
+			return metricBatcherRerouteableError{err: status.Error(codes.Unavailable, "backend down"), data: md}
+		},
+		drainErr: func(context.Context, pmetric.Metrics, string) error {
+			return consumererror.NewMetrics(errors.New("reroute failed"), singleDataPointMetric("failed-subset"))
+		},
+	}
+	chunk, err := newCompressedMetricBatcherChunk(&pmetric.ProtoMarshaler{}, codec, metricBatcherRequest{
+		md:                 compressibleMetrics(16),
+		enqueuedAtUnixNano: time.Now().UnixNano(),
+	})
+	require.NoError(t, err)
+	pending := []compressedMetricBatcherChunk{chunk}
+	pendingDataPoints := chunk.dataPoints
+	pendingBytes := chunk.uncompressedBytes
+	pendingCompressedBytes := chunk.compressedBytes
+	timer := time.NewTimer(time.Hour)
+	require.True(t, timer.Stop())
+	var timerC <-chan time.Time
+	retryingSince := time.Time{}
+
+	err = backend.flushCompressed(
+		t.Context(),
+		&pmetric.ProtoUnmarshaler{},
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&pendingCompressedBytes,
+		metricFlushReasonResolverChange,
+		timer,
+		&timerC,
+		&retryingSince,
+	)
+
+	require.ErrorContains(t, err, "reroute failed")
+	droppedMetric, err := telemetryReader.GetMetric("otelcol_loadbalancer_metric_batch_dropped_datapoints")
+	require.NoError(t, err)
+	droppedDataPoints, ok := sumInt64Metric(droppedMetric)
+	require.True(t, ok)
+	require.Equal(t, int64(1), droppedDataPoints)
+}
+
 func TestCompressedMetricBatcherRetryRecompressFailureDropsFailedSubset(t *testing.T) {
 	telemetryReader := componenttest.NewTelemetry()
 	t.Cleanup(func() {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -1181,6 +1181,108 @@ func TestMergePendingMetricChunksKeepsDistinctResourcesSeparate(t *testing.T) {
 	require.Equal(t, 2, merged.ResourceMetrics().Len())
 }
 
+func TestCompressedMetricBatcherEnqueueStoresCompressedRequests(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	sendStarted := make(chan struct{}, 1)
+	unblockSend := make(chan struct{})
+
+	batcher, err := newMetricBatcher(ts.Logger, ts.TelemetrySettings, metricBatcherSettings{
+		maxDataPoints:      1,
+		maxBytes:           1 << 20,
+		flushInterval:      time.Hour,
+		payloadCompression: QueuePayloadCompressionZstd,
+	}, func(context.Context, *wrappedExporter, pmetric.Metrics, string) error {
+		select {
+		case sendStarted <- struct{}{}:
+		default:
+		}
+		<-unblockSend
+		return nil
+	}, nil)
+	require.NoError(t, err)
+	defer func() {
+		close(unblockSend)
+		require.NoError(t, batcher.Shutdown(context.WithoutCancel(t.Context())))
+	}()
+
+	exp := newWrappedExporter(newNopMockMetricsExporter(), "endpoint-1:4317")
+	requireMetricBatcherEnqueued(t, batcher, exp, singleDataPointMetric("first"))
+	select {
+	case <-sendStarted:
+	case <-time.After(time.Second):
+		t.Fatal("expected first batch to block in send")
+	}
+
+	enqueued, err := batcher.TryEnqueue("endpoint-1:4317", exp, compressibleMetrics(256))
+	require.NoError(t, err)
+	require.True(t, enqueued)
+
+	batcher.mu.RLock()
+	backend := batcher.backends["endpoint-1:4317"]
+	batcher.mu.RUnlock()
+	require.NotNil(t, backend)
+
+	select {
+	case req := <-backend.requests:
+		require.Zero(t, req.md.DataPointCount())
+		require.Equal(t, 256, req.compressedChunk.dataPoints)
+		require.Positive(t, req.compressedChunk.compressedBytes)
+		require.Less(t, req.compressedChunk.compressedBytes, req.compressedChunk.uncompressedBytes)
+	case <-time.After(time.Second):
+		t.Fatal("expected queued request to stay in compressed form while backend send is blocked")
+	}
+}
+
+func TestCompressedMetricBatcherRetriesRemainCompressed(t *testing.T) {
+	ts, _ := getTelemetryAssets(t)
+	telemetry, err := newMetricBatcherTelemetry(ts.TelemetrySettings)
+	require.NoError(t, err)
+	t.Cleanup(telemetry.shutdown)
+
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	backend := &backendMetricBatcher{
+		endpoint:     "endpoint-1:4317",
+		logger:       ts.Logger,
+		settings:     metricBatcherSettings{maxDataPoints: 1000, maxBytes: 1 << 20, flushInterval: time.Hour},
+		telemetry:    telemetry,
+		payloadCodec: codec,
+		send: func(context.Context, *wrappedExporter, pmetric.Metrics, string) error {
+			return errors.New("temporary failure")
+		},
+	}
+	chunk, err := newCompressedMetricBatcherChunk(&pmetric.ProtoMarshaler{}, codec, metricBatcherRequest{
+		md:                 compressibleMetrics(16),
+		enqueuedAtUnixNano: time.Now().UnixNano(),
+	})
+	require.NoError(t, err)
+	pending := []compressedMetricBatcherChunk{chunk}
+	pendingDataPoints := chunk.dataPoints
+	pendingBytes := chunk.uncompressedBytes
+	pendingCompressedBytes := chunk.compressedBytes
+	timer := time.NewTimer(time.Hour)
+	require.True(t, timer.Stop())
+	var timerC <-chan time.Time
+
+	err = backend.flushCompressed(
+		t.Context(),
+		&pmetric.ProtoUnmarshaler{},
+		&pending,
+		&pendingDataPoints,
+		&pendingBytes,
+		&pendingCompressedBytes,
+		metricFlushReasonSize,
+		timer,
+		&timerC,
+	)
+
+	require.ErrorContains(t, err, "temporary failure")
+	require.Len(t, pending, 1)
+	require.Equal(t, chunk.dataPoints, pending[0].dataPoints)
+	require.Equal(t, chunk.compressedBytes, pending[0].compressedBytes)
+	require.NotEmpty(t, pending[0].payload)
+}
+
 func singleDataPointMetric(name string) pmetric.Metrics {
 	md := pmetric.NewMetrics()
 	rm := md.ResourceMetrics().AppendEmpty()

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -242,9 +242,10 @@ func (e *metricExporterImp) runCentralQueue(ctx context.Context) {
 			continue
 		}
 		item := lease.item
+		nextAttempt := time.Now().Add(centralQueueRetryDelay(item.attempt))
 		item.attempt++
 		lease.item = item
-		if requeueErr := lease.requeue(time.Now().Add(centralQueueRetryDelay(item.attempt))); requeueErr != nil {
+		if requeueErr := lease.requeue(nextAttempt); requeueErr != nil {
 			e.logger.Warn("failed to requeue central metric queue item", zap.Error(requeueErr), zap.Error(err))
 		}
 	}

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -35,11 +36,15 @@ const metricBatcherEnqueueBackoff = 2 * time.Millisecond
 type metricExporterImp struct {
 	loadBalancer *loadBalancer
 	batcher      *metricBatcher
+	centralQueue *centralQueue
+	centralCodec *queuePayloadCodec
 	routingKey   routingKey
 
-	logger    *zap.Logger
-	started   atomic.Bool
-	telemetry *metadata.TelemetryBuilder
+	logger        *zap.Logger
+	started       atomic.Bool
+	telemetry     *metadata.TelemetryBuilder
+	centralCancel context.CancelFunc
+	centralWG     sync.WaitGroup
 }
 
 func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metricExporterImp, error) {
@@ -66,6 +71,20 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 		telemetry:    telemetry,
 		logger:       params.Logger,
 	}
+	if cfg.(*Config).CentralQueue.Enabled {
+		centralCfg := cfg.(*Config).CentralQueue
+		centralTelemetry, err := newCentralQueueTelemetry(params.TelemetrySettings, signalKindMetrics)
+		if err != nil {
+			return nil, err
+		}
+		metricExporter.centralQueue = newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           centralCfg.MaxCompressedBytes,
+			maxInflightUncompressedBytes: centralCfg.MaxInflightUncompressedBytes,
+			maxUncompressedBatchBytes:    centralCfg.MaxUncompressedBatchBytes,
+			telemetry:                    centralTelemetry,
+		})
+		metricExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression)
+	}
 
 	switch cfg.(*Config).RoutingKey {
 	case svcRoutingStr, "":
@@ -90,6 +109,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 				maxBytes:                 cfg.(*Config).MetricBatcher.MaxBytes,
 				flushInterval:            cfg.(*Config).MetricBatcher.FlushInterval,
 				maxRetryBufferMultiplier: cfg.(*Config).MetricBatcher.MaxRetryBufferMultiplier,
+				payloadCompression:       cfg.(*Config).MetricBatcher.PayloadCompression,
 			},
 			metricExporter.consumeBatch,
 			metricExporter.rerouteDrainBatch,
@@ -114,6 +134,12 @@ func (e *metricExporterImp) Start(ctx context.Context, host component.Host) erro
 		return err
 	}
 	e.started.Store(true)
+	if e.centralQueue != nil {
+		dispatchCtx, cancel := context.WithCancel(context.Background())
+		e.centralCancel = cancel
+		e.centralWG.Add(1)
+		go e.runCentralQueue(dispatchCtx)
+	}
 	return nil
 }
 
@@ -124,6 +150,17 @@ func (e *metricExporterImp) Shutdown(ctx context.Context) error {
 	var err error
 	if e.batcher != nil {
 		err = e.batcher.Shutdown(ctx)
+	}
+	if e.centralQueue != nil {
+		e.centralQueue.stop()
+		waitErr := waitForInflight(ctx, &e.centralWG)
+		if waitErr != nil && e.centralCancel != nil {
+			e.centralCancel()
+			cancelCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+			waitErr = errors.Join(waitErr, waitForInflight(cancelCtx, &e.centralWG))
+			cancel()
+		}
+		err = errors.Join(err, waitErr, e.centralCodec.Close())
 	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))
 	return err
@@ -139,6 +176,10 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 		return err
 	}
 
+	if e.centralQueue != nil {
+		return e.consumeMetricsCentralQueue(batches)
+	}
+
 	if e.batcher != nil {
 		endpointBatches, err := e.groupRoutedMetricsByEndpoint(batches)
 		if err != nil {
@@ -148,6 +189,65 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 	}
 
 	return e.consumeMetricsByExporter(ctx, batches)
+}
+
+func (e *metricExporterImp) consumeMetricsCentralQueue(batches map[string]pmetric.Metrics) error {
+	var errs error
+	now := time.Now()
+	for routingKey, md := range batches {
+		item, err := newCentralQueueMetricsItem([]byte(routingKey), md, e.centralCodec, now)
+		if err != nil {
+			errs = multierr.Append(errs, err)
+			continue
+		}
+		errs = multierr.Append(errs, e.centralQueue.enqueue(item))
+	}
+	return errs
+}
+
+func (e *metricExporterImp) runCentralQueue(ctx context.Context) {
+	defer e.centralWG.Done()
+	for {
+		lease, err := e.centralQueue.lease(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, errCentralQueueStopped) {
+				return
+			}
+			if errors.Is(err, errCentralQueueInflightFull) {
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(centralQueueLeasePollInterval):
+					continue
+				}
+			}
+			e.logger.Warn("failed to lease central metric queue item", zap.Error(err))
+			continue
+		}
+
+		err = e.consumeCentralQueueMetricItem(ctx, lease.item)
+		lease.done()
+		if err == nil {
+			continue
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		item := lease.item
+		item.attempt++
+		if requeueErr := e.centralQueue.requeue(item, time.Now().Add(centralQueueRetryDelay(item.attempt))); requeueErr != nil {
+			e.logger.Warn("failed to requeue central metric queue item", zap.Error(requeueErr), zap.Error(err))
+		}
+	}
+}
+
+func (e *metricExporterImp) consumeCentralQueueMetricItem(ctx context.Context, item centralQueueItem) error {
+	md, err := decodeCentralQueueMetricsItem(item, e.centralCodec)
+	if err != nil {
+		e.logger.Warn("dropping invalid central metric queue payload", zap.Error(err))
+		return nil
+	}
+	return e.consumeMetricsByExporter(ctx, map[string]pmetric.Metrics{string(item.routingKey): md})
 }
 
 type endpointMetricsBatch struct {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -153,16 +153,16 @@ func (e *metricExporterImp) Shutdown(ctx context.Context) error {
 	}
 	if e.centralQueue != nil {
 		e.centralQueue.stop()
-		waitErr := waitForInflight(ctx, &e.centralWG)
 		if e.centralCancel != nil {
 			e.centralCancel()
 		}
-		if waitErr != nil {
-			cancelCtx, cancel := context.WithTimeout(context.Background(), time.Second)
-			waitErr = errors.Join(waitErr, waitForInflight(cancelCtx, &e.centralWG))
-			cancel()
+		waitCtx, cancel := context.WithTimeout(ctx, time.Second)
+		waitErr := waitForInflight(waitCtx, &e.centralWG)
+		cancel()
+		err = errors.Join(err, waitErr)
+		if waitErr == nil {
+			err = errors.Join(err, e.centralCodec.Close())
 		}
-		err = errors.Join(err, waitErr, e.centralCodec.Close())
 	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))
 	return err
@@ -256,7 +256,19 @@ func (e *metricExporterImp) consumeCentralQueueMetricItem(ctx context.Context, i
 		e.logger.Warn("dropping invalid central metric queue payload", zap.Error(err))
 		return nil
 	}
-	return e.consumeMetricsByExporter(ctx, map[string]pmetric.Metrics{string(item.routingKey): md})
+	exp, _, err := e.loadBalancer.exporterAndEndpoint(item.routingKey)
+	if err != nil {
+		return err
+	}
+
+	exp.forceStartConsume()
+	defer exp.doneConsume()
+
+	start := time.Now()
+	err = exp.ConsumeMetrics(ctx, md)
+	duration := time.Since(start)
+	e.recordBackendResultWithoutDrain(ctx, exp, duration, err, true)
+	return err
 }
 
 type endpointMetricsBatch struct {
@@ -630,6 +642,14 @@ func (e *metricExporterImp) rerouteDrainBatch(ctx context.Context, md pmetric.Me
 }
 
 func (e *metricExporterImp) recordBackendResult(ctx context.Context, we *wrappedExporter, duration time.Duration, err error, updateEndpointHealth bool) endpointHealthFailureDecision {
+	return e.recordBackendResultWithDrain(ctx, we, duration, err, updateEndpointHealth, true)
+}
+
+func (e *metricExporterImp) recordBackendResultWithoutDrain(ctx context.Context, we *wrappedExporter, duration time.Duration, err error, updateEndpointHealth bool) endpointHealthFailureDecision {
+	return e.recordBackendResultWithDrain(ctx, we, duration, err, updateEndpointHealth, false)
+}
+
+func (e *metricExporterImp) recordBackendResultWithDrain(ctx context.Context, we *wrappedExporter, duration time.Duration, err error, updateEndpointHealth, drainRemoved bool) endpointHealthFailureDecision {
 	e.telemetry.LoadbalancerBackendLatency.Record(ctx, duration.Milliseconds(), metric.WithAttributeSet(we.endpointAttr))
 	if err == nil {
 		e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(we.successAttr))
@@ -644,7 +664,10 @@ func (e *metricExporterImp) recordBackendResult(ctx context.Context, we *wrapped
 	if !updateEndpointHealth {
 		return endpointHealthFailureDecision{}
 	}
-	return e.loadBalancer.handleBackendFailure(ctx, we.endpoint, err)
+	if drainRemoved {
+		return e.loadBalancer.handleBackendFailure(ctx, we.endpoint, err)
+	}
+	return e.loadBalancer.handleBackendFailureWithoutDrain(ctx, we.endpoint, err)
 }
 
 func (e *metricExporterImp) recordBackendResultHealthOnly(ctx context.Context, we *wrappedExporter, duration time.Duration, err error, updateEndpointHealth bool) endpointHealthFailureDecision {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -160,9 +160,10 @@ func (e *metricExporterImp) Shutdown(ctx context.Context) error {
 		waitErr := waitForInflight(waitCtx, &e.centralWG)
 		cancel()
 		err = errors.Join(err, waitErr)
-		if waitErr == nil {
-			err = errors.Join(err, e.centralCodec.Close())
+		if waitErr != nil {
+			return err
 		}
+		err = errors.Join(err, e.centralCodec.Close())
 	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))
 	return err

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -226,20 +226,23 @@ func (e *metricExporterImp) runCentralQueue(ctx context.Context) {
 		}
 
 		err = e.consumeCentralQueueMetricItem(ctx, lease.item)
-		lease.done()
 		if err == nil {
+			lease.done()
 			continue
 		}
 		if ctx.Err() != nil {
+			lease.done()
 			return
 		}
 		if consumererror.IsPermanent(err) {
 			e.logger.Warn("dropping central metric queue item after permanent export error", zap.Error(err))
+			lease.done()
 			continue
 		}
 		item := lease.item
 		item.attempt++
-		if requeueErr := e.centralQueue.requeue(item, time.Now().Add(centralQueueRetryDelay(item.attempt))); requeueErr != nil {
+		lease.item = item
+		if requeueErr := lease.requeue(time.Now().Add(centralQueueRetryDelay(item.attempt))); requeueErr != nil {
 			e.logger.Warn("failed to requeue central metric queue item", zap.Error(requeueErr), zap.Error(err))
 		}
 	}

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -233,6 +233,10 @@ func (e *metricExporterImp) runCentralQueue(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		if consumererror.IsPermanent(err) {
+			e.logger.Warn("dropping central metric queue item after permanent export error", zap.Error(err))
+			continue
+		}
 		item := lease.item
 		item.attempt++
 		if requeueErr := e.centralQueue.requeue(item, time.Now().Add(centralQueueRetryDelay(item.attempt))); requeueErr != nil {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -73,9 +73,9 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 	}
 	if cfg.(*Config).CentralQueue.Enabled {
 		centralCfg := cfg.(*Config).CentralQueue
-		centralTelemetry, err := newCentralQueueTelemetry(params.TelemetrySettings, signalKindMetrics)
-		if err != nil {
-			return nil, err
+		centralTelemetry, telemetryErr := newCentralQueueTelemetry(params.TelemetrySettings, signalKindMetrics)
+		if telemetryErr != nil {
+			return nil, telemetryErr
 		}
 		metricExporter.centralQueue = newCentralQueue(centralQueueSettings{
 			maxCompressedBytes:           centralCfg.MaxCompressedBytes,

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -154,8 +154,10 @@ func (e *metricExporterImp) Shutdown(ctx context.Context) error {
 	if e.centralQueue != nil {
 		e.centralQueue.stop()
 		waitErr := waitForInflight(ctx, &e.centralWG)
-		if waitErr != nil && e.centralCancel != nil {
+		if e.centralCancel != nil {
 			e.centralCancel()
+		}
+		if waitErr != nil {
 			cancelCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 			waitErr = errors.Join(waitErr, waitForInflight(cancelCtx, &e.centralWG))
 			cancel()

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -172,6 +172,36 @@ func TestMetricsExporterShutdown(t *testing.T) {
 	assert.NoError(t, res)
 }
 
+func TestConsumeMetricsCentralQueueEnqueuesCompressedByRoutingKey(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	p := &metricExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		routingKey:   svcRouting,
+	}
+	p.started.Store(true)
+
+	md := simpleMetricsWithServiceName()
+	require.NoError(t, p.ConsumeMetrics(t.Context(), md))
+	require.Equal(t, 1, p.centralQueue.len())
+	require.Greater(t, p.centralQueue.compressedBytes(), int64(0))
+
+	lease, err := p.centralQueue.lease(t.Context())
+	require.NoError(t, err)
+	defer lease.done()
+	require.Equal(t, signalKindMetrics, lease.item.signal)
+	require.Equal(t, len(lease.item.payload), cap(lease.item.payload))
+
+	decoded, err := decodeCentralQueueMetricsItem(lease.item, codec)
+	require.NoError(t, err)
+	require.Equal(t, md.DataPointCount(), decoded.DataPointCount())
+}
+
 // loadMetricsMap will parse the given yaml file into a map[string]pmetric.Metrics
 func loadMetricsMap(t *testing.T, path string) map[string]pmetric.Metrics {
 	b, err := os.ReadFile(path)

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -244,6 +244,43 @@ func TestMetricsCentralQueueDropsPermanentExportError(t *testing.T) {
 	require.NoError(t, waitErr)
 }
 
+func TestMetricsCentralQueueFirstRetryUsesInitialDelay(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	endpoint := "endpoint-1:4317"
+	p := &metricExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: &loadBalancer{
+			ring: newHashRing([]string{endpoint}),
+			exporters: map[string]*wrappedExporter{endpoint: newWrappedExporter(newMockMetricsExporter(func(context.Context, pmetric.Metrics) error {
+				return status.Error(codes.Unavailable, "backend unavailable")
+			}), endpoint)},
+			endpointHealth: newEndpointHealthManager(endpointHealthSettings{}),
+			res:            &mockResolver{},
+		},
+		telemetry: tb,
+		logger:    ts.Logger,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	p.centralWG.Add(1)
+	go p.runCentralQueue(ctx)
+	item, err := newCentralQueueMetricsItem([]byte("route-a"), singleDataPointMetric("retry"), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(item))
+
+	requireCentralQueueFirstRetryDelay(t, p.centralQueue)
+	cancel()
+	require.NoError(t, waitForInflight(t.Context(), &p.centralWG))
+}
+
 func TestMetricsCentralQueueDoesNotDirectReroute(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := endpoint2Config()

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -195,6 +195,7 @@ func TestConsumeMetricsCentralQueueEnqueuesCompressedByRoutingKey(t *testing.T) 
 	require.NoError(t, err)
 	defer lease.done()
 	require.Equal(t, signalKindMetrics, lease.item.signal)
+	require.Equal(t, []byte(serviceName1), lease.item.routingKey)
 	require.Equal(t, len(lease.item.payload), cap(lease.item.payload))
 
 	decoded, err := decodeCentralQueueMetricsItem(lease.item, codec)
@@ -241,6 +242,51 @@ func TestMetricsCentralQueueDropsPermanentExportError(t *testing.T) {
 	cancel()
 	waitErr := waitForInflight(t.Context(), &p.centralWG)
 	require.NoError(t, waitErr)
+}
+
+func TestMetricsCentralQueueDoesNotDirectReroute(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := endpoint2Config()
+	enableEndpointHealth(cfg)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	calls := map[string]int{}
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockMetricsExporter(func(context.Context, pmetric.Metrics) error {
+			calls[endpoint]++
+			if endpoint == "endpoint-1:4317" {
+				return status.Error(codes.Unavailable, "backend unavailable")
+			}
+			return nil
+		}), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.endpointHealth.reconcile([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.ring = newHashRing([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1:4317", "endpoint-2:4317"})
+
+	serviceForEndpoint1 := findRoutingIDForEndpoint(t, lb.ring, "endpoint-1:4317")
+	item, err := newCentralQueueMetricsItem(
+		[]byte(serviceForEndpoint1),
+		metricsWithServiceNames(serviceForEndpoint1),
+		codec,
+		time.Now(),
+	)
+	require.NoError(t, err)
+
+	p := &metricExporterImp{
+		centralCodec: codec,
+		loadBalancer: lb,
+		logger:       ts.Logger,
+		telemetry:    tb,
+	}
+
+	err = p.consumeCentralQueueMetricItem(t.Context(), item)
+	require.Error(t, err)
+	assert.Equal(t, 1, calls["endpoint-1:4317"])
+	assert.Zero(t, calls["endpoint-2:4317"])
 }
 
 // loadMetricsMap will parse the given yaml file into a map[string]pmetric.Metrics

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -244,6 +244,34 @@ func TestMetricsCentralQueueDropsPermanentExportError(t *testing.T) {
 	require.NoError(t, waitErr)
 }
 
+func TestMetricsCentralQueueShutdownTimeoutSkipsLoadBalancerShutdown(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	var resolverShutdown atomic.Bool
+	p := &metricExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: &loadBalancer{
+			res: &mockResolver{onShutdown: func(context.Context) error {
+				resolverShutdown.Store(true)
+				return nil
+			}},
+		},
+	}
+	p.started.Store(true)
+	p.centralWG.Add(1)
+	t.Cleanup(p.centralWG.Done)
+
+	shutdownCtx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
+	defer cancel()
+	require.Error(t, p.Shutdown(shutdownCtx))
+	require.False(t, resolverShutdown.Load())
+}
+
 func TestMetricsCentralQueueFirstRetryUsesInitialDelay(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -202,6 +202,47 @@ func TestConsumeMetricsCentralQueueEnqueuesCompressedByRoutingKey(t *testing.T) 
 	require.Equal(t, md.DataPointCount(), decoded.DataPointCount())
 }
 
+func TestMetricsCentralQueueDropsPermanentExportError(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	endpoint := "endpoint-1:4317"
+	var calls atomic.Int64
+	p := &metricExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: &loadBalancer{
+			ring: newHashRing([]string{endpoint}),
+			exporters: map[string]*wrappedExporter{endpoint: newWrappedExporter(newMockMetricsExporter(func(context.Context, pmetric.Metrics) error {
+				calls.Add(1)
+				return consumererror.NewPermanent(errors.New("bad metrics"))
+			}), endpoint)},
+			endpointHealth: newEndpointHealthManager(endpointHealthSettings{}),
+		},
+		telemetry: tb,
+		logger:    ts.Logger,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	p.centralWG.Add(1)
+	go p.runCentralQueue(ctx)
+	item, err := newCentralQueueMetricsItem([]byte("route-a"), singleDataPointMetric("permanent"), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(item))
+
+	require.Eventually(t, func() bool {
+		return calls.Load() == 1 && p.centralQueue.len() == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	cancel()
+	waitErr := waitForInflight(t.Context(), &p.centralWG)
+	require.NoError(t, waitErr)
+}
+
 // loadMetricsMap will parse the given yaml file into a map[string]pmetric.Metrics
 func loadMetricsMap(t *testing.T, path string) map[string]pmetric.Metrics {
 	b, err := os.ReadFile(path)

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -189,7 +189,7 @@ func TestConsumeMetricsCentralQueueEnqueuesCompressedByRoutingKey(t *testing.T) 
 	md := simpleMetricsWithServiceName()
 	require.NoError(t, p.ConsumeMetrics(t.Context(), md))
 	require.Equal(t, 1, p.centralQueue.len())
-	require.Greater(t, p.centralQueue.compressedBytes(), int64(0))
+	require.Positive(t, p.centralQueue.compressedBytes())
 
 	lease, err := p.centralQueue.lease(t.Context())
 	require.NoError(t, err)

--- a/pkg/stanza/operator/parser/syslog/config.schema.yaml
+++ b/pkg/stanza/operator/parser/syslog/config.schema.yaml
@@ -16,7 +16,6 @@ $defs:
         type: string
       protocol:
         type: string
-        description: The protocol to parse syslog messages as. Options are rfc3164, rfc5424, and auto.
   config:
     description: Config is the configuration of a syslog parser operator.
     type: object

--- a/pkg/stanza/operator/parser/syslog/parser_test.go
+++ b/pkg/stanza/operator/parser/syslog/parser_test.go
@@ -25,7 +25,7 @@ func basicConfig() *syslog.Config {
 	return cfg
 }
 
-func processEntry(t *testing.T, cfg *syslog.Config, body any) (*entry.Entry, error, *testutil.FakeOutput) {
+func processEntry(t *testing.T, cfg *syslog.Config, body any) (*entry.Entry, *testutil.FakeOutput, error) {
 	set := componenttest.NewNopTelemetrySettings()
 	op, err := cfg.Build(set)
 	require.NoError(t, err)
@@ -37,7 +37,7 @@ func processEntry(t *testing.T, cfg *syslog.Config, body any) (*entry.Entry, err
 	newEntry := entry.New()
 	newEntry.Body = body
 	err = op.Process(t.Context(), newEntry)
-	return newEntry, err, fake
+	return newEntry, fake, err
 }
 
 func requireReceived(t *testing.T, output *testutil.FakeOutput) *entry.Entry {
@@ -223,7 +223,7 @@ func TestSyslogAutoProtocolMatchesSpecificProtocolParsing(t *testing.T) {
 			if tt.configure != nil {
 				tt.configure(specificCfg)
 			}
-			specificEntry, err, specificOutput := processEntry(t, specificCfg, tt.body)
+			specificEntry, specificOutput, err := processEntry(t, specificCfg, tt.body)
 			require.NoError(t, err)
 			requireReceived(t, specificOutput)
 
@@ -232,7 +232,7 @@ func TestSyslogAutoProtocolMatchesSpecificProtocolParsing(t *testing.T) {
 			if tt.configure != nil {
 				tt.configure(autoCfg)
 			}
-			autoEntry, err, autoOutput := processEntry(t, autoCfg, tt.body)
+			autoEntry, autoOutput, err := processEntry(t, autoCfg, tt.body)
 			require.NoError(t, err)
 			requireReceived(t, autoOutput)
 
@@ -263,7 +263,7 @@ func TestSyslogAutoProtocolOnError(t *testing.T) {
 			cfg.OnError = tc.onError
 
 			body := "invalid syslog message"
-			_, err, output := processEntry(t, cfg, body)
+			_, output, err := processEntry(t, cfg, body)
 			require.Error(t, err)
 			require.ErrorContains(t, err, "failed to parse as rfc5424")
 			require.ErrorContains(t, err, "failed to parse as rfc3164")
@@ -331,7 +331,7 @@ func TestSyslogAutoProtocolRFC6587(t *testing.T) {
 			autoCfg := basicConfig()
 			autoCfg.Protocol = syslog.Auto
 			tt.configure(autoCfg)
-			autoEntry, err, autoOutput := processEntry(t, autoCfg, tt.body)
+			autoEntry, autoOutput, err := processEntry(t, autoCfg, tt.body)
 			require.NoError(t, err)
 			requireReceived(t, autoOutput)
 
@@ -343,7 +343,7 @@ func TestSyslogAutoProtocolRFC6587(t *testing.T) {
 			specificCfg := basicConfig()
 			specificCfg.Protocol = tt.specificProtocol
 			tt.configure(specificCfg)
-			specificEntry, err, specificOutput := processEntry(t, specificCfg, tt.body)
+			specificEntry, specificOutput, err := processEntry(t, specificCfg, tt.body)
 			require.NoError(t, err)
 			requireReceived(t, specificOutput)
 


### PR DESCRIPTION
## Summary
- add opt-in central_queue config for logs and metrics with compressed-byte capacity
- queue logs and metrics as compressed OTLP payloads and disable child OTLP queues in central mode
- add opt-in compressed pending chunks for metric_batcher

## Validation
- go test ./... -count=1 (from exporter/loadbalancingexporter)
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new buffering/dispatch paths with background goroutines, retry/backoff, and new config incompatibilities; issues could impact delivery behavior and shutdown semantics when enabled. Default behavior remains unchanged unless `central_queue` or metric batcher compression is configured.
> 
> **Overview**
> Adds an opt-in `central_queue` mode to `loadbalancingexporter` that buffers **logs and metrics as compressed OTLP payloads** with capacity enforced by compressed bytes, guardrails for uncompressed batch size and inflight decompression, and a background dispatcher that retries with backoff and drops permanent errors.
> 
> Extends configuration, schema, docs, and tests to support `central_queue` (including disabling child OTLP exporter queues and rejecting incompatible settings), and adds optional `metric_batcher.payload_compression` so pending metric chunks/retries can remain compressed in memory with new pending-compressed-bytes telemetry.
> 
> Includes minor syslog parser test helper signature change and a small schema doc cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2283c29043c89b36d0e577436f96bdf92549badc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in central, compressed queue to `loadbalancingexporter` for logs and metrics with guardrails, telemetry, and resilient, non-blocking background dispatch. Aligns `metric_batcher` to keep retries compressed with stricter reroute accounting; adds a bounded shutdown timeout guard; minor syslog schema/test cleanup.

- **New Features**
  - Central queue with capacity by compressed bytes (`central_queue.max_compressed_bytes`), using `snappy` or `zstd` (default `zstd`).
  - Guardrails: `max_uncompressed_batch_bytes`, `max_inflight_uncompressed_bytes`.
  - Background dispatch with exponential backoff (100ms–5s); preserves retry state, drops permanent errors, pauses on inflight budget, ordered leasing, bounded clean shutdown.
  - Telemetry for compressed bytes/capacity/saturation/items/rejected bytes/retries/inflight (tagged by signal).
  - Incompatibility enforcement: enabling `central_queue` disables `sending_queue`, `protocol.otlp.sending_queue`, `log_batcher.enabled`, and `metric_batcher.enabled`; child OTLP queues are force-disabled.
  - `metric_batcher`: optional `payload_compression` (`none`/`snappy`/`zstd`); retries remain compressed with cap/age guardrails and tighter reroute accounting.

- **Migration**
  - Enable `central_queue` and set `central_queue.max_compressed_bytes` (required). Optionally set `payload_compression: snappy | zstd`.
  - Optionally set `max_uncompressed_batch_bytes` and `max_inflight_uncompressed_bytes`.
  - Remove/disable `sending_queue`, `protocol.otlp.sending_queue`, `log_batcher.enabled`, and `metric_batcher.enabled` (ignored when central queue is enabled).

<sup>Written for commit 2283c29043c89b36d0e577436f96bdf92549badc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional central queue for the loadbalancing exporter with Zstd payload compression support for logs and metrics, enabling improved efficiency with configurable capacity and batch size limits.

* **Documentation**
  * Updated loadbalancing exporter documentation with new central queue configuration options and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->