### PR TITLE
fix(loadbalancingexporter): harden central queue age telemetry

### DIFF
--- a/.chloggen/loadbalancingexporter-central-queue-age-fixes.yaml
+++ b/.chloggen/loadbalancingexporter-central-queue-age-fixes.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+component: exporter/loadbalancing
+note: Fix central queue oldest-item-age metric registration and retry timestamp tracking.
+issues: [56]
+subtext: |-
+  Ensures logs and metrics central queues each report oldest-item-age datapoints,
+  unregisters the observer when a central queue stops, and avoids duplicate retry
+  timestamps growing the oldest-item heap.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -33,6 +33,7 @@ type centralQueue struct {
 	currentCompressedBytes int64
 	currentInflightBytes   int64
 	enqueuedAtCounts       map[int64]int
+	enqueuedAtHeapEntries  map[int64]struct{}
 	oldestEnqueuedAt       centralQueueEnqueuedAtHeap
 }
 
@@ -185,6 +186,7 @@ func (q *centralQueue) stop() {
 	q.mu.Lock()
 	q.stopped = true
 	q.mu.Unlock()
+	q.settings.telemetry.stopObservingOldestItemAge()
 }
 
 func (q *centralQueue) compressedBytes() int64 {
@@ -244,8 +246,12 @@ func (q *centralQueue) trackOldestEnqueuedAtLocked(item centralQueueItem) {
 	if q.enqueuedAtCounts == nil {
 		q.enqueuedAtCounts = map[int64]int{}
 	}
-	if q.enqueuedAtCounts[item.enqueuedAtUnixNano] == 0 {
+	if q.enqueuedAtHeapEntries == nil {
+		q.enqueuedAtHeapEntries = map[int64]struct{}{}
+	}
+	if _, ok := q.enqueuedAtHeapEntries[item.enqueuedAtUnixNano]; !ok {
 		heap.Push(&q.oldestEnqueuedAt, item.enqueuedAtUnixNano)
+		q.enqueuedAtHeapEntries[item.enqueuedAtUnixNano] = struct{}{}
 	}
 	q.enqueuedAtCounts[item.enqueuedAtUnixNano]++
 }
@@ -265,7 +271,8 @@ func (q *centralQueue) untrackOldestEnqueuedAtLocked(item centralQueueItem) {
 
 func (q *centralQueue) pruneOldestEnqueuedAtLocked() {
 	for len(q.oldestEnqueuedAt) > 0 && q.enqueuedAtCounts[q.oldestEnqueuedAt[0]] == 0 {
-		heap.Pop(&q.oldestEnqueuedAt)
+		enqueuedAt := heap.Pop(&q.oldestEnqueuedAt).(int64)
+		delete(q.enqueuedAtHeapEntries, enqueuedAt)
 	}
 }
 

--- a/exporter/loadbalancingexporter/central_queue_telemetry.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry.go
@@ -25,6 +25,7 @@ type centralQueueTelemetry struct {
 	retries              metric.Int64Counter
 	inflightUncompressed metric.Int64Gauge
 	oldestItemAge        metric.Int64ObservableGauge
+	oldestItemAgeReg     metric.Registration
 	oldestItemAgeMu      sync.RWMutex
 	oldestItemAgeMillis  func() int64
 }
@@ -89,17 +90,20 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 		"otelcol_loadbalancer_central_queue_oldest_item_age",
 		metric.WithDescription("Age in ms of the oldest queued central load-balancing item."),
 		metric.WithUnit("ms"),
-		metric.WithInt64Callback(func(_ context.Context, observer metric.Int64Observer) error {
+	)
+	errs = errors.Join(errs, err)
+	if err == nil {
+		t.oldestItemAgeReg, err = meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
 			t.oldestItemAgeMu.RLock()
 			oldestItemAgeMillis := t.oldestItemAgeMillis
 			t.oldestItemAgeMu.RUnlock()
 			if oldestItemAgeMillis != nil {
-				observer.Observe(oldestItemAgeMillis(), t.signalAttrs)
+				observer.ObserveInt64(t.oldestItemAge, oldestItemAgeMillis(), t.signalAttrs)
 			}
 			return nil
-		}),
-	)
-	errs = errors.Join(errs, err)
+		}, t.oldestItemAge)
+		errs = errors.Join(errs, err)
+	}
 	return t, errs
 }
 
@@ -137,4 +141,18 @@ func (t *centralQueueTelemetry) observeOldestItemAge(oldestItemAgeMillis func() 
 	t.oldestItemAgeMu.Lock()
 	defer t.oldestItemAgeMu.Unlock()
 	t.oldestItemAgeMillis = oldestItemAgeMillis
+}
+
+func (t *centralQueueTelemetry) stopObservingOldestItemAge() {
+	if t == nil {
+		return
+	}
+	t.oldestItemAgeMu.Lock()
+	registration := t.oldestItemAgeReg
+	t.oldestItemAgeReg = nil
+	t.oldestItemAgeMillis = nil
+	t.oldestItemAgeMu.Unlock()
+	if registration != nil {
+		_ = registration.Unregister()
+	}
 }

--- a/exporter/loadbalancingexporter/central_queue_telemetry_test.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry_test.go
@@ -43,6 +43,28 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 	requireCentralQueueIntSum(t, reader, "otelcol_loadbalancer_central_queue_retries", "{retries}", attrs, 1)
 }
 
+func TestCentralQueueTelemetryOldestItemAgeReportsMultipleSignals(t *testing.T) {
+	reader := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, reader.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	logsTelemetry, err := newCentralQueueTelemetry(reader.NewTelemetrySettings(), signalKindLogs)
+	require.NoError(t, err)
+	metricsTelemetry, err := newCentralQueueTelemetry(reader.NewTelemetrySettings(), signalKindMetrics)
+	require.NoError(t, err)
+	logsTelemetry.observeOldestItemAge(func() int64 { return 125 })
+	metricsTelemetry.observeOldestItemAge(func() int64 { return 250 })
+
+	metric, err := reader.GetMetric("otelcol_loadbalancer_central_queue_oldest_item_age")
+	require.NoError(t, err)
+	require.Equal(t, "ms", metric.Unit)
+	gauge, ok := metric.Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	require.Len(t, gauge.DataPoints, 2)
+	requireCentralQueueIntGaugeDatapoint(t, gauge.DataPoints, attribute.NewSet(attribute.String("signal", string(signalKindLogs))), 125)
+	requireCentralQueueIntGaugeDatapoint(t, gauge.DataPoints, attribute.NewSet(attribute.String("signal", string(signalKindMetrics))), 250)
+}
+
 func requireCentralQueueIntGauge(t *testing.T, reader *componenttest.Telemetry, name, unit string, attrs attribute.Set, value int64) {
 	t.Helper()
 	metric, err := reader.GetMetric(name)
@@ -51,8 +73,18 @@ func requireCentralQueueIntGauge(t *testing.T, reader *componenttest.Telemetry, 
 	gauge, ok := metric.Data.(metricdata.Gauge[int64])
 	require.True(t, ok)
 	require.Len(t, gauge.DataPoints, 1)
-	require.Equal(t, attrs, gauge.DataPoints[0].Attributes)
-	require.Equal(t, value, gauge.DataPoints[0].Value)
+	requireCentralQueueIntGaugeDatapoint(t, gauge.DataPoints, attrs, value)
+}
+
+func requireCentralQueueIntGaugeDatapoint(t *testing.T, datapoints []metricdata.DataPoint[int64], attrs attribute.Set, value int64) {
+	t.Helper()
+	for _, datapoint := range datapoints {
+		if datapoint.Attributes.Equals(&attrs) {
+			require.Equal(t, value, datapoint.Value)
+			return
+		}
+	}
+	require.Failf(t, "missing datapoint", "attributes: %v", attrs)
 }
 
 func requireCentralQueueFloatGauge(t *testing.T, reader *componenttest.Telemetry, name, unit string, attrs attribute.Set, value float64) {

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -139,6 +139,81 @@ func TestCentralQueueTelemetryOldestItemAgeAdvancesWithoutQueueMutation(t *testi
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestCentralQueueStopUnregistersOldestItemAgeObserver(t *testing.T) {
+	reader := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, reader.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	telemetry, err := newCentralQueueTelemetry(reader.NewTelemetrySettings(), signalKindLogs)
+	require.NoError(t, err)
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		telemetry:                    telemetry,
+	})
+
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 10, uncompressedBytes: 10, count: 1}))
+	require.Eventually(t, func() bool {
+		metric, err := reader.GetMetric("otelcol_loadbalancer_central_queue_oldest_item_age")
+		if err != nil {
+			return false
+		}
+		gauge, ok := metric.Data.(metricdata.Gauge[int64])
+		return ok && len(gauge.DataPoints) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	q.stop()
+
+	require.Eventually(t, func() bool {
+		metric, err := reader.GetMetric("otelcol_loadbalancer_central_queue_oldest_item_age")
+		if err != nil {
+			return true
+		}
+		gauge, ok := metric.Data.(metricdata.Gauge[int64])
+		return ok && len(gauge.DataPoints) == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestCentralQueueRetriesDoNotGrowOldestEnqueuedHeap(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+	})
+	base := time.Unix(10, 0)
+	blockedOldest := centralQueueItem{
+		signal:              signalKindLogs,
+		compressedBytes:     10,
+		uncompressedBytes:   10,
+		count:               1,
+		nextAttemptUnixNano: base.Add(time.Hour).UnixNano(),
+		enqueuedAtUnixNano:  base.UnixNano(),
+	}
+	retryingItem := centralQueueItem{
+		signal:             signalKindLogs,
+		compressedBytes:    10,
+		uncompressedBytes:  10,
+		count:              1,
+		enqueuedAtUnixNano: base.Add(time.Millisecond).UnixNano(),
+	}
+	require.NoError(t, q.enqueueAt(blockedOldest, base))
+	require.NoError(t, q.enqueueAt(retryingItem, base))
+
+	now := base.Add(time.Second)
+	for range 10 {
+		lease, err := q.tryLease(now)
+		require.NoError(t, err)
+		require.NotNil(t, lease)
+		require.NoError(t, lease.requeue(now))
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	require.Len(t, q.enqueuedAtCounts, 2)
+	require.Len(t, q.oldestEnqueuedAt, 2)
+}
+
 func TestCentralQueueRejectsOversizedUncompressedItem(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:           100,


### PR DESCRIPTION
## Description

Follow-up to PR #55 review comments for the central queue oldest-age metric.

This change:
- registers the oldest-age observable callback with `Meter.RegisterCallback` so logs and metrics central queues can both emit `otelcol_loadbalancer_central_queue_oldest_item_age` with distinct `signal` datapoints
- unregisters the oldest-age callback when the central queue stops, preventing stale queue retention/reporting after shutdown or reload
- tracks timestamp heap entries separately from active timestamp counts so retry/requeue loops cannot grow duplicate heap entries while an older queued item remains at the heap root

## Testing

- `go test . -run 'TestCentralQueue(TelemetryOldestItemAgeReportsMultipleSignals|StopUnregistersOldestItemAgeObserver|RetriesDoNotGrowOldestEnqueuedHeap)' -count=1`
- `go test . -count=1`
- `go test ./... -count=1`
- `git diff --check`

## Documentation

No user-facing config or metric contract changes. Existing metric name, unit, and labels are preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes metric callback registration/unregistration and queue timestamp tracking; mistakes could silently break `oldest_item_age` reporting or leak memory in long-running retry scenarios.
> 
> **Overview**
> Fixes `otelcol_loadbalancer_central_queue_oldest_item_age` emission by switching to `Meter.RegisterCallback`, allowing both logs and metrics central queues to report distinct `signal` datapoints, and adds explicit unregister on `centralQueue.stop()` to avoid stale observers after shutdown/reload.
> 
> Hardens oldest-item age tracking by deduping `enqueuedAt` timestamps in the heap (separate `enqueuedAtHeapEntries` from refcounts) so retry/requeue loops can’t grow the heap with duplicate entries. Adds focused tests for multi-signal reporting, observer cleanup on stop, and heap stability under retries, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366eed21c97f12fc7e39a089ca971f73a3a1292c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the central queue oldest-age telemetry in the load balancing exporter to ensure accurate per-signal reporting and clean shutdown behavior. No user-facing config or metric changes.

- **Bug Fixes**
  - Register oldest-age observable via `Meter.RegisterCallback` so logs and metrics each emit `otelcol_loadbalancer_central_queue_oldest_item_age` with a distinct `signal` datapoint.
  - Unregister the oldest-age callback when the central queue stops to prevent stale metrics after shutdown or reload.
  - Track heap entries separately from counts to avoid duplicate timestamps during retries; prune deletes heap entries when their count reaches zero.
  - Add changelog entry in `.chloggen` for this fix.

<sup>Written for commit 366eed21c97f12fc7e39a089ca971f73a3a1292c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced oldest item age metric to properly manage telemetry lifecycle when the central queue stops.

* **Tests**
  * Added test coverage for oldest item age metric reporting across multiple signal types.
  * Added test coverage ensuring telemetry metrics are properly cleaned up during queue shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->