### PR TITLE
feat(loadbalancingexporter): preserve central queue byte batches

### DIFF
--- a/.chloggen/loadbalancing-central-byte-batching.yaml
+++ b/.chloggen/loadbalancing-central-byte-batching.yaml
@@ -1,0 +1,8 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Preserve central queue byte batches for random-routed logs and add backend request size telemetry.
+issues: [58]
+subtext: |-
+  Adds backend request bytes, item count, and request count metrics so operators
+  can measure outbound request amplification directly.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/backend_request_metrics.go
+++ b/exporter/loadbalancingexporter/backend_request_metrics.go
@@ -1,0 +1,60 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+)
+
+const (
+	backendRequestSignalLogs    = "logs"
+	backendRequestSignalMetrics = "metrics"
+)
+
+func backendRequestAttributeSet(signal, endpoint string) attribute.Set {
+	return attribute.NewSet(attribute.String("endpoint", endpoint), attribute.String("signal", signal))
+}
+
+func backendRequestMetricOptions(attrs attribute.Set) metric.MeasurementOption {
+	return metric.WithAttributeSet(attrs)
+}
+
+func recordLogBackendRequest(ctx context.Context, tb *metadata.TelemetryBuilder, attrs attribute.Set, ld plog.Logs) {
+	if tb == nil {
+		return
+	}
+
+	opts := backendRequestMetricOptions(attrs)
+	tb.LoadbalancerBackendRequestBytes.Record(ctx, serializedLogsSize(ld), opts)
+	tb.LoadbalancerBackendRequestItems.Record(ctx, int64(ld.LogRecordCount()), opts)
+	tb.LoadbalancerBackendRequestTotal.Add(ctx, 1, opts)
+}
+
+func recordMetricBackendRequest(ctx context.Context, tb *metadata.TelemetryBuilder, attrs attribute.Set, md pmetric.Metrics) {
+	if tb == nil {
+		return
+	}
+
+	opts := backendRequestMetricOptions(attrs)
+	tb.LoadbalancerBackendRequestBytes.Record(ctx, serializedMetricsSize(md), opts)
+	tb.LoadbalancerBackendRequestItems.Record(ctx, int64(md.DataPointCount()), opts)
+	tb.LoadbalancerBackendRequestTotal.Add(ctx, 1, opts)
+}
+
+func serializedLogsSize(ld plog.Logs) int64 {
+	marshaler := plog.ProtoMarshaler{}
+	return int64(marshaler.LogsSize(ld))
+}
+
+func serializedMetricsSize(md pmetric.Metrics) int64 {
+	marshaler := pmetric.ProtoMarshaler{}
+	return int64(marshaler.MetricsSize(md))
+}

--- a/exporter/loadbalancingexporter/backend_request_metrics.go
+++ b/exporter/loadbalancingexporter/backend_request_metrics.go
@@ -23,30 +23,34 @@ func backendRequestAttributeSet(signal, endpoint string) attribute.Set {
 	return attribute.NewSet(attribute.String("endpoint", endpoint), attribute.String("signal", signal))
 }
 
+func backendRequestSignalAttributeSet(signal string) attribute.Set {
+	return attribute.NewSet(attribute.String("signal", signal))
+}
+
 func backendRequestMetricOptions(attrs attribute.Set) metric.MeasurementOption {
 	return metric.WithAttributeSet(attrs)
 }
 
-func recordLogBackendRequest(ctx context.Context, tb *metadata.TelemetryBuilder, attrs attribute.Set, ld plog.Logs) {
+func recordLogBackendRequest(ctx context.Context, tb *metadata.TelemetryBuilder, signalAttrs, endpointAttrs attribute.Set, ld plog.Logs) {
 	if tb == nil {
 		return
 	}
 
-	opts := backendRequestMetricOptions(attrs)
-	tb.LoadbalancerBackendRequestBytes.Record(ctx, serializedLogsSize(ld), opts)
-	tb.LoadbalancerBackendRequestItems.Record(ctx, int64(ld.LogRecordCount()), opts)
-	tb.LoadbalancerBackendRequestTotal.Add(ctx, 1, opts)
+	signalOpts := backendRequestMetricOptions(signalAttrs)
+	tb.LoadbalancerBackendRequestBytes.Record(ctx, serializedLogsSize(ld), signalOpts)
+	tb.LoadbalancerBackendRequestItems.Record(ctx, int64(ld.LogRecordCount()), signalOpts)
+	tb.LoadbalancerBackendRequestTotal.Add(ctx, 1, backendRequestMetricOptions(endpointAttrs))
 }
 
-func recordMetricBackendRequest(ctx context.Context, tb *metadata.TelemetryBuilder, attrs attribute.Set, md pmetric.Metrics) {
+func recordMetricBackendRequest(ctx context.Context, tb *metadata.TelemetryBuilder, signalAttrs, endpointAttrs attribute.Set, md pmetric.Metrics) {
 	if tb == nil {
 		return
 	}
 
-	opts := backendRequestMetricOptions(attrs)
-	tb.LoadbalancerBackendRequestBytes.Record(ctx, serializedMetricsSize(md), opts)
-	tb.LoadbalancerBackendRequestItems.Record(ctx, int64(md.DataPointCount()), opts)
-	tb.LoadbalancerBackendRequestTotal.Add(ctx, 1, opts)
+	signalOpts := backendRequestMetricOptions(signalAttrs)
+	tb.LoadbalancerBackendRequestBytes.Record(ctx, serializedMetricsSize(md), signalOpts)
+	tb.LoadbalancerBackendRequestItems.Record(ctx, int64(md.DataPointCount()), signalOpts)
+	tb.LoadbalancerBackendRequestTotal.Add(ctx, 1, backendRequestMetricOptions(endpointAttrs))
 }
 
 func serializedLogsSize(ld plog.Logs) int64 {

--- a/exporter/loadbalancingexporter/backend_request_metrics_test.go
+++ b/exporter/loadbalancingexporter/backend_request_metrics_test.go
@@ -26,18 +26,19 @@ func assertBackendRequestMetrics(t *testing.T, telemetry *componenttest.Telemetr
 	require.Positive(t, bytes)
 	require.Positive(t, items)
 
-	attrs := attribute.NewSet(attribute.String("endpoint", endpoint), attribute.String("signal", signal))
+	signalAttrs := attribute.NewSet(attribute.String("signal", signal))
+	endpointAttrs := attribute.NewSet(attribute.String("endpoint", endpoint), attribute.String("signal", signal))
 	metadatatest.AssertEqualLoadbalancerBackendRequestTotal(t, telemetry, []metricdata.DataPoint[int64]{
 		{
-			Attributes: attrs,
+			Attributes: endpointAttrs,
 			Value:      1,
 		},
 	}, metricdatatest.IgnoreTimestamp())
 	metadatatest.AssertEqualLoadbalancerBackendRequestBytes(t, telemetry, []metricdata.HistogramDataPoint[int64]{
-		backendRequestHistogramPoint(attrs, bytes, backendRequestBytesBounds),
+		backendRequestHistogramPoint(signalAttrs, bytes, backendRequestBytesBounds),
 	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 	metadatatest.AssertEqualLoadbalancerBackendRequestItems(t, telemetry, []metricdata.HistogramDataPoint[int64]{
-		backendRequestHistogramPoint(attrs, items, backendRequestItemsBounds),
+		backendRequestHistogramPoint(signalAttrs, items, backendRequestItemsBounds),
 	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
 }
 

--- a/exporter/loadbalancingexporter/backend_request_metrics_test.go
+++ b/exporter/loadbalancingexporter/backend_request_metrics_test.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadatatest"
+)
+
+var (
+	backendRequestBytesBounds = []float64{1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216}
+	backendRequestItemsBounds = []float64{1, 10, 50, 100, 500, 1000, 5000, 10000, 50000}
+)
+
+func assertBackendRequestMetrics(t *testing.T, telemetry *componenttest.Telemetry, signal, endpoint string, bytes, items int64) {
+	t.Helper()
+
+	require.Positive(t, bytes)
+	require.Positive(t, items)
+
+	attrs := attribute.NewSet(attribute.String("endpoint", endpoint), attribute.String("signal", signal))
+	metadatatest.AssertEqualLoadbalancerBackendRequestTotal(t, telemetry, []metricdata.DataPoint[int64]{
+		{
+			Attributes: attrs,
+			Value:      1,
+		},
+	}, metricdatatest.IgnoreTimestamp())
+	metadatatest.AssertEqualLoadbalancerBackendRequestBytes(t, telemetry, []metricdata.HistogramDataPoint[int64]{
+		backendRequestHistogramPoint(attrs, bytes, backendRequestBytesBounds),
+	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+	metadatatest.AssertEqualLoadbalancerBackendRequestItems(t, telemetry, []metricdata.HistogramDataPoint[int64]{
+		backendRequestHistogramPoint(attrs, items, backendRequestItemsBounds),
+	}, metricdatatest.IgnoreTimestamp(), metricdatatest.IgnoreExemplars())
+}
+
+func backendRequestHistogramPoint(attrs attribute.Set, value int64, bounds []float64) metricdata.HistogramDataPoint[int64] {
+	return metricdata.HistogramDataPoint[int64]{
+		Attributes:   attrs,
+		Count:        1,
+		Bounds:       bounds,
+		BucketCounts: backendRequestBucketCounts(value, bounds),
+		Min:          metricdata.NewExtrema(value),
+		Max:          metricdata.NewExtrema(value),
+		Sum:          value,
+	}
+}
+
+func backendRequestBucketCounts(value int64, bounds []float64) []uint64 {
+	counts := make([]uint64, len(bounds)+1)
+	for i, bound := range bounds {
+		if float64(value) <= bound {
+			counts[i] = 1
+			return counts
+		}
+	}
+	counts[len(counts)-1] = 1
+	return counts
+}

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -266,6 +266,22 @@ func (q QueueSettings) Validate() error {
 	return nil
 }
 
+func (cfg *Config) centralQueueByteBatchingEnabled() bool {
+	if cfg == nil || !cfg.QueueSettings.QueueConfig.HasValue() {
+		return false
+	}
+
+	queueCfg := cfg.QueueSettings.QueueConfig.Get()
+	if queueCfg == nil || !cfg.QueueSettings.Enabled || !queueCfg.Batch.HasValue() {
+		return false
+	}
+
+	batchCfg := queueCfg.Batch.Get()
+	return batchCfg != nil &&
+		queueCfg.Sizer == exporterhelper.RequestSizerTypeBytes &&
+		batchCfg.Sizer == exporterhelper.RequestSizerTypeBytes
+}
+
 func (cfg *Config) Validate() error {
 	if err := cfg.QueueSettings.Validate(); err != nil {
 		return err

--- a/exporter/loadbalancingexporter/documentation.md
+++ b/exporter/loadbalancingexporter/documentation.md
@@ -57,6 +57,51 @@ Number of times a backend endpoint was quarantined.
 | endpoint | The endpoint of the backend | Any Str | - |
 | reason | Low-cardinality endpoint health reason | Any Str | - |
 
+### otelcol_loadbalancer_backend_request_bytes
+
+Serialized OTLP bytes per backend request before transport compression.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Histogram | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+| endpoint | The endpoint of the backend | Any Str | - |
+
+### otelcol_loadbalancer_backend_request_items
+
+Log records or metric datapoints per backend request.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {items} | Histogram | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+| endpoint | The endpoint of the backend | Any Str | - |
+
+### otelcol_loadbalancer_backend_request_total
+
+Number of backend requests by signal and endpoint.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {requests} | Sum | Int | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+| endpoint | The endpoint of the backend | Any Str | - |
+
 ### otelcol_loadbalancer_backend_reroute_total
 
 Number of endpoint-failure reroute attempts.

--- a/exporter/loadbalancingexporter/documentation.md
+++ b/exporter/loadbalancingexporter/documentation.md
@@ -70,7 +70,6 @@ Serialized OTLP bytes per backend request before transport compression.
 | Name | Description | Values | Semantic Convention |
 | ---- | ----------- | ------ | ------------------- |
 | signal | Telemetry signal for backend request metrics | Str: ``logs``, ``metrics`` | - |
-| endpoint | The endpoint of the backend | Any Str | - |
 
 ### otelcol_loadbalancer_backend_request_items
 
@@ -85,7 +84,6 @@ Log records or metric datapoints per backend request.
 | Name | Description | Values | Semantic Convention |
 | ---- | ----------- | ------ | ------------------- |
 | signal | Telemetry signal for backend request metrics | Str: ``logs``, ``metrics`` | - |
-| endpoint | The endpoint of the backend | Any Str | - |
 
 ### otelcol_loadbalancer_backend_request_total
 

--- a/exporter/loadbalancingexporter/documentation.md
+++ b/exporter/loadbalancingexporter/documentation.md
@@ -69,7 +69,7 @@ Serialized OTLP bytes per backend request before transport compression.
 
 | Name | Description | Values | Semantic Convention |
 | ---- | ----------- | ------ | ------------------- |
-| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+| signal | Telemetry signal for backend request metrics | Str: ``logs``, ``metrics`` | - |
 | endpoint | The endpoint of the backend | Any Str | - |
 
 ### otelcol_loadbalancer_backend_request_items
@@ -84,7 +84,7 @@ Log records or metric datapoints per backend request.
 
 | Name | Description | Values | Semantic Convention |
 | ---- | ----------- | ------ | ------------------- |
-| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+| signal | Telemetry signal for backend request metrics | Str: ``logs``, ``metrics`` | - |
 | endpoint | The endpoint of the backend | Any Str | - |
 
 ### otelcol_loadbalancer_backend_request_total
@@ -99,7 +99,7 @@ Number of backend requests by signal and endpoint.
 
 | Name | Description | Values | Semantic Convention |
 | ---- | ----------- | ------ | ------------------- |
-| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+| signal | Telemetry signal for backend request metrics | Str: ``logs``, ``metrics`` | - |
 | endpoint | The endpoint of the backend | Any Str | - |
 
 ### otelcol_loadbalancer_backend_reroute_total

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -264,6 +264,20 @@ func TestWrappedExporterHasEndpointAttribute(t *testing.T) {
 	successValue, found = wrappedExp.failureAttr.Value("success")
 	require.True(t, found, "failure attr should have success field")
 	assert.False(t, successValue.AsBool())
+
+	endpointValue, found = wrappedExp.logRequestAttr.Value("endpoint")
+	require.True(t, found, "log request attr should have endpoint")
+	assert.Equal(t, testEndpoint, endpointValue.AsString())
+	signalValue, found := wrappedExp.logRequestAttr.Value("signal")
+	require.True(t, found, "log request attr should have signal field")
+	assert.Equal(t, backendRequestSignalLogs, signalValue.AsString())
+
+	endpointValue, found = wrappedExp.metricRequestAttr.Value("endpoint")
+	require.True(t, found, "metric request attr should have endpoint")
+	assert.Equal(t, testEndpoint, endpointValue.AsString())
+	signalValue, found = wrappedExp.metricRequestAttr.Value("signal")
+	require.True(t, found, "metric request attr should have signal field")
+	assert.Equal(t, backendRequestSignalMetrics, signalValue.AsString())
 }
 
 func TestWrappedExporterNormalizesEndpointAttributeWithoutPort(t *testing.T) {

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -278,6 +278,18 @@ func TestWrappedExporterHasEndpointAttribute(t *testing.T) {
 	signalValue, found = wrappedExp.metricRequestAttr.Value("signal")
 	require.True(t, found, "metric request attr should have signal field")
 	assert.Equal(t, backendRequestSignalMetrics, signalValue.AsString())
+
+	signalValue, found = wrappedExp.logSignalAttr.Value("signal")
+	require.True(t, found, "log signal attr should have signal field")
+	assert.Equal(t, backendRequestSignalLogs, signalValue.AsString())
+	_, found = wrappedExp.logSignalAttr.Value("endpoint")
+	assert.False(t, found, "log signal attr should not have endpoint")
+
+	signalValue, found = wrappedExp.metricSignalAttr.Value("signal")
+	require.True(t, found, "metric signal attr should have signal field")
+	assert.Equal(t, backendRequestSignalMetrics, signalValue.AsString())
+	_, found = wrappedExp.metricSignalAttr.Value("endpoint")
+	assert.False(t, found, "metric signal attr should not have endpoint")
 }
 
 func TestWrappedExporterNormalizesEndpointAttributeWithoutPort(t *testing.T) {

--- a/exporter/loadbalancingexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/loadbalancingexporter/internal/metadata/generated_telemetry.go
@@ -29,6 +29,9 @@ type TelemetryBuilder struct {
 	LoadbalancerBackendLatency           metric.Int64Histogram
 	LoadbalancerBackendOutcome           metric.Int64Counter
 	LoadbalancerBackendQuarantineTotal   metric.Int64Counter
+	LoadbalancerBackendRequestBytes      metric.Int64Histogram
+	LoadbalancerBackendRequestItems      metric.Int64Histogram
+	LoadbalancerBackendRequestTotal      metric.Int64Counter
 	LoadbalancerBackendRerouteTotal      metric.Int64Counter
 	LoadbalancerBackendStaleTotal        metric.Int64Counter
 	LoadbalancerBackendState             metric.Int64Gauge
@@ -90,6 +93,26 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_loadbalancer_backend_quarantine_total",
 		metric.WithDescription("Number of times a backend endpoint was quarantined. [Development]"),
 		metric.WithUnit("{quarantines}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerBackendRequestBytes, err = builder.meter.Int64Histogram(
+		"otelcol_loadbalancer_backend_request_bytes",
+		metric.WithDescription("Serialized OTLP bytes per backend request before transport compression. [Development]"),
+		metric.WithUnit("By"),
+		metric.WithExplicitBucketBoundaries([]float64{1024, 4096, 16384, 65536, 262144, 1.048576e+06, 4.194304e+06, 1.6777216e+07}...),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerBackendRequestItems, err = builder.meter.Int64Histogram(
+		"otelcol_loadbalancer_backend_request_items",
+		metric.WithDescription("Log records or metric datapoints per backend request. [Development]"),
+		metric.WithUnit("{items}"),
+		metric.WithExplicitBucketBoundaries([]float64{1, 10, 50, 100, 500, 1000, 5000, 10000, 50000}...),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerBackendRequestTotal, err = builder.meter.Int64Counter(
+		"otelcol_loadbalancer_backend_request_total",
+		metric.WithDescription("Number of backend requests by signal and endpoint. [Development]"),
+		metric.WithUnit("{requests}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.LoadbalancerBackendRerouteTotal, err = builder.meter.Int64Counter(

--- a/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest.go
@@ -84,6 +84,52 @@ func AssertEqualLoadbalancerBackendQuarantineTotal(t *testing.T, tt *componentte
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualLoadbalancerBackendRequestBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_backend_request_bytes",
+		Description: "Serialized OTLP bytes per backend request before transport compression. [Development]",
+		Unit:        "By",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_backend_request_bytes")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerBackendRequestItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_backend_request_items",
+		Description: "Log records or metric datapoints per backend request. [Development]",
+		Unit:        "{items}",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_backend_request_items")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerBackendRequestTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_backend_request_total",
+		Description: "Number of backend requests by signal and endpoint. [Development]",
+		Unit:        "{requests}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_backend_request_total")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualLoadbalancerBackendRerouteTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_loadbalancer_backend_reroute_total",

--- a/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest_test.go
@@ -23,6 +23,9 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.LoadbalancerBackendLatency.Record(context.Background(), 1)
 	tb.LoadbalancerBackendOutcome.Add(context.Background(), 1)
 	tb.LoadbalancerBackendQuarantineTotal.Add(context.Background(), 1)
+	tb.LoadbalancerBackendRequestBytes.Record(context.Background(), 1)
+	tb.LoadbalancerBackendRequestItems.Record(context.Background(), 1)
+	tb.LoadbalancerBackendRequestTotal.Add(context.Background(), 1)
 	tb.LoadbalancerBackendRerouteTotal.Add(context.Background(), 1)
 	tb.LoadbalancerBackendStaleTotal.Add(context.Background(), 1)
 	tb.LoadbalancerBackendState.Record(context.Background(), 1)
@@ -40,6 +43,15 @@ func TestSetupTelemetry(t *testing.T) {
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualLoadbalancerBackendQuarantineTotal(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerBackendRequestBytes(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerBackendRequestItems(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerBackendRequestTotal(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualLoadbalancerBackendRerouteTotal(t, testTel,

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -1149,7 +1149,7 @@ func TestLogBatcherFlushesRemovedBackendToOldExporter(t *testing.T) {
 }
 
 func newTestLogsExporter(
-	t *testing.T,
+	t testing.TB,
 	ts exporter.Settings,
 	tb *metadata.TelemetryBuilder,
 	cfg *Config,
@@ -1159,7 +1159,7 @@ func newTestLogsExporter(
 
 	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
 	require.NoError(t, err)
-	lb.addMissingExporters(t.Context(), cfg.Resolver.Static.Get().Hostnames)
+	lb.addMissingExporters(context.Background(), cfg.Resolver.Static.Get().Hostnames)
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
 		onResolve: func(_ context.Context) ([]string, error) {

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -1149,17 +1149,17 @@ func TestLogBatcherFlushesRemovedBackendToOldExporter(t *testing.T) {
 }
 
 func newTestLogsExporter(
-	t testing.TB,
+	tb testing.TB,
 	ts exporter.Settings,
-	tb *metadata.TelemetryBuilder,
+	telemetryBuilder *metadata.TelemetryBuilder,
 	cfg *Config,
 	componentFactory func(context.Context, string) (component.Component, error),
 ) (*logExporterImp, *loadBalancer) {
-	t.Helper()
+	tb.Helper()
 
-	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
-	require.NoError(t, err)
-	lb.addMissingExporters(context.Background(), cfg.Resolver.Static.Get().Hostnames)
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, telemetryBuilder)
+	require.NoError(tb, err)
+	lb.addMissingExporters(tb.Context(), cfg.Resolver.Static.Get().Hostnames)
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
 		onResolve: func(_ context.Context) ([]string, error) {
@@ -1168,7 +1168,7 @@ func newTestLogsExporter(
 	}
 
 	p, err := newLogsExporter(ts, cfg)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	p.loadBalancer = lb
 	return p, lb
 }

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -438,7 +438,7 @@ func (e *logExporterImp) consumeBatchWithDecision(ctx context.Context, le *wrapp
 	}
 	defer le.doneConsume()
 
-	recordLogBackendRequest(ctx, e.telemetry, le.logRequestAttr, ld)
+	recordLogBackendRequest(ctx, e.telemetry, le.logSignalAttr, le.logRequestAttr, ld)
 	start := time.Now()
 	err := le.ConsumeLogs(ctx, ld)
 	duration := time.Since(start)

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -34,13 +34,14 @@ type logExporterImp struct {
 	centralQueue *centralQueue
 	centralCodec *queuePayloadCodec
 
-	logger        *zap.Logger
-	started       atomic.Bool
-	telemetry     *metadata.TelemetryBuilder
-	ignoreTraceID bool
-	randomTraceID func() pcommon.TraceID
-	centralCancel context.CancelFunc
-	centralWG     sync.WaitGroup
+	logger                   *zap.Logger
+	started                  atomic.Bool
+	telemetry                *metadata.TelemetryBuilder
+	ignoreTraceID            bool
+	randomTraceID            func() pcommon.TraceID
+	centralQueueByteBatching bool
+	centralCancel            context.CancelFunc
+	centralWG                sync.WaitGroup
 }
 
 // Create new logs exporter
@@ -63,11 +64,12 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 	}
 
 	logExporter := &logExporterImp{
-		loadBalancer:  lb,
-		telemetry:     telemetry,
-		logger:        params.Logger,
-		ignoreTraceID: cfg.(*Config).LogRouting.IgnoreTraceID,
-		randomTraceID: random,
+		loadBalancer:             lb,
+		telemetry:                telemetry,
+		logger:                   params.Logger,
+		ignoreTraceID:            cfg.(*Config).LogRouting.IgnoreTraceID,
+		randomTraceID:            random,
+		centralQueueByteBatching: cfg.(*Config).centralQueueByteBatchingEnabled(),
 	}
 	if cfg.(*Config).CentralQueue.Enabled {
 		centralCfg := cfg.(*Config).CentralQueue
@@ -160,6 +162,10 @@ func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 		return e.consumeLogsCentralQueue(ctx, ld)
 	}
 	if e.batcher == nil {
+		if e.ignoreTraceID && e.centralQueueByteBatching {
+			return e.consumeLog(ctx, ld)
+		}
+
 		var errs error
 		batches := batchpersignal.SplitLogs(ld)
 		for _, batch := range batches {

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -145,9 +145,6 @@ func (e *logExporterImp) Shutdown(ctx context.Context) error {
 		waitErr := waitForInflight(waitCtx, &e.centralWG)
 		cancel()
 		err = errors.Join(err, waitErr)
-		if waitErr != nil {
-			return err
-		}
 		err = errors.Join(err, e.centralCodec.Close())
 	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -438,6 +438,7 @@ func (e *logExporterImp) consumeBatchWithDecision(ctx context.Context, le *wrapp
 	}
 	defer le.doneConsume()
 
+	recordLogBackendRequest(ctx, e.telemetry, le.logRequestAttr, ld)
 	start := time.Now()
 	err := le.ConsumeLogs(ctx, ld)
 	duration := time.Since(start)

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -917,6 +917,73 @@ func TestConsumeLogsIgnoreTraceIDUsesRandomRoutingKey(t *testing.T) {
 	assert.Equal(t, 1, calls["endpoint-2:4317"])
 }
 
+func TestConsumeLogsIgnoreTraceIDCentralByteBatchDoesNotSplitByTraceID(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := twoEndpointLogConfig()
+	cfg.LogRouting.IgnoreTraceID = true
+	enableCentralQueueByteBatchingForTest(cfg)
+
+	var calls atomic.Int64
+	var records atomic.Int64
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+			assert.Equal(t, "endpoint-2:4317", endpoint)
+			calls.Add(1)
+			records.Add(int64(ld.LogRecordCount()))
+			return nil
+		}), nil
+	}
+
+	p, lb := newTestLogsExporter(t, ts, tb, cfg, componentFactory)
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+	traceIDForEndpoint2 := findTraceIDForEndpoint(t, lb.ring, "endpoint-2:4317")
+	p.randomTraceID = func() pcommon.TraceID {
+		return traceIDForEndpoint2
+	}
+
+	input := logsWithTraceIDs([16]byte{1}, [16]byte{2}, [16]byte{3})
+	require.NoError(t, p.ConsumeLogs(t.Context(), input))
+
+	assert.Equal(t, int64(1), calls.Load())
+	assert.Equal(t, int64(3), records.Load())
+}
+
+func TestConsumeLogsIgnoreTraceIDWithoutCentralByteBatchingKeepsTraceSplit(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := twoEndpointLogConfig()
+	cfg.LogRouting.IgnoreTraceID = true
+
+	var calls atomic.Int64
+	var records atomic.Int64
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+			assert.Equal(t, "endpoint-2:4317", endpoint)
+			calls.Add(1)
+			records.Add(int64(ld.LogRecordCount()))
+			return nil
+		}), nil
+	}
+
+	p, lb := newTestLogsExporter(t, ts, tb, cfg, componentFactory)
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+	traceIDForEndpoint2 := findTraceIDForEndpoint(t, lb.ring, "endpoint-2:4317")
+	p.randomTraceID = func() pcommon.TraceID {
+		return traceIDForEndpoint2
+	}
+
+	input := logsWithTraceIDs([16]byte{1}, [16]byte{2}, [16]byte{3})
+	require.NoError(t, p.ConsumeLogs(t.Context(), input))
+
+	assert.Equal(t, int64(3), calls.Load())
+	assert.Equal(t, int64(3), records.Load())
+}
+
 func TestGroupLogsByEndpointKeepsEmptyTraceLogsTogetherPerScope(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), nil, tb)
@@ -1325,6 +1392,21 @@ func twoEndpointLogConfig() *Config {
 			Static: configoptional.Some(StaticResolver{Hostnames: []string{"endpoint-1:4317", "endpoint-2:4317"}}),
 		},
 	}
+}
+
+func enableCentralQueueByteBatchingForTest(cfg *Config) {
+	queueCfg := exporterhelper.NewDefaultQueueConfig()
+	queueCfg.Sizer = exporterhelper.RequestSizerTypeBytes
+	queueCfg.QueueSize = 1 << 20
+	queueCfg.NumConsumers = 4
+	queueCfg.Batch = configoptional.Some(exporterhelper.BatchConfig{
+		Sizer:        exporterhelper.RequestSizerTypeBytes,
+		MinSize:      256,
+		MaxSize:      1 << 20,
+		FlushTimeout: time.Second,
+	})
+	cfg.QueueSettings.Enabled = true
+	cfg.QueueSettings.QueueConfig = configoptional.Some(queueCfg)
 }
 
 func simpleLogWithID(id pcommon.TraceID) plog.Logs {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -1019,6 +1019,136 @@ func TestConsumeLogsRecordsBackendRequestMetrics(t *testing.T) {
 	)
 }
 
+func TestConsumeLogsCentralByteBatchReroutesWholeMergedBatch(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := twoEndpointLogConfig()
+	cfg.LogRouting.IgnoreTraceID = true
+	enableCentralQueueByteBatchingForTest(cfg)
+	enableEndpointHealth(cfg)
+
+	calls := map[string]int{}
+	records := map[string]int{}
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+			calls[endpoint]++
+			records[endpoint] += ld.LogRecordCount()
+			if endpoint == "endpoint-1:4317" {
+				return status.Error(codes.Unavailable, "backend unavailable")
+			}
+			return nil
+		}), nil
+	}
+
+	p, lb := newTestLogsExporter(t, ts, tb, cfg, componentFactory)
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+	traceIDForEndpoint1 := findTraceIDForEndpoint(t, lb.ring, "endpoint-1:4317")
+	p.randomTraceID = func() pcommon.TraceID {
+		return traceIDForEndpoint1
+	}
+
+	input := logsWithTraceIDs([16]byte{1}, [16]byte{2}, [16]byte{3}, [16]byte{4})
+	require.NoError(t, p.ConsumeLogs(t.Context(), input))
+
+	assert.Equal(t, 1, calls["endpoint-1:4317"])
+	assert.Equal(t, 1, calls["endpoint-2:4317"])
+	assert.Equal(t, 4, records["endpoint-1:4317"])
+	assert.Equal(t, 4, records["endpoint-2:4317"])
+}
+
+func TestConsumeLogsCentralByteBatchHighCardinalityTraceIDsUseOneBackendRequest(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := twoEndpointLogConfig()
+	cfg.LogRouting.IgnoreTraceID = true
+	enableCentralQueueByteBatchingForTest(cfg)
+
+	var calls atomic.Int64
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+			assert.Equal(t, "endpoint-2:4317", endpoint)
+			assert.Equal(t, 64, ld.LogRecordCount())
+			calls.Add(1)
+			return nil
+		}), nil
+	}
+
+	p, lb := newTestLogsExporter(t, ts, tb, cfg, componentFactory)
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+	traceIDForEndpoint2 := findTraceIDForEndpoint(t, lb.ring, "endpoint-2:4317")
+	p.randomTraceID = func() pcommon.TraceID {
+		return traceIDForEndpoint2
+	}
+
+	ids := make([]pcommon.TraceID, 64)
+	for i := range ids {
+		ids[i][15] = byte(i + 1)
+	}
+	require.NoError(t, p.ConsumeLogs(t.Context(), logsWithTraceIDs(ids...)))
+
+	assert.Equal(t, int64(1), calls.Load())
+}
+
+func BenchmarkConsumeLogsRandomRoutingRequestAmplification(b *testing.B) {
+	ids := make([]pcommon.TraceID, 256)
+	for i := range ids {
+		ids[i][15] = byte(i + 1)
+	}
+	input := logsWithTraceIDs(ids...)
+	serializedBytes := serializedLogsSize(input)
+
+	for _, tc := range []struct {
+		name              string
+		centralByteBatch  bool
+		expectedSendCount int64
+	}{
+		{name: "legacy_split", centralByteBatch: false, expectedSendCount: 256},
+		{name: "central_byte_batch", centralByteBatch: true, expectedSendCount: 1},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			ts, tb := getTelemetryAssets(b)
+			cfg := twoEndpointLogConfig()
+			cfg.LogRouting.IgnoreTraceID = true
+			if tc.centralByteBatch {
+				enableCentralQueueByteBatchingForTest(cfg)
+			}
+
+			var sendCount atomic.Int64
+			componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+				return newMockLogsExporter(func(_ context.Context, _ plog.Logs) error {
+					sendCount.Add(1)
+					return nil
+				}), nil
+			}
+
+			p, lb := newTestLogsExporter(b, ts, tb, cfg, componentFactory)
+			require.NoError(b, p.Start(b.Context(), componenttest.NewNopHost()))
+			b.Cleanup(func() {
+				require.NoError(b, p.Shutdown(context.WithoutCancel(b.Context())))
+			})
+			traceIDForEndpoint1 := findTraceIDForEndpoint(b, lb.ring, "endpoint-1:4317")
+			p.randomTraceID = func() pcommon.TraceID {
+				return traceIDForEndpoint1
+			}
+
+			b.SetBytes(serializedBytes)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				require.NoError(b, p.ConsumeLogs(b.Context(), input))
+			}
+			b.StopTimer()
+
+			requestsPerInput := float64(sendCount.Load()) / float64(b.N)
+			b.ReportMetric(requestsPerInput, "backend_requests/input")
+			require.Equal(b, float64(tc.expectedSendCount), requestsPerInput)
+		})
+	}
+}
+
 func TestGroupLogsByEndpointKeepsEmptyTraceLogsTogetherPerScope(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), nil, tb)
@@ -1453,7 +1583,7 @@ func simpleLogWithID(id pcommon.TraceID) plog.Logs {
 	return logs
 }
 
-func findTraceIDForEndpoint(t *testing.T, ring *hashRing, endpoint string) pcommon.TraceID {
+func findTraceIDForEndpoint(t testing.TB, ring *hashRing, endpoint string) pcommon.TraceID {
 	t.Helper()
 
 	for i := range 4096 {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -984,6 +984,41 @@ func TestConsumeLogsIgnoreTraceIDWithoutCentralByteBatchingKeepsTraceSplit(t *te
 	assert.Equal(t, int64(3), records.Load())
 }
 
+func TestConsumeLogsRecordsBackendRequestMetrics(t *testing.T) {
+	ts, tb, telemetry := getTelemetryAssetsWithReader(t)
+	cfg := twoEndpointLogConfig()
+	endpoint := "endpoint-1:4317"
+
+	sent := plog.NewLogs()
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+			if endpoint == "endpoint-1:4317" {
+				ld.CopyTo(sent)
+			}
+			return nil
+		}), nil
+	}
+
+	p, lb := newTestLogsExporter(t, ts, tb, cfg, componentFactory)
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	traceIDForEndpoint1 := findTraceIDForEndpoint(t, lb.ring, endpoint)
+	require.NoError(t, p.ConsumeLogs(t.Context(), simpleLogWithID(traceIDForEndpoint1)))
+
+	assert.Equal(t, 1, sent.LogRecordCount())
+	assertBackendRequestMetrics(
+		t,
+		telemetry,
+		backendRequestSignalLogs,
+		endpoint,
+		serializedLogsSize(sent),
+		int64(sent.LogRecordCount()),
+	)
+}
+
 func TestGroupLogsByEndpointKeepsEmptyTraceLogsTogetherPerScope(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	lb, err := newLoadBalancer(ts.Logger, simpleConfig(), nil, tb)

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -1583,8 +1583,8 @@ func simpleLogWithID(id pcommon.TraceID) plog.Logs {
 	return logs
 }
 
-func findTraceIDForEndpoint(t testing.TB, ring *hashRing, endpoint string) pcommon.TraceID {
-	t.Helper()
+func findTraceIDForEndpoint(tb testing.TB, ring *hashRing, endpoint string) pcommon.TraceID {
+	tb.Helper()
 
 	for i := range 4096 {
 		var traceID pcommon.TraceID
@@ -1594,7 +1594,7 @@ func findTraceIDForEndpoint(t testing.TB, ring *hashRing, endpoint string) pcomm
 		}
 	}
 
-	require.FailNow(t, "failed to find trace id for endpoint", "endpoint=%s", endpoint)
+	require.FailNow(tb, "failed to find trace id for endpoint", "endpoint=%s", endpoint)
 	return pcommon.TraceID{}
 }
 

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -257,7 +257,7 @@ func TestLogsCentralQueueShutdownCancelsBeforeWaiting(t *testing.T) {
 	require.NoError(t, p.Shutdown(shutdownCtx))
 }
 
-func TestLogsCentralQueueShutdownTimeoutSkipsLoadBalancerShutdown(t *testing.T) {
+func TestLogsCentralQueueShutdownTimeoutStillRunsTeardown(t *testing.T) {
 	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
 	t.Cleanup(func() { require.NoError(t, codec.Close()) })
 	var resolverShutdown atomic.Bool
@@ -282,7 +282,7 @@ func TestLogsCentralQueueShutdownTimeoutSkipsLoadBalancerShutdown(t *testing.T) 
 	shutdownCtx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
 	defer cancel()
 	require.Error(t, p.Shutdown(shutdownCtx))
-	require.False(t, resolverShutdown.Load())
+	require.True(t, resolverShutdown.Load())
 }
 
 func TestLogsCentralQueueDropsPermanentExportError(t *testing.T) {

--- a/exporter/loadbalancingexporter/metadata.yaml
+++ b/exporter/loadbalancingexporter/metadata.yaml
@@ -97,7 +97,7 @@ telemetry:
         value_type: int
         monotonic: true
     loadbalancer_backend_request_bytes:
-      attributes: [backend_request_signal, endpoint]
+      attributes: [backend_request_signal]
       enabled: true
       stability: development
       description: Serialized OTLP bytes per backend request before transport compression.
@@ -106,7 +106,7 @@ telemetry:
         value_type: int
         bucket_boundaries: [1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216]
     loadbalancer_backend_request_items:
-      attributes: [backend_request_signal, endpoint]
+      attributes: [backend_request_signal]
       enabled: true
       stability: development
       description: Log records or metric datapoints per backend request.

--- a/exporter/loadbalancingexporter/metadata.yaml
+++ b/exporter/loadbalancingexporter/metadata.yaml
@@ -13,6 +13,13 @@ status:
     seeking_new: true
 
 attributes:
+  backend_request_signal:
+    name_override: signal
+    description: Telemetry signal for backend request metrics
+    type: string
+    enum:
+      - logs
+      - metrics
   endpoint:
     description: The endpoint of the backend
     type: string
@@ -90,7 +97,7 @@ telemetry:
         value_type: int
         monotonic: true
     loadbalancer_backend_request_bytes:
-      attributes: [signal, endpoint]
+      attributes: [backend_request_signal, endpoint]
       enabled: true
       stability: development
       description: Serialized OTLP bytes per backend request before transport compression.
@@ -99,7 +106,7 @@ telemetry:
         value_type: int
         bucket_boundaries: [1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216]
     loadbalancer_backend_request_items:
-      attributes: [signal, endpoint]
+      attributes: [backend_request_signal, endpoint]
       enabled: true
       stability: development
       description: Log records or metric datapoints per backend request.
@@ -108,7 +115,7 @@ telemetry:
         value_type: int
         bucket_boundaries: [1, 10, 50, 100, 500, 1000, 5000, 10000, 50000]
     loadbalancer_backend_request_total:
-      attributes: [signal, endpoint]
+      attributes: [backend_request_signal, endpoint]
       enabled: true
       stability: development
       description: Number of backend requests by signal and endpoint.

--- a/exporter/loadbalancingexporter/metadata.yaml
+++ b/exporter/loadbalancingexporter/metadata.yaml
@@ -89,6 +89,33 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+    loadbalancer_backend_request_bytes:
+      attributes: [signal, endpoint]
+      enabled: true
+      stability: development
+      description: Serialized OTLP bytes per backend request before transport compression.
+      unit: By
+      histogram:
+        value_type: int
+        bucket_boundaries: [1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216]
+    loadbalancer_backend_request_items:
+      attributes: [signal, endpoint]
+      enabled: true
+      stability: development
+      description: Log records or metric datapoints per backend request.
+      unit: "{items}"
+      histogram:
+        value_type: int
+        bucket_boundaries: [1, 10, 50, 100, 500, 1000, 5000, 10000, 50000]
+    loadbalancer_backend_request_total:
+      attributes: [signal, endpoint]
+      enabled: true
+      stability: development
+      description: Number of backend requests by signal and endpoint.
+      unit: "{requests}"
+      sum:
+        value_type: int
+        monotonic: true
     loadbalancer_backend_reroute_total:
       attributes: [signal, result, reason]
       enabled: true

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -478,14 +478,14 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 	needsCleanup = false
 	var errs error
 	for exp, mds := range metricsByExporter {
-		failedMetrics := pmetric.NewMetrics()
-		mds.CopyTo(failedMetrics)
-
-		var retryMetrics pmetric.Metrics
-		if directRerouteAttemptAllowed(e.loadBalancer, rerouteAttempt) {
-			retryMetrics = pmetric.NewMetrics()
-			mds.CopyTo(retryMetrics)
+		var preservedMetrics pmetric.Metrics
+		preservedMetricsValid := false
+		if exp.metricsMutatesData() {
+			preservedMetrics = pmetric.NewMetrics()
+			mds.CopyTo(preservedMetrics)
+			preservedMetricsValid = true
 		}
+
 		recordMetricBackendRequest(ctx, e.telemetry, exp.metricRequestAttr, mds)
 		start := time.Now()
 		err := exp.ConsumeMetrics(ctx, mds)
@@ -494,6 +494,8 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 		exp.doneConsume()
 		decision := e.recordBackendResult(ctx, exp, duration, err, true)
 		if err != nil && shouldRerouteDirectFailure(e.loadBalancer, exp.endpoint, decision, rerouteAttempt) {
+			retryMetrics := metricFailureSubset(mds, preservedMetrics, preservedMetricsValid)
+			failedMetrics := metricFailureSubset(mds, preservedMetrics, preservedMetricsValid)
 			rerouted, splitErr := e.splitMetricsByRouting(retryMetrics)
 			if splitErr != nil {
 				e.loadBalancer.recordBackendReroute(ctx, "metrics", decision.reason, splitErr)
@@ -504,12 +506,23 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 				err = wrapDirectMetricsRerouteError(rerouteErr, failedMetrics)
 			}
 		} else if err != nil {
+			failedMetrics := metricFailureSubset(mds, preservedMetrics, preservedMetricsValid)
 			err = wrapDirectMetricsRerouteError(err, failedMetrics)
 		}
 		errs = multierr.Append(errs, err)
 	}
 
 	return errs
+}
+
+func metricFailureSubset(md, preserved pmetric.Metrics, preservedValid bool) pmetric.Metrics {
+	failedMetrics := pmetric.NewMetrics()
+	if preservedValid {
+		preserved.CopyTo(failedMetrics)
+	} else {
+		md.CopyTo(failedMetrics)
+	}
+	return failedMetrics
 }
 
 func (e *metricExporterImp) consumeBatch(ctx context.Context, we *wrappedExporter, md pmetric.Metrics, reason string) error {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -737,7 +737,10 @@ func wrapDirectMetricsRerouteError(err error, md pmetric.Metrics) error {
 	}
 	var metricsErr consumererror.Metrics
 	if errors.As(err, &metricsErr) {
-		return err
+		failed := pmetric.NewMetrics()
+		appendMetricErrorData(failed, err)
+		metrics.Merge(failed, md)
+		return consumererror.NewMetrics(err, failed)
 	}
 	return consumererror.NewMetrics(err, md)
 }

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -474,6 +474,7 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 
 	needsCleanup = false
 	var errs error
+	failed := pmetric.NewMetrics()
 	for exp, mds := range metricsByExporter {
 		var preservedMetrics pmetric.Metrics
 		preservedMetricsValid := false
@@ -506,10 +507,34 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 			failedMetrics := metricFailureSubset(mds, preservedMetrics, preservedMetricsValid)
 			err = wrapDirectMetricsRerouteError(err, failedMetrics)
 		}
+		appendMetricErrorData(failed, err)
 		errs = multierr.Append(errs, err)
 	}
 
+	if failed.ResourceMetrics().Len() > 0 {
+		return consumererror.NewMetrics(errs, failed)
+	}
 	return errs
+}
+
+func appendMetricErrorData(dest pmetric.Metrics, err error) {
+	if err == nil {
+		return
+	}
+	if unwrapper, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, wrappedErr := range unwrapper.Unwrap() {
+			appendMetricErrorData(dest, wrappedErr)
+		}
+		return
+	}
+	var metricsErr consumererror.Metrics
+	if errors.As(err, &metricsErr) {
+		metrics.Merge(dest, metricsErr.Data())
+		return
+	}
+	if unwrapper, ok := err.(interface{ Unwrap() error }); ok {
+		appendMetricErrorData(dest, unwrapper.Unwrap())
+	}
 }
 
 func metricFailureSubset(md, preserved pmetric.Metrics, preservedValid bool) pmetric.Metrics {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -266,7 +266,7 @@ func (e *metricExporterImp) consumeCentralQueueMetricItem(ctx context.Context, i
 	exp.forceStartConsume()
 	defer exp.doneConsume()
 
-	recordMetricBackendRequest(ctx, e.telemetry, exp.metricRequestAttr, md)
+	recordMetricBackendRequest(ctx, e.telemetry, exp.metricSignalAttr, exp.metricRequestAttr, md)
 	start := time.Now()
 	err = exp.ConsumeMetrics(ctx, md)
 	duration := time.Since(start)
@@ -486,7 +486,7 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 			preservedMetricsValid = true
 		}
 
-		recordMetricBackendRequest(ctx, e.telemetry, exp.metricRequestAttr, mds)
+		recordMetricBackendRequest(ctx, e.telemetry, exp.metricSignalAttr, exp.metricRequestAttr, mds)
 		start := time.Now()
 		err := exp.ConsumeMetrics(ctx, mds)
 		duration := time.Since(start)
@@ -548,7 +548,7 @@ func (e *metricExporterImp) consumeBatch(ctx context.Context, we *wrappedExporte
 	}
 	defer we.doneConsume()
 
-	recordMetricBackendRequest(ctx, e.telemetry, we.metricRequestAttr, md)
+	recordMetricBackendRequest(ctx, e.telemetry, we.metricSignalAttr, we.metricRequestAttr, md)
 	start := time.Now()
 	err := we.ConsumeMetrics(ctx, md)
 	duration := time.Since(start)
@@ -637,7 +637,7 @@ func (e *metricExporterImp) rerouteDrainBatch(ctx context.Context, md pmetric.Me
 	var errs error
 	needsCleanup = false
 	for exp, mds := range metricsByExporter {
-		recordMetricBackendRequest(ctx, e.telemetry, exp.metricRequestAttr, mds)
+		recordMetricBackendRequest(ctx, e.telemetry, exp.metricSignalAttr, exp.metricRequestAttr, mds)
 		start := time.Now()
 		err = exp.ConsumeMetrics(ctx, mds)
 		duration := time.Since(start)

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -478,13 +478,13 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 	needsCleanup = false
 	var errs error
 	for exp, mds := range metricsByExporter {
+		failedMetrics := pmetric.NewMetrics()
+		mds.CopyTo(failedMetrics)
+
 		var retryMetrics pmetric.Metrics
-		var failedMetrics pmetric.Metrics
 		if directRerouteAttemptAllowed(e.loadBalancer, rerouteAttempt) {
 			retryMetrics = pmetric.NewMetrics()
 			mds.CopyTo(retryMetrics)
-			failedMetrics = pmetric.NewMetrics()
-			mds.CopyTo(failedMetrics)
 		}
 		recordMetricBackendRequest(ctx, e.telemetry, exp.metricRequestAttr, mds)
 		start := time.Now()
@@ -503,6 +503,8 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 				e.loadBalancer.recordBackendReroute(ctx, "metrics", decision.reason, rerouteErr)
 				err = wrapDirectMetricsRerouteError(rerouteErr, failedMetrics)
 			}
+		} else if err != nil {
+			err = wrapDirectMetricsRerouteError(err, failedMetrics)
 		}
 		errs = multierr.Append(errs, err)
 	}

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -266,6 +266,7 @@ func (e *metricExporterImp) consumeCentralQueueMetricItem(ctx context.Context, i
 	exp.forceStartConsume()
 	defer exp.doneConsume()
 
+	recordMetricBackendRequest(ctx, e.telemetry, exp.metricRequestAttr, md)
 	start := time.Now()
 	err = exp.ConsumeMetrics(ctx, md)
 	duration := time.Since(start)
@@ -485,6 +486,7 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 			failedMetrics = pmetric.NewMetrics()
 			mds.CopyTo(failedMetrics)
 		}
+		recordMetricBackendRequest(ctx, e.telemetry, exp.metricRequestAttr, mds)
 		start := time.Now()
 		err := exp.ConsumeMetrics(ctx, mds)
 		duration := time.Since(start)
@@ -531,6 +533,7 @@ func (e *metricExporterImp) consumeBatch(ctx context.Context, we *wrappedExporte
 	}
 	defer we.doneConsume()
 
+	recordMetricBackendRequest(ctx, e.telemetry, we.metricRequestAttr, md)
 	start := time.Now()
 	err := we.ConsumeMetrics(ctx, md)
 	duration := time.Since(start)
@@ -619,6 +622,7 @@ func (e *metricExporterImp) rerouteDrainBatch(ctx context.Context, md pmetric.Me
 	var errs error
 	needsCleanup = false
 	for exp, mds := range metricsByExporter {
+		recordMetricBackendRequest(ctx, e.telemetry, exp.metricRequestAttr, mds)
 		start := time.Now()
 		err = exp.ConsumeMetrics(ctx, mds)
 		duration := time.Since(start)

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -511,7 +511,7 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 		errs = multierr.Append(errs, err)
 	}
 
-	if failed.ResourceMetrics().Len() > 0 {
+	if failed.DataPointCount() > 0 {
 		return consumererror.NewMetrics(errs, failed)
 	}
 	return errs
@@ -739,8 +739,13 @@ func wrapDirectMetricsRerouteError(err error, md pmetric.Metrics) error {
 	if errors.As(err, &metricsErr) {
 		failed := pmetric.NewMetrics()
 		appendMetricErrorData(failed, err)
-		metrics.Merge(failed, md)
-		return consumererror.NewMetrics(err, failed)
+		// A non-empty consumererror.Metrics payload is the authoritative failed subset.
+		// Fall back to this batch only when the nested retryable error has no payload.
+		if failed.DataPointCount() == 0 {
+			metrics.Merge(failed, md)
+			return consumererror.NewMetrics(err, failed)
+		}
+		return err
 	}
 	return consumererror.NewMetrics(err, md)
 }

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -160,9 +160,6 @@ func (e *metricExporterImp) Shutdown(ctx context.Context) error {
 		waitErr := waitForInflight(waitCtx, &e.centralWG)
 		cancel()
 		err = errors.Join(err, waitErr)
-		if waitErr != nil {
-			return err
-		}
 		err = errors.Join(err, e.centralCodec.Close())
 	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -1275,6 +1275,30 @@ func TestConsumeMetricsRerouteFailureReturnsConsumerErrorMetrics(t *testing.T) {
 	))
 }
 
+func TestWrapDirectMetricsRerouteErrorMergesExistingConsumerErrorMetrics(t *testing.T) {
+	rerouteFailed := singleDataPointMetric("reroute-failed")
+	outerFailed := singleDataPointMetric("outer-failed")
+	err := wrapDirectMetricsRerouteError(
+		consumererror.NewMetrics(errors.New("reroute failed"), rerouteFailed),
+		outerFailed,
+	)
+
+	var metricsErr consumererror.Metrics
+	require.ErrorAs(t, err, &metricsErr)
+
+	expected := pmetric.NewMetrics()
+	metrics.Merge(expected, rerouteFailed)
+	metrics.Merge(expected, outerFailed)
+	require.NoError(t, pmetrictest.CompareMetrics(
+		expected,
+		metricsErr.Data(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+	))
+}
+
 func TestConsumeMetricsRerouteFailurePreservesConsumerErrorMetricsAfterExporterMutation(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := endpoint2Config()

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -245,7 +245,7 @@ func TestMetricsCentralQueueDropsPermanentExportError(t *testing.T) {
 	require.NoError(t, waitErr)
 }
 
-func TestMetricsCentralQueueShutdownTimeoutSkipsLoadBalancerShutdown(t *testing.T) {
+func TestMetricsCentralQueueShutdownTimeoutStillRunsTeardown(t *testing.T) {
 	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
 	t.Cleanup(func() { require.NoError(t, codec.Close()) })
 	var resolverShutdown atomic.Bool
@@ -270,7 +270,7 @@ func TestMetricsCentralQueueShutdownTimeoutSkipsLoadBalancerShutdown(t *testing.
 	shutdownCtx, cancel := context.WithTimeout(t.Context(), 20*time.Millisecond)
 	defer cancel()
 	require.Error(t, p.Shutdown(shutdownCtx))
-	require.False(t, resolverShutdown.Load())
+	require.True(t, resolverShutdown.Load())
 }
 
 func TestMetricsCentralQueueFirstRetryUsesInitialDelay(t *testing.T) {

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -2514,17 +2514,17 @@ func appendSimpleMetricWithID(dest pmetric.ResourceMetrics, id string) {
 }
 
 func newTestMetricsExporter(
-	t testing.TB,
+	tb testing.TB,
 	ts exporter.Settings,
-	tb *metadata.TelemetryBuilder,
+	telemetryBuilder *metadata.TelemetryBuilder,
 	cfg *Config,
 	componentFactory func(context.Context, string) (component.Component, error),
 ) (*metricExporterImp, *loadBalancer) {
-	t.Helper()
+	tb.Helper()
 
-	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
-	require.NoError(t, err)
-	lb.addMissingExporters(context.Background(), cfg.Resolver.Static.Get().Hostnames)
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, telemetryBuilder)
+	require.NoError(tb, err)
+	lb.addMissingExporters(tb.Context(), cfg.Resolver.Static.Get().Hostnames)
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
 		onResolve: func(_ context.Context) ([]string, error) {
@@ -2533,7 +2533,7 @@ func newTestMetricsExporter(
 	}
 
 	p, err := newMetricsExporter(ts, cfg)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 	p.loadBalancer = lb
 	return p, lb
 }

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -1157,7 +1157,7 @@ func TestConsumeMetricsReroutePreservesPayloadAfterExporterMutation(t *testing.T
 
 	var rerouted pmetric.Metrics
 	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
-		return newMockMetricsExporter(func(_ context.Context, md pmetric.Metrics) error {
+		return newMutatingMockMetricsExporter(func(_ context.Context, md pmetric.Metrics) error {
 			if endpoint == "endpoint-1:4317" {
 				md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).SetName("mutated")
 				return status.Error(codes.Unavailable, "backend unavailable")
@@ -1240,7 +1240,7 @@ func TestConsumeMetricsRerouteFailurePreservesConsumerErrorMetricsAfterExporterM
 	enableEndpointHealth(cfg)
 
 	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
-		return newMockMetricsExporter(func(_ context.Context, md pmetric.Metrics) error {
+		return newMutatingMockMetricsExporter(func(_ context.Context, md pmetric.Metrics) error {
 			md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).SetName("mutated")
 			if endpoint == "endpoint-1:4317" {
 				return status.Error(codes.Unavailable, "backend unavailable")
@@ -2580,6 +2580,7 @@ type mockMetricsExporter struct {
 	component.Component
 	ConsumeMetricsFn func(ctx context.Context, td pmetric.Metrics) error
 	consumeErr       error
+	capabilities     consumer.Capabilities
 }
 
 func newMockMetricsExporter(consumeMetricsFn func(ctx context.Context, td pmetric.Metrics) error) exporter.Metrics {
@@ -2593,8 +2594,16 @@ func newNopMockMetricsExporter() exporter.Metrics {
 	return &mockMetricsExporter{Component: mockComponent{}}
 }
 
-func (*mockMetricsExporter) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
+func newMutatingMockMetricsExporter(consumeMetricsFn func(ctx context.Context, td pmetric.Metrics) error) exporter.Metrics {
+	return &mockMetricsExporter{
+		Component:        mockComponent{},
+		ConsumeMetricsFn: consumeMetricsFn,
+		capabilities:     consumer.Capabilities{MutatesData: true},
+	}
+}
+
+func (e *mockMetricsExporter) Capabilities() consumer.Capabilities {
+	return e.capabilities
 }
 
 func (e *mockMetricsExporter) Shutdown(context.Context) error {

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -1275,7 +1275,7 @@ func TestConsumeMetricsRerouteFailureReturnsConsumerErrorMetrics(t *testing.T) {
 	))
 }
 
-func TestWrapDirectMetricsRerouteErrorMergesExistingConsumerErrorMetrics(t *testing.T) {
+func TestWrapDirectMetricsRerouteErrorPreservesExistingConsumerErrorMetrics(t *testing.T) {
 	rerouteFailed := singleDataPointMetric("reroute-failed")
 	outerFailed := singleDataPointMetric("outer-failed")
 	err := wrapDirectMetricsRerouteError(
@@ -1286,11 +1286,28 @@ func TestWrapDirectMetricsRerouteErrorMergesExistingConsumerErrorMetrics(t *test
 	var metricsErr consumererror.Metrics
 	require.ErrorAs(t, err, &metricsErr)
 
-	expected := pmetric.NewMetrics()
-	metrics.Merge(expected, rerouteFailed)
-	metrics.Merge(expected, outerFailed)
 	require.NoError(t, pmetrictest.CompareMetrics(
-		expected,
+		rerouteFailed,
+		metricsErr.Data(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+	))
+}
+
+func TestWrapDirectMetricsRerouteErrorFallsBackWhenConsumerErrorMetricsEmpty(t *testing.T) {
+	outerFailed := singleDataPointMetric("outer-failed")
+	err := wrapDirectMetricsRerouteError(
+		consumererror.NewMetrics(errors.New("reroute failed"), pmetric.NewMetrics()),
+		outerFailed,
+	)
+
+	var metricsErr consumererror.Metrics
+	require.ErrorAs(t, err, &metricsErr)
+
+	require.NoError(t, pmetrictest.CompareMetrics(
+		outerFailed,
 		metricsErr.Data(),
 		pmetrictest.IgnoreResourceMetricsOrder(),
 		pmetrictest.IgnoreScopeMetricsOrder(),

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -382,6 +382,47 @@ func TestMetricsCentralQueueRetriesOnlyFailedEndpointItem(t *testing.T) {
 	require.NotZero(t, remaining.nextAttemptUnixNano)
 }
 
+func TestConsumeMetricsByExporterAggregatesFailedEndpointSubsets(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+
+	failedEndpoint1 := "endpoint-1:4317"
+	failedEndpoint2 := "endpoint-2:4317"
+	successEndpoint := "endpoint-3:4317"
+	lb := &loadBalancer{
+		ring:           newHashRing([]string{failedEndpoint1, failedEndpoint2, successEndpoint}),
+		exporters:      map[string]*wrappedExporter{},
+		endpointHealth: newEndpointHealthManager(endpointHealthSettings{}),
+	}
+	for _, endpoint := range []string{failedEndpoint1, failedEndpoint2, successEndpoint} {
+		lb.exporters[endpoint] = newWrappedExporter(newMockMetricsExporter(func(context.Context, pmetric.Metrics) error {
+			if endpoint == successEndpoint {
+				return nil
+			}
+			return status.Error(codes.Unavailable, "backend unavailable")
+		}), endpoint)
+	}
+
+	routeFailed1 := findRoutingIDForEndpoint(t, lb.ring, failedEndpoint1)
+	routeFailed2 := findRoutingIDForEndpoint(t, lb.ring, failedEndpoint2)
+	routeSuccess := findRoutingIDForEndpoint(t, lb.ring, successEndpoint)
+	p := &metricExporterImp{
+		loadBalancer: lb,
+		logger:       ts.Logger,
+		telemetry:    tb,
+	}
+
+	err := p.consumeMetricsByExporter(t.Context(), map[string]pmetric.Metrics{
+		routeFailed1: metricsWithServiceDataPoints(routeFailed1),
+		routeFailed2: metricsWithServiceDataPoints(routeFailed2),
+		routeSuccess: metricsWithServiceDataPoints(routeSuccess),
+	})
+	require.Error(t, err)
+
+	var metricsErr consumererror.Metrics
+	require.ErrorAs(t, err, &metricsErr)
+	require.ElementsMatch(t, []string{routeFailed1, routeFailed2}, serviceNamesFromMetrics(metricsErr.Data()))
+}
+
 func TestMetricsCentralQueueDoesNotDirectReroute(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := endpoint2Config()
@@ -2470,6 +2511,17 @@ func metricsWithServiceNames(serviceNames ...string) pmetric.Metrics {
 		appendSimpleMetricWithID(rm, signal1Name)
 	}
 	return metrics
+}
+
+func serviceNamesFromMetrics(md pmetric.Metrics) []string {
+	serviceNames := make([]string, 0, md.ResourceMetrics().Len())
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		serviceName, ok := md.ResourceMetrics().At(i).Resource().Attributes().Get(serviceNameKey)
+		if ok {
+			serviceNames = append(serviceNames, serviceName.Str())
+		}
+	}
+	return serviceNames
 }
 
 func metricsWithServiceDataPoints(serviceNames ...string) pmetric.Metrics {

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -1061,6 +1061,95 @@ func TestConsumeMetricsRecordsBackendRequestMetrics(t *testing.T) {
 	)
 }
 
+func TestConsumeMetricsCentralByteBatchPartialFailureReturnsOnlyFailedEndpointSubset(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := serviceBasedRoutingConfig()
+	enableCentralQueueByteBatchingForTest(cfg)
+
+	ring := newHashRing([]string{"endpoint-1", "endpoint-2"})
+	serviceForEndpoint1 := findRoutingIDForEndpoint(t, ring, "endpoint-1")
+	serviceForEndpoint2 := findRoutingIDForEndpoint(t, ring, "endpoint-2")
+
+	var endpoint1Records int
+	var endpoint2Records int
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockMetricsExporter(func(_ context.Context, md pmetric.Metrics) error {
+			switch endpoint {
+			case "endpoint-1:4317":
+				endpoint1Records += md.DataPointCount()
+				return status.Error(codes.Unavailable, "backend unavailable")
+			case "endpoint-2:4317":
+				endpoint2Records += md.DataPointCount()
+			}
+			return nil
+		}), nil
+	}
+
+	p, _ := newTestMetricsExporter(t, ts, tb, cfg, componentFactory)
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	input := metricsWithServiceDataPoints(serviceForEndpoint1, serviceForEndpoint2, serviceForEndpoint2)
+	err := p.ConsumeMetrics(t.Context(), input)
+	require.Error(t, err)
+
+	assert.Equal(t, 1, endpoint1Records)
+	assert.Equal(t, 2, endpoint2Records)
+
+	var metricsErr consumererror.Metrics
+	require.ErrorAs(t, err, &metricsErr)
+	require.NoError(t, pmetrictest.CompareMetrics(
+		metricsWithServiceDataPoints(serviceForEndpoint1),
+		metricsErr.Data(),
+		pmetrictest.IgnoreResourceMetricsOrder(),
+		pmetrictest.IgnoreScopeMetricsOrder(),
+		pmetrictest.IgnoreMetricsOrder(),
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+	))
+}
+
+func BenchmarkConsumeMetricsRouteAwareMergedInput(b *testing.B) {
+	ring := newHashRing([]string{"endpoint-1", "endpoint-2"})
+	serviceForEndpoint1 := findRoutingIDForEndpoint(b, ring, "endpoint-1")
+	serviceForEndpoint2 := findRoutingIDForEndpoint(b, ring, "endpoint-2")
+	input := metricsWithServiceDataPoints(
+		serviceForEndpoint1, serviceForEndpoint1, serviceForEndpoint1, serviceForEndpoint1,
+		serviceForEndpoint2, serviceForEndpoint2, serviceForEndpoint2, serviceForEndpoint2,
+	)
+	serializedBytes := serializedMetricsSize(input)
+
+	ts, tb := getTelemetryAssets(b)
+	cfg := serviceBasedRoutingConfig()
+	enableCentralQueueByteBatchingForTest(cfg)
+
+	var sendCount atomic.Int64
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
+			sendCount.Add(1)
+			return nil
+		}), nil
+	}
+
+	p, _ := newTestMetricsExporter(b, ts, tb, cfg, componentFactory)
+	require.NoError(b, p.Start(b.Context(), componenttest.NewNopHost()))
+	b.Cleanup(func() {
+		require.NoError(b, p.Shutdown(context.WithoutCancel(b.Context())))
+	})
+
+	b.SetBytes(serializedBytes)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		require.NoError(b, p.ConsumeMetrics(b.Context(), input))
+	}
+	b.StopTimer()
+
+	requestsPerInput := float64(sendCount.Load()) / float64(b.N)
+	b.ReportMetric(requestsPerInput, "backend_requests/input")
+	require.Equal(b, float64(2), requestsPerInput)
+}
+
 func TestConsumeMetricsReroutePreservesPayloadAfterExporterMutation(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := endpoint2Config()
@@ -2425,7 +2514,7 @@ func appendSimpleMetricWithID(dest pmetric.ResourceMetrics, id string) {
 }
 
 func newTestMetricsExporter(
-	t *testing.T,
+	t testing.TB,
 	ts exporter.Settings,
 	tb *metadata.TelemetryBuilder,
 	cfg *Config,
@@ -2435,7 +2524,7 @@ func newTestMetricsExporter(
 
 	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
 	require.NoError(t, err)
-	lb.addMissingExporters(t.Context(), cfg.Resolver.Static.Get().Hostnames)
+	lb.addMissingExporters(context.Background(), cfg.Resolver.Static.Get().Hostnames)
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
 		onResolve: func(_ context.Context) ([]string, error) {

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -36,6 +36,7 @@ import (
 	"google.golang.org/grpc/status"
 	"gopkg.in/yaml.v3"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadatatest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
@@ -1022,6 +1023,42 @@ func TestConsumeMetricsReroutesEndpointLocalFailure(t *testing.T) {
 			Value:      1,
 		},
 	}, metricdatatest.IgnoreTimestamp())
+}
+
+func TestConsumeMetricsRecordsBackendRequestMetrics(t *testing.T) {
+	ts, tb, telemetry := getTelemetryAssetsWithReader(t)
+	cfg := endpoint2Config()
+	routeEndpoint := "endpoint-2"
+	backendEndpoint := "endpoint-2:4317"
+
+	sent := pmetric.NewMetrics()
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockMetricsExporter(func(_ context.Context, md pmetric.Metrics) error {
+			if endpoint == backendEndpoint {
+				md.CopyTo(sent)
+			}
+			return nil
+		}), nil
+	}
+
+	p, lb := newTestMetricsExporter(t, ts, tb, cfg, componentFactory)
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	serviceForEndpoint2 := findRoutingIDForEndpoint(t, lb.ring, routeEndpoint)
+	require.NoError(t, p.ConsumeMetrics(t.Context(), metricsWithServiceDataPoints(serviceForEndpoint2, serviceForEndpoint2)))
+
+	assert.Equal(t, 2, sent.DataPointCount())
+	assertBackendRequestMetrics(
+		t,
+		telemetry,
+		backendRequestSignalMetrics,
+		backendEndpoint,
+		serializedMetricsSize(sent),
+		int64(sent.DataPointCount()),
+	)
 }
 
 func TestConsumeMetricsReroutePreservesPayloadAfterExporterMutation(t *testing.T) {
@@ -2346,6 +2383,20 @@ func metricsWithServiceNames(serviceNames ...string) pmetric.Metrics {
 	return metrics
 }
 
+func metricsWithServiceDataPoints(serviceNames ...string) pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	metrics.ResourceMetrics().EnsureCapacity(len(serviceNames))
+	for i, serviceName := range serviceNames {
+		rm := metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr(serviceNameKey, serviceName)
+		sm := rm.ScopeMetrics().AppendEmpty()
+		m := sm.Metrics().AppendEmpty()
+		m.SetName(fmt.Sprintf("metric-%d", i))
+		m.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(int64(i + 1))
+	}
+	return metrics
+}
+
 func simpleMetricsWithResource() pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 	metrics.ResourceMetrics().EnsureCapacity(1)
@@ -2371,6 +2422,31 @@ func twoServicesWithSameMetricName() pmetric.Metrics {
 
 func appendSimpleMetricWithID(dest pmetric.ResourceMetrics, id string) {
 	dest.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName(id)
+}
+
+func newTestMetricsExporter(
+	t *testing.T,
+	ts exporter.Settings,
+	tb *metadata.TelemetryBuilder,
+	cfg *Config,
+	componentFactory func(context.Context, string) (component.Component, error),
+) (*metricExporterImp, *loadBalancer) {
+	t.Helper()
+
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.addMissingExporters(t.Context(), cfg.Resolver.Static.Get().Hostnames)
+	lb.res = &mockResolver{
+		triggerCallbacks: true,
+		onResolve: func(_ context.Context) ([]string, error) {
+			return cfg.Resolver.Static.Get().Hostnames, nil
+		},
+	}
+
+	p, err := newMetricsExporter(ts, cfg)
+	require.NoError(t, err)
+	p.loadBalancer = lb
+	return p, lb
 }
 
 func TestConsumeMetricsReleasesStartedConsumesOnEarlyReturn(t *testing.T) {

--- a/exporter/loadbalancingexporter/routing_test.go
+++ b/exporter/loadbalancingexporter/routing_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func findRoutingIDForEndpoint(t *testing.T, ring *hashRing, endpoint string) string {
+func findRoutingIDForEndpoint(t testing.TB, ring *hashRing, endpoint string) string {
 	t.Helper()
 
 	for i := range 4096 {

--- a/exporter/loadbalancingexporter/routing_test.go
+++ b/exporter/loadbalancingexporter/routing_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func findRoutingIDForEndpoint(t testing.TB, ring *hashRing, endpoint string) string {
-	t.Helper()
+func findRoutingIDForEndpoint(tb testing.TB, ring *hashRing, endpoint string) string {
+	tb.Helper()
 
 	for i := range 4096 {
 		routingID := fmt.Sprintf("routing-id-%d", i)
@@ -21,6 +21,6 @@ func findRoutingIDForEndpoint(t testing.TB, ring *hashRing, endpoint string) str
 		}
 	}
 
-	require.FailNow(t, "failed to find routing id for endpoint", "endpoint=%s", endpoint)
+	require.FailNow(tb, "failed to find routing id for endpoint", "endpoint=%s", endpoint)
 	return ""
 }

--- a/exporter/loadbalancingexporter/wrapped_exporter.go
+++ b/exporter/loadbalancingexporter/wrapped_exporter.go
@@ -107,6 +107,11 @@ func (we *wrappedExporter) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 	return me.ConsumeMetrics(ctx, md)
 }
 
+func (we *wrappedExporter) metricsMutatesData() bool {
+	me, ok := we.Component.(exporter.Metrics)
+	return ok && me.Capabilities().MutatesData
+}
+
 func (we *wrappedExporter) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	le, ok := we.Component.(exporter.Logs)
 	if !ok {

--- a/exporter/loadbalancingexporter/wrapped_exporter.go
+++ b/exporter/loadbalancingexporter/wrapped_exporter.go
@@ -35,6 +35,8 @@ type wrappedExporter struct {
 	failureAttr       attribute.Set
 	logRequestAttr    attribute.Set
 	metricRequestAttr attribute.Set
+	logSignalAttr     attribute.Set
+	metricSignalAttr  attribute.Set
 }
 
 func newWrappedExporter(exp component.Component, identifier string) *wrappedExporter {
@@ -48,6 +50,8 @@ func newWrappedExporter(exp component.Component, identifier string) *wrappedExpo
 		failureAttr:       attribute.NewSet(ea, attribute.Bool("success", false)),
 		logRequestAttr:    backendRequestAttributeSet(backendRequestSignalLogs, endpoint),
 		metricRequestAttr: backendRequestAttributeSet(backendRequestSignalMetrics, endpoint),
+		logSignalAttr:     backendRequestSignalAttributeSet(backendRequestSignalLogs),
+		metricSignalAttr:  backendRequestSignalAttributeSet(backendRequestSignalMetrics),
 	}
 }
 

--- a/exporter/loadbalancingexporter/wrapped_exporter.go
+++ b/exporter/loadbalancingexporter/wrapped_exporter.go
@@ -30,20 +30,24 @@ type wrappedExporter struct {
 	endpoint  string
 
 	// we store the attributes here for both cases, to avoid new allocations on the hot path
-	endpointAttr attribute.Set
-	successAttr  attribute.Set
-	failureAttr  attribute.Set
+	endpointAttr      attribute.Set
+	successAttr       attribute.Set
+	failureAttr       attribute.Set
+	logRequestAttr    attribute.Set
+	metricRequestAttr attribute.Set
 }
 
 func newWrappedExporter(exp component.Component, identifier string) *wrappedExporter {
 	endpoint := endpointWithPort(identifier)
 	ea := attribute.String("endpoint", endpoint)
 	return &wrappedExporter{
-		Component:    exp,
-		endpoint:     endpoint,
-		endpointAttr: attribute.NewSet(ea),
-		successAttr:  attribute.NewSet(ea, attribute.Bool("success", true)),
-		failureAttr:  attribute.NewSet(ea, attribute.Bool("success", false)),
+		Component:         exp,
+		endpoint:          endpoint,
+		endpointAttr:      attribute.NewSet(ea),
+		successAttr:       attribute.NewSet(ea, attribute.Bool("success", true)),
+		failureAttr:       attribute.NewSet(ea, attribute.Bool("success", false)),
+		logRequestAttr:    backendRequestAttributeSet(backendRequestSignalLogs, endpoint),
+		metricRequestAttr: backendRequestAttributeSet(backendRequestSignalMetrics, endpoint),
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve central queue byte batches for random-routed logs
- keep non-central random log routing behavior unchanged
- add direct backend request bytes/items/count metrics for logs and metrics
- return only the failed metric endpoint subset when a merged metrics input partially fails

## Tests
- go test ./... -count=1 (from exporter/loadbalancingexporter)
- go test ./... -count=1 (from pkg/batchpersignal)
- go test . -bench 'BenchmarkConsumeLogsRandomRoutingRequestAmplification|BenchmarkConsumeMetricsRouteAwareMergedInput' -run '^$' -count=5 (from exporter/loadbalancingexporter)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request routing/batching behavior for randomly routed logs under specific queue/batch byte-sizing settings and adjusts metrics export error propagation to return per-endpoint failed subsets, which could affect retry/diagnostics paths. Adds new internal telemetry instruments and modifies shutdown teardown sequencing.
> 
> **Overview**
> **Reduces backend request fan-out for random-routed logs** by preserving merged payloads when `log_routing.ignore_trace_id=true` and both queue + batch sizers are `bytes`, instead of splitting logs into many backend requests.
> 
> **Adds new internal telemetry** for outbound backend requests: `otelcol_loadbalancer_backend_request_bytes`, `..._items`, and `..._total` (tagged by `signal` and optionally `endpoint`), recorded on each logs/metrics export call.
> 
> **Tightens metrics failure handling and teardown** by aggregating only the failed-endpoint subset into returned `consumererror.Metrics` (preserving data when downstream exporters mutate input) and ensuring central-queue shutdown timeouts still run codec closure and load balancer shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a634089049d94322ba4b2f465df39cde7de5107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves merged byte-based batches for randomly routed logs to cut backend request fan‑out, adds per-request backend telemetry, and tightens metric failure handling and central-queue shutdown behavior.

- New Features
  - Preserve merged log byte batches when the queue and batch sizers are `bytes` and `log_routing.ignore_trace_id=true`; random routing sends one backend request.
  - Record backend request metrics for logs and metrics: `otelcol_loadbalancer_backend_request_bytes` and `otelcol_loadbalancer_backend_request_items` as signal-scoped histograms, and `otelcol_loadbalancer_backend_request_total` by `signal` and `endpoint`; sizes use serialized OTLP bytes pre-compression.

- Bug Fixes
  - Metrics: for direct sends with merged inputs, return a single `consumererror.Metrics` that aggregates only the failed endpoint subsets (including nested reroute payloads); avoid copies unless the downstream exporter `MutatesData`; fall back to the outer failed subset if nested payloads are empty.
  - Central queue shutdown: on timeout, still close the codec and shut down the load balancer while surfacing the timeout error.

<sup>Written for commit 3a634089049d94322ba4b2f465df39cde7de5107. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added backend request telemetry: per-request serialized bytes, item counts, and total request counts, tagged by signal (logs/metrics) and endpoint.

* **Documentation**
  * Updated telemetry docs to describe the three new backend request metrics and their attributes.

* **Tests**
  * Expanded tests for central queue byte-batching behavior and backend request metric recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->