### PR TITLE
feat(loadbalancingexporter): add central queue oldest age metric

### DIFF
--- a/.chloggen/loadbalancingexporter-central-queue-oldest-age.yaml
+++ b/.chloggen/loadbalancingexporter-central-queue-oldest-age.yaml
@@ -1,0 +1,8 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add a central queue oldest-item-age metric for load-balanced logs and metrics.
+issues: [55]
+subtext: |-
+  Adds `otelcol_loadbalancer_central_queue_oldest_item_age` so operators can track
+  stale compressed central queue backlog separately from queue size and saturation.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -522,3 +522,4 @@ The following metrics are recorded by this exporter:
   * `otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age` reports the age of the oldest metric datapoint currently pending for each backend endpoint.
   * `otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age_max` reports the maximum pending oldest-datapoint age across all backend endpoints.
   * `otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age` records the age of the oldest metric datapoint in each flushed batch.
+* When central queue mode is active, `otelcol_loadbalancer_central_queue_oldest_item_age` reports the age in milliseconds of the oldest item waiting in the central queue.

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -4,6 +4,7 @@
 package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 
 import (
+	"container/heap"
 	"context"
 	"sync"
 	"time"
@@ -31,7 +32,8 @@ type centralQueue struct {
 
 	currentCompressedBytes int64
 	currentInflightBytes   int64
-	oldestEnqueuedAt       int64
+	enqueuedAtCounts       map[int64]int
+	oldestEnqueuedAt       centralQueueEnqueuedAtHeap
 }
 
 type centralQueueLease struct {
@@ -136,9 +138,7 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 func (q *centralQueue) removeItemLocked(index int) {
 	removed := q.items[index]
 	q.items = removeCentralQueueItem(q.items, index)
-	if removed.enqueuedAtUnixNano == q.oldestEnqueuedAt {
-		q.refreshOldestEnqueuedAtLocked()
-	}
+	q.untrackOldestEnqueuedAtLocked(removed)
 }
 
 func removeCentralQueueItem(items []centralQueueItem, index int) []centralQueueItem {
@@ -226,10 +226,11 @@ func (q *centralQueue) oldestItemAgeMillis() int64 {
 }
 
 func (q *centralQueue) oldestItemAgeMillisLocked(now time.Time) int64 {
-	if q.oldestEnqueuedAt == 0 {
+	q.pruneOldestEnqueuedAtLocked()
+	if len(q.oldestEnqueuedAt) == 0 {
 		return 0
 	}
-	age := now.Sub(time.Unix(0, q.oldestEnqueuedAt))
+	age := now.Sub(time.Unix(0, q.oldestEnqueuedAt[0]))
 	if age <= 0 {
 		return 0
 	}
@@ -240,21 +241,58 @@ func (q *centralQueue) trackOldestEnqueuedAtLocked(item centralQueueItem) {
 	if item.enqueuedAtUnixNano == 0 {
 		return
 	}
-	if q.oldestEnqueuedAt == 0 || item.enqueuedAtUnixNano < q.oldestEnqueuedAt {
-		q.oldestEnqueuedAt = item.enqueuedAtUnixNano
+	if q.enqueuedAtCounts == nil {
+		q.enqueuedAtCounts = map[int64]int{}
+	}
+	if q.enqueuedAtCounts[item.enqueuedAtUnixNano] == 0 {
+		heap.Push(&q.oldestEnqueuedAt, item.enqueuedAtUnixNano)
+	}
+	q.enqueuedAtCounts[item.enqueuedAtUnixNano]++
+}
+
+func (q *centralQueue) untrackOldestEnqueuedAtLocked(item centralQueueItem) {
+	if item.enqueuedAtUnixNano == 0 || q.enqueuedAtCounts == nil {
+		return
+	}
+	count := q.enqueuedAtCounts[item.enqueuedAtUnixNano]
+	if count <= 1 {
+		delete(q.enqueuedAtCounts, item.enqueuedAtUnixNano)
+	} else {
+		q.enqueuedAtCounts[item.enqueuedAtUnixNano] = count - 1
+	}
+	q.pruneOldestEnqueuedAtLocked()
+}
+
+func (q *centralQueue) pruneOldestEnqueuedAtLocked() {
+	for len(q.oldestEnqueuedAt) > 0 && q.enqueuedAtCounts[q.oldestEnqueuedAt[0]] == 0 {
+		heap.Pop(&q.oldestEnqueuedAt)
 	}
 }
 
-func (q *centralQueue) refreshOldestEnqueuedAtLocked() {
-	q.oldestEnqueuedAt = 0
-	for _, item := range q.items {
-		if item.enqueuedAtUnixNano == 0 {
-			continue
-		}
-		if q.oldestEnqueuedAt == 0 || item.enqueuedAtUnixNano < q.oldestEnqueuedAt {
-			q.oldestEnqueuedAt = item.enqueuedAtUnixNano
-		}
-	}
+type centralQueueEnqueuedAtHeap []int64
+
+func (h centralQueueEnqueuedAtHeap) Len() int {
+	return len(h)
+}
+
+func (h centralQueueEnqueuedAtHeap) Less(i, j int) bool {
+	return h[i] < h[j]
+}
+
+func (h centralQueueEnqueuedAtHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *centralQueueEnqueuedAtHeap) Push(x any) {
+	*h = append(*h, x.(int64))
+}
+
+func (h *centralQueueEnqueuedAtHeap) Pop() any {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[:n-1]
+	return x
 }
 
 func centralQueueRetryDelay(attempt int) time.Duration {

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -31,6 +31,7 @@ type centralQueue struct {
 
 	currentCompressedBytes int64
 	currentInflightBytes   int64
+	oldestEnqueuedAt       int64
 }
 
 type centralQueueLease struct {
@@ -40,7 +41,9 @@ type centralQueueLease struct {
 }
 
 func newCentralQueue(settings centralQueueSettings) *centralQueue {
-	return &centralQueue{settings: settings}
+	q := &centralQueue{settings: settings}
+	q.settings.telemetry.observeOldestItemAge(q.oldestItemAgeMillis)
+	return q
 }
 
 func (q *centralQueue) enqueue(item centralQueueItem) error {
@@ -72,6 +75,7 @@ func (q *centralQueue) enqueueAt(item centralQueueItem, now time.Time) error {
 	}
 	q.items = append(q.items, item)
 	q.currentCompressedBytes += int64(item.compressedBytes)
+	q.trackOldestEnqueuedAtLocked(item)
 	snapshot := q.snapshotLockedAt(now)
 	q.mu.Unlock()
 	q.settings.telemetry.record(context.Background(), snapshot)
@@ -117,7 +121,7 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 			continue
 		}
 
-		q.items = removeCentralQueueItem(q.items, i)
+		q.removeItemLocked(i)
 		q.currentInflightBytes += int64(item.uncompressedBytes)
 		snapshot := q.snapshotLocked()
 		q.settings.telemetry.record(context.Background(), snapshot)
@@ -127,6 +131,14 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 		return nil, errCentralQueueInflightFull
 	}
 	return nil, nil
+}
+
+func (q *centralQueue) removeItemLocked(index int) {
+	removed := q.items[index]
+	q.items = removeCentralQueueItem(q.items, index)
+	if removed.enqueuedAtUnixNano == q.oldestEnqueuedAt {
+		q.refreshOldestEnqueuedAtLocked()
+	}
 }
 
 func removeCentralQueueItem(items []centralQueueItem, index int) []centralQueueItem {
@@ -160,6 +172,7 @@ func (l *centralQueueLease) requeue(nextAttempt time.Time) error {
 			err = errCentralQueueStopped
 		} else {
 			l.queue.items = append(l.queue.items, item)
+			l.queue.trackOldestEnqueuedAtLocked(item)
 		}
 		snapshot := l.queue.snapshotLocked()
 		l.queue.mu.Unlock()
@@ -206,24 +219,42 @@ func (q *centralQueue) snapshotLockedAt(now time.Time) centralQueueSnapshot {
 	}
 }
 
+func (q *centralQueue) oldestItemAgeMillis() int64 {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.oldestItemAgeMillisLocked(time.Now())
+}
+
 func (q *centralQueue) oldestItemAgeMillisLocked(now time.Time) int64 {
-	var oldestUnixNano int64
-	for _, item := range q.items {
-		if item.enqueuedAtUnixNano == 0 {
-			continue
-		}
-		if oldestUnixNano == 0 || item.enqueuedAtUnixNano < oldestUnixNano {
-			oldestUnixNano = item.enqueuedAtUnixNano
-		}
-	}
-	if oldestUnixNano == 0 {
+	if q.oldestEnqueuedAt == 0 {
 		return 0
 	}
-	age := now.Sub(time.Unix(0, oldestUnixNano))
+	age := now.Sub(time.Unix(0, q.oldestEnqueuedAt))
 	if age <= 0 {
 		return 0
 	}
 	return age.Milliseconds()
+}
+
+func (q *centralQueue) trackOldestEnqueuedAtLocked(item centralQueueItem) {
+	if item.enqueuedAtUnixNano == 0 {
+		return
+	}
+	if q.oldestEnqueuedAt == 0 || item.enqueuedAtUnixNano < q.oldestEnqueuedAt {
+		q.oldestEnqueuedAt = item.enqueuedAtUnixNano
+	}
+}
+
+func (q *centralQueue) refreshOldestEnqueuedAtLocked() {
+	q.oldestEnqueuedAt = 0
+	for _, item := range q.items {
+		if item.enqueuedAtUnixNano == 0 {
+			continue
+		}
+		if q.oldestEnqueuedAt == 0 || item.enqueuedAtUnixNano < q.oldestEnqueuedAt {
+			q.oldestEnqueuedAt = item.enqueuedAtUnixNano
+		}
+	}
 }
 
 func centralQueueRetryDelay(attempt int) time.Duration {

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -193,12 +193,37 @@ func (q *centralQueue) len() int {
 }
 
 func (q *centralQueue) snapshotLocked() centralQueueSnapshot {
+	return q.snapshotLockedAt(time.Now())
+}
+
+func (q *centralQueue) snapshotLockedAt(now time.Time) centralQueueSnapshot {
 	return centralQueueSnapshot{
 		compressedBytes:      q.currentCompressedBytes,
 		compressedCapacity:   q.settings.maxCompressedBytes,
 		items:                int64(len(q.items)),
 		inflightUncompressed: q.currentInflightBytes,
+		oldestItemAgeMillis:  q.oldestItemAgeMillisLocked(now),
 	}
+}
+
+func (q *centralQueue) oldestItemAgeMillisLocked(now time.Time) int64 {
+	var oldestUnixNano int64
+	for _, item := range q.items {
+		if item.enqueuedAtUnixNano == 0 {
+			continue
+		}
+		if oldestUnixNano == 0 || item.enqueuedAtUnixNano < oldestUnixNano {
+			oldestUnixNano = item.enqueuedAtUnixNano
+		}
+	}
+	if oldestUnixNano == 0 {
+		return 0
+	}
+	age := now.Sub(time.Unix(0, oldestUnixNano))
+	if age <= 0 {
+		return 0
+	}
+	return age.Milliseconds()
 }
 
 func centralQueueRetryDelay(attempt int) time.Duration {

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -72,7 +72,7 @@ func (q *centralQueue) enqueueAt(item centralQueueItem, now time.Time) error {
 	}
 	q.items = append(q.items, item)
 	q.currentCompressedBytes += int64(item.compressedBytes)
-	snapshot := q.snapshotLocked()
+	snapshot := q.snapshotLockedAt(now)
 	q.mu.Unlock()
 	q.settings.telemetry.record(context.Background(), snapshot)
 	return nil

--- a/exporter/loadbalancingexporter/central_queue_telemetry.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry.go
@@ -23,6 +23,7 @@ type centralQueueTelemetry struct {
 	rejectedBytes        metric.Int64Counter
 	retries              metric.Int64Counter
 	inflightUncompressed metric.Int64Gauge
+	oldestItemAge        metric.Int64Gauge
 }
 
 type centralQueueSnapshot struct {
@@ -30,6 +31,7 @@ type centralQueueSnapshot struct {
 	compressedCapacity   int64
 	items                int64
 	inflightUncompressed int64
+	oldestItemAgeMillis  int64
 }
 
 func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signalKind) (*centralQueueTelemetry, error) {
@@ -80,6 +82,12 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
+	t.oldestItemAge, err = meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_oldest_item_age",
+		metric.WithDescription("Age in ms of the oldest queued central load-balancing item."),
+		metric.WithUnit("ms"),
+	)
+	errs = errors.Join(errs, err)
 	return t, errs
 }
 
@@ -94,6 +102,7 @@ func (t *centralQueueTelemetry) record(ctx context.Context, snapshot centralQueu
 	}
 	t.items.Record(ctx, snapshot.items, t.signalAttrs)
 	t.inflightUncompressed.Record(ctx, snapshot.inflightUncompressed, t.signalAttrs)
+	t.oldestItemAge.Record(ctx, snapshot.oldestItemAgeMillis, t.signalAttrs)
 }
 
 func (t *centralQueueTelemetry) recordRejected(ctx context.Context, compressedBytes int64) {

--- a/exporter/loadbalancingexporter/central_queue_telemetry.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry.go
@@ -6,6 +6,7 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/attribute"
@@ -23,7 +24,9 @@ type centralQueueTelemetry struct {
 	rejectedBytes        metric.Int64Counter
 	retries              metric.Int64Counter
 	inflightUncompressed metric.Int64Gauge
-	oldestItemAge        metric.Int64Gauge
+	oldestItemAge        metric.Int64ObservableGauge
+	oldestItemAgeMu      sync.RWMutex
+	oldestItemAgeMillis  func() int64
 }
 
 type centralQueueSnapshot struct {
@@ -82,10 +85,19 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
-	t.oldestItemAge, err = meter.Int64Gauge(
+	t.oldestItemAge, err = meter.Int64ObservableGauge(
 		"otelcol_loadbalancer_central_queue_oldest_item_age",
 		metric.WithDescription("Age in ms of the oldest queued central load-balancing item."),
 		metric.WithUnit("ms"),
+		metric.WithInt64Callback(func(_ context.Context, observer metric.Int64Observer) error {
+			t.oldestItemAgeMu.RLock()
+			oldestItemAgeMillis := t.oldestItemAgeMillis
+			t.oldestItemAgeMu.RUnlock()
+			if oldestItemAgeMillis != nil {
+				observer.Observe(oldestItemAgeMillis(), t.signalAttrs)
+			}
+			return nil
+		}),
 	)
 	errs = errors.Join(errs, err)
 	return t, errs
@@ -102,7 +114,6 @@ func (t *centralQueueTelemetry) record(ctx context.Context, snapshot centralQueu
 	}
 	t.items.Record(ctx, snapshot.items, t.signalAttrs)
 	t.inflightUncompressed.Record(ctx, snapshot.inflightUncompressed, t.signalAttrs)
-	t.oldestItemAge.Record(ctx, snapshot.oldestItemAgeMillis, t.signalAttrs)
 }
 
 func (t *centralQueueTelemetry) recordRejected(ctx context.Context, compressedBytes int64) {
@@ -117,4 +128,13 @@ func (t *centralQueueTelemetry) recordRetry(ctx context.Context) {
 		return
 	}
 	t.retries.Add(ctx, 1, t.signalAttrs)
+}
+
+func (t *centralQueueTelemetry) observeOldestItemAge(oldestItemAgeMillis func() int64) {
+	if t == nil {
+		return
+	}
+	t.oldestItemAgeMu.Lock()
+	defer t.oldestItemAgeMu.Unlock()
+	t.oldestItemAgeMillis = oldestItemAgeMillis
 }

--- a/exporter/loadbalancingexporter/central_queue_telemetry_test.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry_test.go
@@ -20,6 +20,7 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 	})
 	telemetry, err := newCentralQueueTelemetry(reader.NewTelemetrySettings(), signalKindLogs)
 	require.NoError(t, err)
+	telemetry.observeOldestItemAge(func() int64 { return 125 })
 
 	telemetry.record(t.Context(), centralQueueSnapshot{
 		compressedBytes:      50,

--- a/exporter/loadbalancingexporter/central_queue_telemetry_test.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry_test.go
@@ -26,6 +26,7 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 		compressedCapacity:   100,
 		items:                3,
 		inflightUncompressed: 80,
+		oldestItemAgeMillis:  125,
 	})
 	telemetry.recordRejected(t.Context(), 7)
 	telemetry.recordRetry(t.Context())
@@ -36,6 +37,7 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 	requireCentralQueueFloatGauge(t, reader, "otelcol_loadbalancer_central_queue_saturation", "1", attrs, 0.5)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_items", "{items}", attrs, 3)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_inflight_uncompressed_bytes", "By", attrs, 80)
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_oldest_item_age", "ms", attrs, 125)
 	requireCentralQueueIntSum(t, reader, "otelcol_loadbalancer_central_queue_rejected_compressed_bytes", "By", attrs, 7)
 	requireCentralQueueIntSum(t, reader, "otelcol_loadbalancer_central_queue_retries", "{retries}", attrs, 1)
 }

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestCentralQueueAdmitsByCompressedBytes(t *testing.T) {
@@ -106,6 +108,35 @@ func TestCentralQueueSnapshotReportsOldestQueuedItemAge(t *testing.T) {
 	require.NotNil(t, retryLease)
 	retryLease.done()
 	require.Zero(t, snapshotAt(base.Add(time.Second)).oldestItemAgeMillis)
+}
+
+func TestCentralQueueTelemetryOldestItemAgeAdvancesWithoutQueueMutation(t *testing.T) {
+	reader := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, reader.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	telemetry, err := newCentralQueueTelemetry(reader.NewTelemetrySettings(), signalKindLogs)
+	require.NoError(t, err)
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		telemetry:                    telemetry,
+	})
+
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 10, uncompressedBytes: 10, count: 1}))
+
+	require.Eventually(t, func() bool {
+		metric, err := reader.GetMetric("otelcol_loadbalancer_central_queue_oldest_item_age")
+		if err != nil {
+			return false
+		}
+		gauge, ok := metric.Data.(metricdata.Gauge[int64])
+		if !ok || len(gauge.DataPoints) != 1 {
+			return false
+		}
+		return gauge.DataPoints[0].Value >= 10
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestCentralQueueRejectsOversizedUncompressedItem(t *testing.T) {

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -67,6 +67,47 @@ func TestCentralQueueLeaseReservesCompressedBytesUntilDoneOrRequeue(t *testing.T
 	require.Zero(t, q.compressedBytes())
 }
 
+func TestCentralQueueSnapshotReportsOldestQueuedItemAge(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+	})
+	base := time.Unix(10, 0)
+	snapshotAt := func(now time.Time) centralQueueSnapshot {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		return q.snapshotLockedAt(now)
+	}
+
+	require.Zero(t, snapshotAt(base).oldestItemAgeMillis)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, compressedBytes: 10, uncompressedBytes: 10, count: 1}, base))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, compressedBytes: 10, uncompressedBytes: 10, count: 1}, base.Add(100*time.Millisecond)))
+
+	require.EqualValues(t, 250, snapshotAt(base.Add(250*time.Millisecond)).oldestItemAgeMillis)
+
+	lease, err := q.tryLease(base.Add(250 * time.Millisecond))
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+
+	require.EqualValues(t, 150, snapshotAt(base.Add(250*time.Millisecond)).oldestItemAgeMillis)
+
+	require.NoError(t, lease.requeue(base.Add(time.Second)))
+	require.EqualValues(t, 300, snapshotAt(base.Add(300*time.Millisecond)).oldestItemAgeMillis)
+
+	secondLease, err := q.tryLease(base.Add(300 * time.Millisecond))
+	require.NoError(t, err)
+	require.NotNil(t, secondLease)
+	secondLease.done()
+	require.EqualValues(t, 300, snapshotAt(base.Add(300*time.Millisecond)).oldestItemAgeMillis)
+
+	retryLease, err := q.tryLease(base.Add(time.Second))
+	require.NoError(t, err)
+	require.NotNil(t, retryLease)
+	retryLease.done()
+	require.Zero(t, snapshotAt(base.Add(time.Second)).oldestItemAgeMillis)
+}
+
 func TestCentralQueueRejectsOversizedUncompressedItem(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:           100,


### PR DESCRIPTION
## Description
Adds `otelcol_loadbalancer_central_queue_oldest_item_age` so Grafana can show oldest-message age for the new central queue path while legacy queue age panels remain usable for older collectors. The gauge is observable at scrape time, so age continues advancing while the queue is idle between mutations, and the queue keeps a cached oldest enqueue timestamp so mutation snapshots do not scan the whole queue.

## Link to tracking issue
Uses PR #55 as the tracking reference for this Sawmills fork change.

## Testing
- `go test . -count=1` in `exporter/loadbalancingexporter`

## Documentation
- Updated `exporter/loadbalancingexporter/README.md` with the new central queue age metric.
- Added `.chloggen/loadbalancingexporter-central-queue-oldest-age.yaml`.

Assisted-by: GPT-5 Codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new central-queue telemetry and mutates queue bookkeeping to maintain a heap of enqueue timestamps; bugs here could skew metrics or subtly impact queue behavior under concurrency.
> 
> **Overview**
> Adds a new observable gauge metric, `otelcol_loadbalancer_central_queue_oldest_item_age`, to report the age (ms) of the oldest item waiting in the load balancer’s central queue, and documents it in the README and changelog.
> 
> Updates central-queue internals to track enqueue timestamps via a counted min-heap so oldest-age can be computed at scrape time (advancing even when the queue is idle) without scanning the full queue, and extends tests to validate age calculations and metric emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d71b928fe0ca43c5992df4eab1f8f29c640bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->