### PR TITLE
[chore] test(loadbalancingexporter): cover central queue failed subset retries

### DIFF
--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -363,6 +363,78 @@ func TestLogsCentralQueueFirstRetryUsesInitialDelay(t *testing.T) {
 	require.NoError(t, waitForInflight(t.Context(), &p.centralWG))
 }
 
+func TestLogsCentralQueueRetriesOnlyFailedEndpointItem(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := endpoint2Config()
+	enableEndpointHealth(cfg)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	var callsMu sync.Mutex
+	calls := map[string]int{}
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(context.Context, plog.Logs) error {
+			callsMu.Lock()
+			calls[endpoint]++
+			callsMu.Unlock()
+			if endpoint == "endpoint-1:4317" {
+				return status.Error(codes.Unavailable, "backend unavailable")
+			}
+			return nil
+		}), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.endpointHealth.reconcile([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.ring = newHashRing([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1:4317", "endpoint-2:4317"})
+
+	failedRoute := findRoutingIDForEndpoint(t, lb.ring, "endpoint-1:4317")
+	successRoute := findRoutingIDForEndpoint(t, lb.ring, "endpoint-2:4317")
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: lb,
+		logger:       ts.Logger,
+		telemetry:    tb,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	p.centralWG.Add(1)
+	go p.runCentralQueue(ctx)
+
+	failedItem, err := newCentralQueueLogsItem([]byte(failedRoute), simpleLogs(), codec, time.Now())
+	require.NoError(t, err)
+	// Keep the retry far enough out that slow CI cannot process it before assertions.
+	failedItem.attempt = 10
+	require.NoError(t, p.centralQueue.enqueue(failedItem))
+	successItem, err := newCentralQueueLogsItem([]byte(successRoute), simpleLogs(), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(successItem))
+
+	require.Eventually(t, func() bool {
+		callsMu.Lock()
+		defer callsMu.Unlock()
+		return calls["endpoint-1:4317"] == 1 && calls["endpoint-2:4317"] == 1 && p.centralQueue.len() == 1
+	}, time.Second, time.Millisecond)
+	cancel()
+	require.NoError(t, waitForInflight(t.Context(), &p.centralWG))
+
+	p.centralQueue.mu.Lock()
+	items := append([]centralQueueItem(nil), p.centralQueue.items...)
+	p.centralQueue.mu.Unlock()
+	require.Len(t, items, 1)
+	remaining := items[0]
+	require.Equal(t, []byte(failedRoute), remaining.routingKey)
+	require.Equal(t, 11, remaining.attempt)
+	require.NotZero(t, remaining.nextAttemptUnixNano)
+}
+
 func TestLogsCentralQueueDoesNotDrainSynchronously(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := endpoint2Config()

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -309,6 +309,78 @@ func TestMetricsCentralQueueFirstRetryUsesInitialDelay(t *testing.T) {
 	require.NoError(t, waitForInflight(t.Context(), &p.centralWG))
 }
 
+func TestMetricsCentralQueueRetriesOnlyFailedEndpointItem(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := endpoint2Config()
+	enableEndpointHealth(cfg)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	var callsMu sync.Mutex
+	calls := map[string]int{}
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockMetricsExporter(func(context.Context, pmetric.Metrics) error {
+			callsMu.Lock()
+			calls[endpoint]++
+			callsMu.Unlock()
+			if endpoint == "endpoint-1:4317" {
+				return status.Error(codes.Unavailable, "backend unavailable")
+			}
+			return nil
+		}), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.endpointHealth.reconcile([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.ring = newHashRing([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1:4317", "endpoint-2:4317"})
+
+	failedRoute := findRoutingIDForEndpoint(t, lb.ring, "endpoint-1:4317")
+	successRoute := findRoutingIDForEndpoint(t, lb.ring, "endpoint-2:4317")
+	p := &metricExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: lb,
+		logger:       ts.Logger,
+		telemetry:    tb,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	p.centralWG.Add(1)
+	go p.runCentralQueue(ctx)
+
+	failedItem, err := newCentralQueueMetricsItem([]byte(failedRoute), metricsWithServiceNames(failedRoute), codec, time.Now())
+	require.NoError(t, err)
+	// Keep the retry far enough out that slow CI cannot process it before assertions.
+	failedItem.attempt = 10
+	require.NoError(t, p.centralQueue.enqueue(failedItem))
+	successItem, err := newCentralQueueMetricsItem([]byte(successRoute), metricsWithServiceNames(successRoute), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(successItem))
+
+	require.Eventually(t, func() bool {
+		callsMu.Lock()
+		defer callsMu.Unlock()
+		return calls["endpoint-1:4317"] == 1 && calls["endpoint-2:4317"] == 1 && p.centralQueue.len() == 1
+	}, time.Second, time.Millisecond)
+	cancel()
+	require.NoError(t, waitForInflight(t.Context(), &p.centralWG))
+
+	p.centralQueue.mu.Lock()
+	items := append([]centralQueueItem(nil), p.centralQueue.items...)
+	p.centralQueue.mu.Unlock()
+	require.Len(t, items, 1)
+	remaining := items[0]
+	require.Equal(t, []byte(failedRoute), remaining.routingKey)
+	require.Equal(t, 11, remaining.attempt)
+	require.NotZero(t, remaining.nextAttemptUnixNano)
+}
+
 func TestMetricsCentralQueueDoesNotDirectReroute(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := endpoint2Config()


### PR DESCRIPTION
loadbalancingexporter: Cover central queue failed subset retries

Adds regression coverage proving mixed central queue dispatch only requeues the failed routed item while successful backend items are acknowledged.

- adds log central queue mixed success/failure retry coverage
- adds metric central queue mixed success/failure retry coverage
- keeps the retry delay far enough out to avoid a second retry during assertions

Validation:
- go test ./... (exporter/loadbalancingexporter)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that tighten coverage around central-queue retry behavior without modifying production code paths.
> 
> **Overview**
> Adds new regression coverage for `loadbalancingexporter` central-queue dispatch when multiple routed items are in-flight.
> 
> The new logs and metrics tests simulate one backend returning `Unavailable` while another succeeds, and assert that only the failed item is left in the central queue (with incremented `attempt`/scheduled retry) while the successful item is acknowledged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec13781a3b9fc0d70b462217b70d2adaaf332102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests for `loadbalancingexporter` central queue to verify mixed-route retries: when one endpoint fails and another succeeds, only the failed routed item is requeued and the successful item is acknowledged. Covers both logs and metrics exporters, with a long retry delay to avoid a second retry during assertions.

<sup>Written for commit ec13781a3b9fc0d70b462217b70d2adaaf332102. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for load balancer central queue behavior during endpoint failures. Tests validate correct retry state management, including attempt count tracking and next retry timestamp scheduling for failed items. Coverage added for both log and metrics exporters, verifying queue retention and item state updates during multi-endpoint load balancing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->