### PR TITLE
loadbalancingexporter: compressed central queue coalescing

### DIFF
--- a/.chloggen/loadbalancingexporter-backend-request-telemetry.yaml
+++ b/.chloggen/loadbalancingexporter-backend-request-telemetry.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add backend request bytes, item count, and request count metrics to the loadbalancing exporter.
+issues: [58]
+subtext: |-
+  The new metrics expose the final LB-to-backend send boundary by signal and endpoint so operators can measure request amplification and effective payload size.
+change_logs: [user]

--- a/.chloggen/loadbalancingexporter-central-queue.yaml
+++ b/.chloggen/loadbalancingexporter-central-queue.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add optional compressed central queue coalescing for loadbalanced logs and metrics.
+issues: []
+subtext: |-
+  The `central_queue` option stores queued OTLP payloads compressed, enforces capacity by compressed bytes, coalesces small payloads by backend lane, and selects backend endpoints when a coalesced window is sent.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -145,7 +145,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
 * The `central_queue` property enables a single compressed-byte backlog for load-balanced logs and metrics before selecting a backend endpoint. It is `disabled` by default for backward compatibility and cannot be combined with `sending_queue`, `log_batcher`, or `metric_batcher`.
   * `enabled` turns the central queue on or off.
   * Logs use the central queue only when `log_routing.ignore_trace_id` is `true`; trace-aware log routing keeps the existing direct path to preserve trace affinity.
-  * `payload_compression` compresses queued OTLP payloads while they are pending in memory. Supported values: `none`, `snappy`, `zstd`. Default when enabled: `zstd`.
+  * `payload_compression` compresses queued OTLP payloads while they are pending in memory. Supported values: `snappy`, `zstd`. Default when enabled: `zstd`.
   * `capacity_bytes` limits the queue by compressed bytes. Default: `17179869184` (`16 GiB`).
   * `num_consumers` controls the number of central queue send workers. Default: `60`.
   * `request_batching.target_compressed_bytes` coalesces queued payloads for the same backend lane until the compressed window reaches this target. Default: `262144` (`256 KiB`).

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -142,6 +142,18 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
     * `rise` is the number of consecutive successful probes required before a backend is readmitted. Default: `2`.
 * The `log_routing` property controls log-specific routing behavior.
   * `ignore_trace_id` routes logs using an auto-generated `traceID` even when each log record has a `traceID`. Default: `false`.
+* The `central_queue` property enables a single compressed-byte backlog for load-balanced logs and metrics before selecting a backend endpoint. It is `disabled` by default for backward compatibility and cannot be combined with `sending_queue`, `log_batcher`, or `metric_batcher`.
+  * `enabled` turns the central queue on or off.
+  * Logs use the central queue only when `log_routing.ignore_trace_id` is `true`; trace-aware log routing keeps the existing direct path to preserve trace affinity.
+  * `payload_compression` compresses queued OTLP payloads while they are pending in memory. Supported values: `none`, `snappy`, `zstd`. Default when enabled: `zstd`.
+  * `capacity_bytes` limits the queue by compressed bytes. Default: `17179869184` (`16 GiB`).
+  * `num_consumers` controls the number of central queue send workers. Default: `60`.
+  * `request_batching.target_compressed_bytes` coalesces queued payloads for the same backend lane until the compressed window reaches this target. Default: `262144` (`256 KiB`).
+  * `request_batching.max_compressed_bytes` caps a single coalesced request window by compressed bytes. Default: `1048576` (`1 MiB`).
+  * `request_batching.max_uncompressed_bytes` caps a single coalesced request window by uncompressed OTLP bytes. Default: `4194304` (`4 MiB`).
+  * `request_batching.max_merged_items` caps a single coalesced request window by signal items. Default: `10000`.
+  * `request_batching.max_delay` bounds how long a small queued item waits for more payloads in the same backend lane. Default: `250ms`.
+  * `request_batching.lane_count` controls how many lanes are used to coalesce routing keys before late endpoint selection. Default: `64`.
 * The `log_batcher` property enables post-routing log batching per backend. It is `disabled` by default for backward compatibility.
   * `enabled` turns post-routing log batching on or off.
   * `max_records` flushes a backend batch when it reaches this many log records. Default: `512`.

--- a/exporter/loadbalancingexporter/backend_request_telemetry.go
+++ b/exporter/loadbalancingexporter/backend_request_telemetry.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+)
+
+const (
+	backendRequestSignalTraces  = "traces"
+	backendRequestSignalLogs    = "logs"
+	backendRequestSignalMetrics = "metrics"
+)
+
+func recordBackendRequest(ctx context.Context, telemetry *metadata.TelemetryBuilder, endpoint, signal string, items, bytes int) {
+	attrs := metric.WithAttributeSet(attribute.NewSet(attribute.String("endpoint", endpoint), attribute.String("signal", signal)))
+	telemetry.LoadbalancerBackendRequestTotal.Add(ctx, 1, attrs)
+	telemetry.LoadbalancerBackendRequestItems.Record(ctx, int64(items), attrs)
+	telemetry.LoadbalancerBackendRequestBytes.Record(ctx, int64(bytes), attrs)
+}

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -39,6 +39,15 @@ type centralQueueKey struct {
 	laneID    uint32
 }
 
+type centralQueueFlushReason string
+
+const (
+	centralQueueFlushReasonTargetReached      centralQueueFlushReason = "target_reached"
+	centralQueueFlushReasonHardCap            centralQueueFlushReason = "hard_cap"
+	centralQueueFlushReasonMaxDelayLowTraffic centralQueueFlushReason = "max_delay_low_traffic"
+	centralQueueFlushReasonShutdown           centralQueueFlushReason = "shutdown"
+)
+
 type centralQueueItem struct {
 	key               centralQueueKey
 	payload           []byte
@@ -55,6 +64,7 @@ type centralQueueWindow struct {
 	uncompressedBytes int
 	itemCount         int
 	oldestEnqueuedAt  time.Time
+	flushReason       centralQueueFlushReason
 }
 
 type centralQueueSettings struct {
@@ -179,6 +189,7 @@ func (q *centralQueue) buildWindowLocked(key centralQueueKey, items []centralQue
 	for len(items) > 0 {
 		item := items[0]
 		if len(window.items) > 0 && exceedsWindowLimits(window, item, batching) {
+			window.flushReason = centralQueueFlushReasonHardCap
 			break
 		}
 		items = items[1:]
@@ -190,8 +201,12 @@ func (q *centralQueue) buildWindowLocked(key centralQueueKey, items []centralQue
 			window.oldestEnqueuedAt = item.enqueuedAt
 		}
 		if window.compressedBytes >= int(batching.TargetCompressedBytes) {
+			window.flushReason = centralQueueFlushReasonTargetReached
 			break
 		}
+	}
+	if window.flushReason == "" {
+		window.flushReason = centralQueueFlushReasonMaxDelayLowTraffic
 	}
 
 	return window, items
@@ -246,6 +261,9 @@ func (q *centralQueue) popWindowLocked(index int) centralQueueWindow {
 	key := q.activeKeys[index]
 	items := q.queues[key]
 	window, remaining := q.buildWindowLocked(key, items)
+	if q.stopped && window.compressedBytes < int(q.settings.batching.TargetCompressedBytes) {
+		window.flushReason = centralQueueFlushReasonShutdown
+	}
 	q.queues[key] = remaining
 	if len(remaining) == 0 {
 		delete(q.queues, key)

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -1,0 +1,355 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"context"
+	"errors"
+	"hash/crc32"
+	"sync"
+	"time"
+)
+
+var (
+	errCentralQueueFull         = errors.New("central queue is full")
+	errCentralQueueStopped      = errors.New("central queue is stopped")
+	errCentralQueueItemTooLarge = errors.New("central queue item exceeds hard limits")
+)
+
+type centralQueueSignal string
+
+const (
+	centralQueueSignalLogs    centralQueueSignal = "logs"
+	centralQueueSignalMetrics centralQueueSignal = "metrics"
+)
+
+const defaultCentralQueueBackendID = "default"
+
+func centralQueueLaneID(identifier []byte, laneCount int) uint32 {
+	if laneCount <= 0 {
+		return 0
+	}
+	return crc32.ChecksumIEEE(identifier) % uint32(laneCount)
+}
+
+type centralQueueKey struct {
+	signal    centralQueueSignal
+	backendID string
+	laneID    uint32
+}
+
+type centralQueueItem struct {
+	key               centralQueueKey
+	payload           []byte
+	compressedBytes   int
+	uncompressedBytes int
+	itemCount         int
+	enqueuedAt        time.Time
+}
+
+type centralQueueWindow struct {
+	key               centralQueueKey
+	items             []centralQueueItem
+	compressedBytes   int
+	uncompressedBytes int
+	itemCount         int
+	oldestEnqueuedAt  time.Time
+}
+
+type centralQueueSettings struct {
+	capacityBytes int64
+	batching      CentralQueueBatchingConfig
+	now           func() time.Time
+}
+
+type centralQueue struct {
+	settings centralQueueSettings
+
+	mu          sync.Mutex
+	notEmpty    *sync.Cond
+	queues      map[centralQueueKey][]centralQueueItem
+	activeKeys  []centralQueueKey
+	activeKey   map[centralQueueKey]bool
+	queuedBytes int64
+	stopped     bool
+}
+
+func centralQueueSettingsFromConfig(cfg CentralQueueConfig) centralQueueSettings {
+	cfg.ApplyDefaults()
+	return centralQueueSettings{
+		capacityBytes: cfg.CapacityBytes,
+		batching:      cfg.RequestBatching,
+		now:           time.Now,
+	}
+}
+
+func newCentralQueue(settings centralQueueSettings) *centralQueue {
+	if settings.now == nil {
+		settings.now = time.Now
+	}
+	q := &centralQueue{
+		settings:  settings,
+		queues:    make(map[centralQueueKey][]centralQueueItem),
+		activeKey: make(map[centralQueueKey]bool),
+	}
+	q.notEmpty = sync.NewCond(&q.mu)
+	return q
+}
+
+func (q *centralQueue) enqueue(ctx context.Context, item centralQueueItem) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if item.enqueuedAt.IsZero() {
+		item.enqueuedAt = q.settings.now()
+	}
+	if err := q.validateItem(item); err != nil {
+		return err
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.stopped {
+		return errCentralQueueStopped
+	}
+	if q.queuedBytes+int64(item.compressedBytes) > q.settings.capacityBytes {
+		return errCentralQueueFull
+	}
+	q.pushBackLocked(item)
+	q.queuedBytes += int64(item.compressedBytes)
+	q.notEmpty.Signal()
+	return nil
+}
+
+func (q *centralQueue) validateItem(item centralQueueItem) error {
+	if item.compressedBytes <= 0 || item.uncompressedBytes <= 0 || item.itemCount <= 0 {
+		return errCentralQueueItemTooLarge
+	}
+	batching := q.settings.batching
+	if item.compressedBytes > int(batching.MaxCompressedBytes) ||
+		item.uncompressedBytes > int(batching.MaxUncompressedBytes) ||
+		item.itemCount > batching.MaxMergedItems {
+		return errCentralQueueItemTooLarge
+	}
+	return nil
+}
+
+func (q *centralQueue) nextWindow(ctx context.Context) (centralQueueWindow, bool) {
+	done := q.broadcastOnContextDone(ctx)
+	defer close(done)
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	for {
+		for len(q.activeKeys) == 0 && !q.stopped && ctx.Err() == nil {
+			q.notEmpty.Wait()
+		}
+		if ctx.Err() != nil || len(q.activeKeys) == 0 {
+			return centralQueueWindow{}, false
+		}
+
+		now := q.settings.now()
+		if readyIndex := q.readyKeyIndexLocked(now); readyIndex >= 0 {
+			window := q.popWindowLocked(readyIndex)
+			q.queuedBytes -= int64(window.compressedBytes)
+			if len(q.activeKeys) > 0 {
+				q.notEmpty.Signal()
+			}
+			return window, true
+		}
+
+		wait := q.nextReadyDelayLocked(now)
+		timer := time.AfterFunc(wait, func() {
+			q.mu.Lock()
+			q.notEmpty.Broadcast()
+			q.mu.Unlock()
+		})
+		q.notEmpty.Wait()
+		timer.Stop()
+	}
+}
+
+func (q *centralQueue) buildWindowLocked(key centralQueueKey, items []centralQueueItem) (centralQueueWindow, []centralQueueItem) {
+	batching := q.settings.batching
+	window := centralQueueWindow{key: key, items: make([]centralQueueItem, 0, len(items))}
+
+	for len(items) > 0 {
+		item := items[0]
+		if len(window.items) > 0 && exceedsWindowLimits(window, item, batching) {
+			break
+		}
+		items = items[1:]
+		window.items = append(window.items, item)
+		window.compressedBytes += item.compressedBytes
+		window.uncompressedBytes += item.uncompressedBytes
+		window.itemCount += item.itemCount
+		if window.oldestEnqueuedAt.IsZero() || item.enqueuedAt.Before(window.oldestEnqueuedAt) {
+			window.oldestEnqueuedAt = item.enqueuedAt
+		}
+		if window.compressedBytes >= int(batching.TargetCompressedBytes) {
+			break
+		}
+	}
+
+	return window, items
+}
+
+func (q *centralQueue) readyKeyIndexLocked(now time.Time) int {
+	if q.stopped {
+		return 0
+	}
+	for i, key := range q.activeKeys {
+		if q.laneReadyLocked(key, now) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (q *centralQueue) laneReadyLocked(key centralQueueKey, now time.Time) bool {
+	items := q.queues[key]
+	if len(items) == 0 {
+		return false
+	}
+	window, remaining := q.buildWindowLocked(key, items)
+	if window.compressedBytes >= int(q.settings.batching.TargetCompressedBytes) {
+		return true
+	}
+	if len(remaining) > 0 {
+		return true
+	}
+	return now.Sub(window.oldestEnqueuedAt) >= q.settings.batching.MaxDelay
+}
+
+func (q *centralQueue) nextReadyDelayLocked(now time.Time) time.Duration {
+	delay := q.settings.batching.MaxDelay
+	for _, key := range q.activeKeys {
+		items := q.queues[key]
+		if len(items) == 0 {
+			continue
+		}
+		untilReady := q.settings.batching.MaxDelay - now.Sub(items[0].enqueuedAt)
+		if untilReady <= 0 {
+			return 0
+		}
+		if untilReady < delay {
+			delay = untilReady
+		}
+	}
+	return delay
+}
+
+func (q *centralQueue) popWindowLocked(index int) centralQueueWindow {
+	key := q.activeKeys[index]
+	items := q.queues[key]
+	window, remaining := q.buildWindowLocked(key, items)
+	q.queues[key] = remaining
+	if len(remaining) == 0 {
+		delete(q.queues, key)
+		delete(q.activeKey, key)
+		q.activeKeys = append(q.activeKeys[:index], q.activeKeys[index+1:]...)
+	} else {
+		q.activeKeys = append(q.activeKeys[:index], q.activeKeys[index+1:]...)
+		q.activeKeys = append(q.activeKeys, key)
+	}
+	return window
+}
+
+func exceedsWindowLimits(window centralQueueWindow, item centralQueueItem, batching CentralQueueBatchingConfig) bool {
+	return window.compressedBytes+item.compressedBytes > int(batching.MaxCompressedBytes) ||
+		window.uncompressedBytes+item.uncompressedBytes > int(batching.MaxUncompressedBytes) ||
+		window.itemCount+item.itemCount > batching.MaxMergedItems
+}
+
+func (q *centralQueue) requeueFront(window centralQueueWindow) {
+	if len(window.items) == 0 {
+		return
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	existing := q.queues[window.key]
+	requeued := make([]centralQueueItem, 0, len(window.items)+len(existing))
+	requeued = append(requeued, window.items...)
+	requeued = append(requeued, existing...)
+	q.queues[window.key] = requeued
+	if !q.activeKey[window.key] {
+		q.activeKey[window.key] = true
+		q.activeKeys = append([]centralQueueKey{window.key}, q.activeKeys...)
+	}
+	q.queuedBytes += int64(window.compressedBytes)
+	q.notEmpty.Signal()
+}
+
+func (q *centralQueue) stop() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.stopped = true
+	q.notEmpty.Broadcast()
+}
+
+func (q *centralQueue) currentBytes() int64 {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.queuedBytes
+}
+
+func (q *centralQueue) activeLaneCount(signal centralQueueSignal) int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	count := 0
+	for key := range q.queues {
+		if key.signal == signal {
+			count++
+		}
+	}
+	return count
+}
+
+func (q *centralQueue) oldestItemAge(signal centralQueueSignal, now time.Time) time.Duration {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	var oldest time.Time
+	for key, items := range q.queues {
+		if key.signal != signal || len(items) == 0 {
+			continue
+		}
+		enqueuedAt := items[0].enqueuedAt
+		if oldest.IsZero() || enqueuedAt.Before(oldest) {
+			oldest = enqueuedAt
+		}
+	}
+	if oldest.IsZero() {
+		return 0
+	}
+	return now.Sub(oldest)
+}
+
+func (q *centralQueue) pushBackLocked(item centralQueueItem) {
+	q.queues[item.key] = append(q.queues[item.key], item)
+	if q.activeKey[item.key] {
+		return
+	}
+	q.activeKey[item.key] = true
+	q.activeKeys = append(q.activeKeys, item.key)
+}
+
+func (q *centralQueue) broadcastOnContextDone(ctx context.Context) chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			q.mu.Lock()
+			q.notEmpty.Broadcast()
+			q.mu.Unlock()
+		case <-done:
+		}
+	}()
+	return done
+}

--- a/exporter/loadbalancingexporter/central_queue_config.go
+++ b/exporter/loadbalancingexporter/central_queue_config.go
@@ -85,10 +85,10 @@ func (c CentralQueueConfig) Validate() error {
 		return nil
 	}
 	switch c.PayloadCompression {
-	case QueuePayloadCompressionNone, QueuePayloadCompressionSnappy, QueuePayloadCompressionZstd:
+	case QueuePayloadCompressionSnappy, QueuePayloadCompressionZstd:
 		// Valid payload compression value.
 	default:
-		return fmt.Errorf("central_queue.payload_compression must be one of [none, snappy, zstd], found %q", c.PayloadCompression)
+		return fmt.Errorf("central_queue.payload_compression must be one of [snappy, zstd], found %q", c.PayloadCompression)
 	}
 	if c.CapacityBytes <= 0 {
 		return errors.New("central_queue.capacity_bytes must be greater than 0")

--- a/exporter/loadbalancingexporter/central_queue_config.go
+++ b/exporter/loadbalancingexporter/central_queue_config.go
@@ -1,0 +1,122 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	defaultCentralQueueCapacityBytes      int64 = 16 << 30
+	defaultCentralQueueNumConsumers             = 60
+	defaultCentralQueueTargetBytes        int64 = 256 << 10
+	defaultCentralQueueMaxCompressedBytes int64 = 1 << 20
+	defaultCentralQueueMaxUncompressed    int64 = 4 << 20
+	defaultCentralQueueMaxMergedItems           = 10000
+	defaultCentralQueueMaxDelay                 = 250 * time.Millisecond
+	defaultCentralQueueLaneCount                = 64
+)
+
+type CentralQueueConfig struct {
+	Enabled            bool                       `mapstructure:"enabled"`
+	PayloadCompression QueuePayloadCompression    `mapstructure:"payload_compression"`
+	CapacityBytes      int64                      `mapstructure:"capacity_bytes"`
+	NumConsumers       int                        `mapstructure:"num_consumers"`
+	RequestBatching    CentralQueueBatchingConfig `mapstructure:"request_batching"`
+
+	// prevent unkeyed literal initialization
+	_ struct{}
+}
+
+type CentralQueueBatchingConfig struct {
+	TargetCompressedBytes int64         `mapstructure:"target_compressed_bytes"`
+	MaxCompressedBytes    int64         `mapstructure:"max_compressed_bytes"`
+	MaxUncompressedBytes  int64         `mapstructure:"max_uncompressed_bytes"`
+	MaxMergedItems        int           `mapstructure:"max_merged_items"`
+	MaxDelay              time.Duration `mapstructure:"max_delay"`
+	LaneCount             int           `mapstructure:"lane_count"`
+
+	// prevent unkeyed literal initialization
+	_ struct{}
+}
+
+func (c *CentralQueueConfig) ApplyDefaults() {
+	if !c.Enabled {
+		return
+	}
+	if c.PayloadCompression == "" {
+		c.PayloadCompression = QueuePayloadCompressionZstd
+	}
+	if c.CapacityBytes == 0 {
+		c.CapacityBytes = defaultCentralQueueCapacityBytes
+	}
+	if c.NumConsumers == 0 {
+		c.NumConsumers = defaultCentralQueueNumConsumers
+	}
+	c.RequestBatching.ApplyDefaults()
+}
+
+func (c *CentralQueueBatchingConfig) ApplyDefaults() {
+	if c.TargetCompressedBytes == 0 {
+		c.TargetCompressedBytes = defaultCentralQueueTargetBytes
+	}
+	if c.MaxCompressedBytes == 0 {
+		c.MaxCompressedBytes = defaultCentralQueueMaxCompressedBytes
+	}
+	if c.MaxUncompressedBytes == 0 {
+		c.MaxUncompressedBytes = defaultCentralQueueMaxUncompressed
+	}
+	if c.MaxMergedItems == 0 {
+		c.MaxMergedItems = defaultCentralQueueMaxMergedItems
+	}
+	if c.MaxDelay == 0 {
+		c.MaxDelay = defaultCentralQueueMaxDelay
+	}
+	if c.LaneCount == 0 {
+		c.LaneCount = defaultCentralQueueLaneCount
+	}
+}
+
+func (c CentralQueueConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	switch c.PayloadCompression {
+	case QueuePayloadCompressionNone, QueuePayloadCompressionSnappy, QueuePayloadCompressionZstd:
+		// Valid payload compression value.
+	default:
+		return fmt.Errorf("central_queue.payload_compression must be one of [none, snappy, zstd], found %q", c.PayloadCompression)
+	}
+	if c.CapacityBytes <= 0 {
+		return errors.New("central_queue.capacity_bytes must be greater than 0")
+	}
+	if c.NumConsumers <= 0 {
+		return errors.New("central_queue.num_consumers must be greater than 0")
+	}
+	return c.RequestBatching.validateEnabled()
+}
+
+func (c CentralQueueBatchingConfig) validateEnabled() error {
+	if c.TargetCompressedBytes <= 0 {
+		return errors.New("central_queue.request_batching.target_compressed_bytes must be greater than 0")
+	}
+	if c.MaxCompressedBytes < c.TargetCompressedBytes {
+		return errors.New("central_queue.request_batching.max_compressed_bytes must be greater than or equal to target_compressed_bytes")
+	}
+	if c.MaxUncompressedBytes <= 0 {
+		return errors.New("central_queue.request_batching.max_uncompressed_bytes must be greater than 0")
+	}
+	if c.MaxMergedItems <= 0 {
+		return errors.New("central_queue.request_batching.max_merged_items must be greater than 0")
+	}
+	if c.MaxDelay <= 0 {
+		return errors.New("central_queue.request_batching.max_delay must be greater than 0")
+	}
+	if c.LaneCount <= 0 {
+		return errors.New("central_queue.request_batching.lane_count must be greater than 0")
+	}
+	return nil
+}

--- a/exporter/loadbalancingexporter/central_queue_logs.go
+++ b/exporter/loadbalancingexporter/central_queue_logs.go
@@ -1,0 +1,87 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+)
+
+const logFlushReasonCentralQueue = "central_queue"
+
+func newLogCentralQueueRuntime(cfg CentralQueueConfig, ignoreTraceID bool, telemetry *metadata.TelemetryBuilder) *centralQueueRuntime {
+	if !cfg.Enabled || !ignoreTraceID {
+		return nil
+	}
+	return newCentralQueueRuntime(cfg, centralQueueSignalLogs, telemetry)
+}
+
+func (e *logExporterImp) consumeLogsCentralQueue(ctx context.Context, ld plog.Logs) error {
+	if ld.LogRecordCount() == 0 {
+		return nil
+	}
+	marshaler := &plog.ProtoMarshaler{}
+	payload, err := marshaler.MarshalLogs(ld)
+	if err != nil {
+		return err
+	}
+	encoded, err := e.centralQueue.codec.Encode(payload)
+	if err != nil {
+		return err
+	}
+
+	routingKey := e.routingKeyForLogs(ld)
+	item := centralQueueItem{
+		key: centralQueueKey{
+			signal:    centralQueueSignalLogs,
+			backendID: defaultCentralQueueBackendID,
+			laneID:    centralQueueLaneID(routingKey[:], e.centralQueue.queue.settings.batching.LaneCount),
+		},
+		payload:           encoded,
+		compressedBytes:   len(encoded),
+		uncompressedBytes: len(payload),
+		itemCount:         ld.LogRecordCount(),
+	}
+	return e.centralQueue.enqueue(ctx, item)
+}
+
+func (e *logExporterImp) consumeLogCentralQueueWindow(ctx context.Context, window centralQueueWindow) error {
+	ld, err := e.decodeCentralQueueLogWindow(window)
+	if err != nil {
+		return err
+	}
+	le, _, err := e.loadBalancer.randomExporterAndEndpoint()
+	if err != nil {
+		return err
+	}
+	_, err = e.consumeBatchWithDecision(ctx, le, ld, logFlushReasonCentralQueue, true, false, true)
+	return err
+}
+
+func (e *logExporterImp) decodeCentralQueueLogWindow(window centralQueueWindow) (plog.Logs, error) {
+	unmarshaler := &plog.ProtoUnmarshaler{}
+	var merged plog.Logs
+	for i, item := range window.items {
+		payload, err := e.centralQueue.codec.Decode(item.payload)
+		if err != nil {
+			return plog.Logs{}, err
+		}
+		logs, err := unmarshaler.UnmarshalLogs(payload)
+		if err != nil {
+			return plog.Logs{}, err
+		}
+		if i == 0 {
+			merged = logs
+			continue
+		}
+		mergeLogChunksByMove(merged, logs)
+	}
+	if len(window.items) == 0 {
+		return plog.NewLogs(), nil
+	}
+	return merged, nil
+}

--- a/exporter/loadbalancingexporter/central_queue_logs.go
+++ b/exporter/loadbalancingexporter/central_queue_logs.go
@@ -34,12 +34,10 @@ func (e *logExporterImp) consumeLogsCentralQueue(ctx context.Context, ld plog.Lo
 		return err
 	}
 
-	routingKey := e.routingKeyForLogs(ld)
 	item := centralQueueItem{
 		key: centralQueueKey{
 			signal:    centralQueueSignalLogs,
 			backendID: defaultCentralQueueBackendID,
-			laneID:    centralQueueLaneID(routingKey[:], e.centralQueue.queue.settings.batching.LaneCount),
 		},
 		payload:           encoded,
 		compressedBytes:   len(encoded),

--- a/exporter/loadbalancingexporter/central_queue_logs_test.go
+++ b/exporter/loadbalancingexporter/central_queue_logs_test.go
@@ -1,0 +1,137 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+)
+
+func TestLogCentralQueueCoalescesSmallItemsBeforeSend(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := centralQueueLogsConfig()
+	sink := new(consumertest.LogsSink)
+
+	p, _ := newTestLogsExporter(t, ts, tb, cfg, func(context.Context, string) (component.Component, error) {
+		return newMockLogsExporter(sink.ConsumeLogs), nil
+	})
+	p.randomTraceID = func() pcommon.TraceID {
+		return pcommon.TraceID([16]byte{1})
+	}
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, p.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	require.NoError(t, p.ConsumeLogs(t.Context(), sharedScopeLogsWithoutTraceIDs("first")))
+	require.NoError(t, p.ConsumeLogs(t.Context(), sharedScopeLogsWithoutTraceIDs("second")))
+
+	require.Eventually(t, func() bool {
+		logs := sink.AllLogs()
+		return len(logs) == 1 && logs[0].LogRecordCount() == 2
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestLogCentralQueueRequeuesWindowAfterSendFailure(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := centralQueueLogsConfig()
+
+	var calls atomic.Int64
+	sink := new(consumertest.LogsSink)
+	p, _ := newTestLogsExporter(t, ts, tb, cfg, func(context.Context, string) (component.Component, error) {
+		return newMockLogsExporter(func(ctx context.Context, ld plog.Logs) error {
+			if calls.Add(1) == 1 {
+				return errors.New("temporary backend failure")
+			}
+			return sink.ConsumeLogs(ctx, ld)
+		}), nil
+	})
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, p.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	require.NoError(t, p.ConsumeLogs(t.Context(), sharedScopeLogsWithoutTraceIDs("retry-me")))
+
+	require.Eventually(t, func() bool {
+		logs := sink.AllLogs()
+		return calls.Load() >= 2 && len(logs) == 1 && logs[0].LogRecordCount() == 1
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestLogCentralQueueRecordsTelemetry(t *testing.T) {
+	ts, _, telemetry := getTelemetryAssetsWithReader(t)
+	cfg := centralQueueLogsConfig()
+	sink := new(consumertest.LogsSink)
+
+	p, err := newLogsExporter(ts, cfg)
+	require.NoError(t, err)
+	p.loadBalancer.componentFactory = func(context.Context, string) (component.Component, error) {
+		return newMockLogsExporter(sink.ConsumeLogs), nil
+	}
+	p.randomTraceID = func() pcommon.TraceID {
+		return pcommon.TraceID([16]byte{1})
+	}
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, p.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	require.NoError(t, p.ConsumeLogs(t.Context(), sharedScopeLogsWithoutTraceIDs("first")))
+	require.NoError(t, p.ConsumeLogs(t.Context(), sharedScopeLogsWithoutTraceIDs("second")))
+	require.Eventually(t, func() bool {
+		return len(sink.AllLogs()) == 1
+	}, time.Second, 10*time.Millisecond)
+
+	signalAttrs := attribute.NewSet(attribute.String("signal", "logs"))
+	enqueueAttrs := attribute.NewSet(attribute.String("signal", "logs"), attribute.String("result", "success"))
+	assertInt64CounterDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_enqueue_total", enqueueAttrs, 2)
+	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_window_payloads", signalAttrs, 2)
+	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_window_items", signalAttrs, 2)
+	assertInt64GaugeDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_capacity_bytes", signalAttrs, cfg.CentralQueue.CapacityBytes)
+	assertInt64GaugeDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_size_bytes", signalAttrs, 0)
+}
+
+func TestLogCentralQueueDisabledWhenTraceRoutingIsEnabled(t *testing.T) {
+	cfg := centralQueueLogsConfig()
+	cfg.LogRouting.IgnoreTraceID = false
+
+	p, err := newLogsExporter(exportertest.NewNopSettings(metadata.Type), cfg)
+	require.NoError(t, err)
+	assert.Nil(t, p.centralQueue)
+}
+
+func centralQueueLogsConfig() *Config {
+	cfg := simpleConfig()
+	cfg.LogRouting.IgnoreTraceID = true
+	cfg.CentralQueue.Enabled = true
+	cfg.CentralQueue.PayloadCompression = QueuePayloadCompressionZstd
+	cfg.CentralQueue.CapacityBytes = 1 << 20
+	cfg.CentralQueue.NumConsumers = 1
+	cfg.CentralQueue.RequestBatching.TargetCompressedBytes = 1 << 20
+	cfg.CentralQueue.RequestBatching.MaxCompressedBytes = 2 << 20
+	cfg.CentralQueue.RequestBatching.MaxUncompressedBytes = 4 << 20
+	cfg.CentralQueue.RequestBatching.MaxMergedItems = 1000
+	cfg.CentralQueue.RequestBatching.MaxDelay = 25 * time.Millisecond
+	cfg.CentralQueue.RequestBatching.LaneCount = 64
+	return cfg
+}

--- a/exporter/loadbalancingexporter/central_queue_logs_test.go
+++ b/exporter/loadbalancingexporter/central_queue_logs_test.go
@@ -49,6 +49,37 @@ func TestLogCentralQueueCoalescesSmallItemsBeforeSend(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestLogCentralQueueRandomRoutingDoesNotFragmentByLaneCount(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := centralQueueLogsConfig()
+	cfg.CentralQueue.RequestBatching.LaneCount = 64
+	sink := new(consumertest.LogsSink)
+
+	p, _ := newTestLogsExporter(t, ts, tb, cfg, func(context.Context, string) (component.Component, error) {
+		return newMockLogsExporter(sink.ConsumeLogs), nil
+	})
+	traceIDs := distinctCentralQueueLaneTraceIDs(t, 8, cfg.CentralQueue.RequestBatching.LaneCount)
+	var next atomic.Int64
+	p.randomTraceID = func() pcommon.TraceID {
+		index := int(next.Add(1)-1) % len(traceIDs)
+		return traceIDs[index]
+	}
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, p.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	for i := 0; i < len(traceIDs); i++ {
+		require.NoError(t, p.ConsumeLogs(t.Context(), sharedScopeLogsWithoutTraceIDs("fragment-proof")))
+	}
+
+	require.Eventually(t, func() bool {
+		logs := sink.AllLogs()
+		return len(logs) == 1 && logs[0].LogRecordCount() == len(traceIDs)
+	}, time.Second, 10*time.Millisecond)
+}
+
 func TestLogCentralQueueRequeuesWindowAfterSendFailure(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := centralQueueLogsConfig()
@@ -104,11 +135,45 @@ func TestLogCentralQueueRecordsTelemetry(t *testing.T) {
 
 	signalAttrs := attribute.NewSet(attribute.String("signal", "logs"))
 	enqueueAttrs := attribute.NewSet(attribute.String("signal", "logs"), attribute.String("result", "success"))
+	flushAttrs := attribute.NewSet(attribute.String("signal", "logs"), attribute.String("reason", string(centralQueueFlushReasonMaxDelayLowTraffic)))
 	assertInt64CounterDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_enqueue_total", enqueueAttrs, 2)
+	assertInt64CounterDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_window_flush_total", flushAttrs, 1)
+	assertInt64CounterDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_window_underfilled_total", flushAttrs, 1)
 	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_window_payloads", signalAttrs, 2)
 	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_window_items", signalAttrs, 2)
 	assertInt64GaugeDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_capacity_bytes", signalAttrs, cfg.CentralQueue.CapacityBytes)
 	assertInt64GaugeDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_size_bytes", signalAttrs, 0)
+}
+
+func TestLogCentralQueueRecordsHardCapUnderfilledTelemetry(t *testing.T) {
+	ts, _, telemetry := getTelemetryAssetsWithReader(t)
+	cfg := centralQueueLogsConfig()
+	cfg.CentralQueue.RequestBatching.MaxMergedItems = 1
+	sink := new(consumertest.LogsSink)
+
+	p, err := newLogsExporter(ts, cfg)
+	require.NoError(t, err)
+	p.loadBalancer.componentFactory = func(context.Context, string) (component.Component, error) {
+		return newMockLogsExporter(sink.ConsumeLogs), nil
+	}
+	p.randomTraceID = func() pcommon.TraceID {
+		return pcommon.TraceID([16]byte{1})
+	}
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, p.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	require.NoError(t, p.ConsumeLogs(t.Context(), sharedScopeLogsWithoutTraceIDs("first")))
+	require.NoError(t, p.ConsumeLogs(t.Context(), sharedScopeLogsWithoutTraceIDs("second")))
+	require.Eventually(t, func() bool {
+		return len(sink.AllLogs()) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	hardCapAttrs := attribute.NewSet(attribute.String("signal", "logs"), attribute.String("reason", string(centralQueueFlushReasonHardCap)))
+	assertInt64CounterDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_window_flush_total", hardCapAttrs, 1)
+	assertInt64CounterDataPoint(t, telemetry, "otelcol_loadbalancer_central_queue_window_underfilled_total", hardCapAttrs, 1)
 }
 
 func TestLogCentralQueueDisabledWhenTraceRoutingIsEnabled(t *testing.T) {
@@ -134,4 +199,21 @@ func centralQueueLogsConfig() *Config {
 	cfg.CentralQueue.RequestBatching.MaxDelay = 25 * time.Millisecond
 	cfg.CentralQueue.RequestBatching.LaneCount = 64
 	return cfg
+}
+
+func distinctCentralQueueLaneTraceIDs(t *testing.T, count, laneCount int) []pcommon.TraceID {
+	t.Helper()
+	traceIDs := make([]pcommon.TraceID, 0, count)
+	seen := make(map[uint32]struct{}, count)
+	for i := 1; len(traceIDs) < count && i < 10_000; i++ {
+		traceID := pcommon.TraceID([16]byte{byte(i >> 8), byte(i)})
+		lane := centralQueueLaneID(traceID[:], laneCount)
+		if _, ok := seen[lane]; ok {
+			continue
+		}
+		seen[lane] = struct{}{}
+		traceIDs = append(traceIDs, traceID)
+	}
+	require.Len(t, traceIDs, count)
+	return traceIDs
 }

--- a/exporter/loadbalancingexporter/central_queue_metrics.go
+++ b/exporter/loadbalancingexporter/central_queue_metrics.go
@@ -1,0 +1,112 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/multierr"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+	expmetrics "github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics"
+)
+
+func newMetricCentralQueueRuntime(cfg CentralQueueConfig, telemetry *metadata.TelemetryBuilder) *centralQueueRuntime {
+	if !cfg.Enabled {
+		return nil
+	}
+	return newCentralQueueRuntime(cfg, centralQueueSignalMetrics, telemetry)
+}
+
+func (e *metricExporterImp) consumeMetricsCentralQueue(ctx context.Context, batches map[string]pmetric.Metrics) error {
+	var errs error
+	failed := pmetric.NewMetrics()
+	for routingID, md := range batches {
+		if err := e.enqueueMetricsCentralQueue(ctx, routingID, md); err != nil {
+			errs = multierr.Append(errs, err)
+			expmetrics.Merge(failed, md)
+		}
+	}
+	if failed.DataPointCount() > 0 {
+		return consumererror.NewMetrics(errs, failed)
+	}
+	return errs
+}
+
+func (e *metricExporterImp) enqueueMetricsCentralQueue(ctx context.Context, routingID string, md pmetric.Metrics) error {
+	if md.DataPointCount() == 0 {
+		return nil
+	}
+	marshaler := &pmetric.ProtoMarshaler{}
+	payload, err := marshaler.MarshalMetrics(md)
+	if err != nil {
+		return err
+	}
+	encoded, err := e.centralQueue.codec.Encode(payload)
+	if err != nil {
+		return err
+	}
+
+	item := centralQueueItem{
+		key: centralQueueKey{
+			signal:    centralQueueSignalMetrics,
+			backendID: defaultCentralQueueBackendID,
+			laneID:    centralQueueLaneID([]byte(routingID), e.centralQueue.queue.settings.batching.LaneCount),
+		},
+		payload:           encoded,
+		compressedBytes:   len(encoded),
+		uncompressedBytes: len(payload),
+		itemCount:         md.DataPointCount(),
+	}
+	return e.centralQueue.enqueue(ctx, item)
+}
+
+func (e *metricExporterImp) consumeMetricCentralQueueWindow(ctx context.Context, window centralQueueWindow) error {
+	md, err := e.decodeCentralQueueMetricWindow(window)
+	if err != nil {
+		return err
+	}
+	we, _, err := e.loadBalancer.randomExporterAndEndpoint()
+	if err != nil {
+		return err
+	}
+	return e.consumeCentralQueueMetrics(ctx, we, md)
+}
+
+func (e *metricExporterImp) decodeCentralQueueMetricWindow(window centralQueueWindow) (pmetric.Metrics, error) {
+	unmarshaler := &pmetric.ProtoUnmarshaler{}
+	chunks := make([]pmetric.Metrics, 0, len(window.items))
+	for _, item := range window.items {
+		payload, err := e.centralQueue.codec.Decode(item.payload)
+		if err != nil {
+			return pmetric.Metrics{}, err
+		}
+		md, err := unmarshaler.UnmarshalMetrics(payload)
+		if err != nil {
+			return pmetric.Metrics{}, err
+		}
+		chunks = append(chunks, md)
+	}
+	return mergePendingMetricChunks(chunks), nil
+}
+
+func (e *metricExporterImp) consumeCentralQueueMetrics(ctx context.Context, we *wrappedExporter, md pmetric.Metrics) error {
+	if !we.tryStartConsume() {
+		return errExporterIsStopping
+	}
+	defer we.doneConsume()
+
+	recordBackendRequest(ctx, e.telemetry, we.endpoint, backendRequestSignalMetrics, md.DataPointCount(), (&pmetric.ProtoMarshaler{}).MetricsSize(md))
+	start := time.Now()
+	err := we.ConsumeMetrics(ctx, md)
+	duration := time.Since(start)
+	decision := e.recordBackendResultHealthOnly(ctx, we, duration, err, true)
+	if err != nil && shouldRerouteDirectFailure(e.loadBalancer, we.endpoint, decision, 0) {
+		e.loadBalancer.cleanupBackendWithoutDrain(ctx, we.endpoint)
+	}
+	return err
+}

--- a/exporter/loadbalancingexporter/central_queue_metrics_test.go
+++ b/exporter/loadbalancingexporter/central_queue_metrics_test.go
@@ -1,0 +1,122 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+)
+
+func TestMetricCentralQueueCoalescesByLaneBeforeEndpointSelection(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := centralQueueMetricsConfig()
+	ring := newHashRing(cfg.Resolver.Static.Get().Hostnames)
+	serviceForEndpoint1 := findRoutingIDForEndpoint(t, ring, "endpoint-1:4317")
+	serviceForEndpoint2 := findRoutingIDForEndpoint(t, ring, "endpoint-2:4317")
+	require.NotEqual(t, serviceForEndpoint1, serviceForEndpoint2)
+
+	sink := new(consumertest.MetricsSink)
+	p, _ := newTestMetricsExporter(t, ts, tb, cfg, func(context.Context, string) (component.Component, error) {
+		return newMockMetricsExporter(sink.ConsumeMetrics), nil
+	})
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, p.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	require.NoError(t, p.ConsumeMetrics(t.Context(), metricWithServiceName("first", serviceForEndpoint1)))
+	require.NoError(t, p.ConsumeMetrics(t.Context(), metricWithServiceName("second", serviceForEndpoint2)))
+
+	require.Eventually(t, func() bool {
+		allMetrics := sink.AllMetrics()
+		return len(allMetrics) == 1 && allMetrics[0].DataPointCount() == 2
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestMetricCentralQueueRequeuesWindowAfterSendFailure(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := centralQueueMetricsConfig()
+
+	var calls atomic.Int64
+	sink := new(consumertest.MetricsSink)
+	p, _ := newTestMetricsExporter(t, ts, tb, cfg, func(context.Context, string) (component.Component, error) {
+		return newMockMetricsExporter(func(ctx context.Context, md pmetric.Metrics) error {
+			if calls.Add(1) == 1 {
+				return errors.New("temporary backend failure")
+			}
+			return sink.ConsumeMetrics(ctx, md)
+		}), nil
+	})
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, p.Shutdown(context.WithoutCancel(t.Context())))
+	})
+
+	require.NoError(t, p.ConsumeMetrics(t.Context(), metricWithServiceName("retry-me", serviceName1)))
+
+	require.Eventually(t, func() bool {
+		allMetrics := sink.AllMetrics()
+		return calls.Load() >= 2 && len(allMetrics) == 1 && allMetrics[0].DataPointCount() == 1
+	}, time.Second, 10*time.Millisecond)
+}
+
+func centralQueueMetricsConfig() *Config {
+	cfg := endpoint2Config()
+	cfg.CentralQueue.Enabled = true
+	cfg.CentralQueue.PayloadCompression = QueuePayloadCompressionZstd
+	cfg.CentralQueue.CapacityBytes = 1 << 20
+	cfg.CentralQueue.NumConsumers = 1
+	cfg.CentralQueue.RequestBatching.TargetCompressedBytes = 1 << 20
+	cfg.CentralQueue.RequestBatching.MaxCompressedBytes = 2 << 20
+	cfg.CentralQueue.RequestBatching.MaxUncompressedBytes = 4 << 20
+	cfg.CentralQueue.RequestBatching.MaxMergedItems = 1000
+	cfg.CentralQueue.RequestBatching.MaxDelay = 25 * time.Millisecond
+	cfg.CentralQueue.RequestBatching.LaneCount = 1
+	return cfg
+}
+
+func metricWithServiceName(metricName, serviceName string) pmetric.Metrics {
+	md := singleDataPointMetric(metricName)
+	md.ResourceMetrics().At(0).Resource().Attributes().PutStr(serviceNameKey, serviceName)
+	return md
+}
+
+func newTestMetricsExporter(
+	t *testing.T,
+	ts exporter.Settings,
+	tb *metadata.TelemetryBuilder,
+	cfg *Config,
+	componentFactory func(context.Context, string) (component.Component, error),
+) (*metricExporterImp, *loadBalancer) {
+	t.Helper()
+
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.addMissingExporters(t.Context(), cfg.Resolver.Static.Get().Hostnames)
+	lb.res = &mockResolver{
+		triggerCallbacks: true,
+		onResolve: func(context.Context) ([]string, error) {
+			return cfg.Resolver.Static.Get().Hostnames, nil
+		},
+	}
+
+	p, err := newMetricsExporter(ts, cfg)
+	require.NoError(t, err)
+	p.loadBalancer = lb
+	return p, lb
+}

--- a/exporter/loadbalancingexporter/central_queue_runtime.go
+++ b/exporter/loadbalancingexporter/central_queue_runtime.go
@@ -1,0 +1,169 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+)
+
+const centralQueueSendRetryBackoff = 25 * time.Millisecond
+
+type centralQueueConsumeFunc func(context.Context, centralQueueWindow) error
+
+type centralQueueRuntime struct {
+	queue        *centralQueue
+	codec        *queuePayloadCodec
+	numConsumers int
+	signal       centralQueueSignal
+	telemetry    *metadata.TelemetryBuilder
+
+	signalAttrs         attribute.Set
+	enqueueSuccessAttrs attribute.Set
+	enqueueFailureAttrs attribute.Set
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	stopping atomic.Bool
+	errMu    sync.Mutex
+	err      error
+}
+
+func newCentralQueueRuntime(cfg CentralQueueConfig, signal centralQueueSignal, telemetry *metadata.TelemetryBuilder) *centralQueueRuntime {
+	cfg.ApplyDefaults()
+	signalAttr := attribute.String("signal", string(signal))
+	return &centralQueueRuntime{
+		queue:               newCentralQueue(centralQueueSettingsFromConfig(cfg)),
+		codec:               newQueuePayloadCodec(cfg.PayloadCompression),
+		numConsumers:        cfg.NumConsumers,
+		signal:              signal,
+		telemetry:           telemetry,
+		signalAttrs:         attribute.NewSet(signalAttr),
+		enqueueSuccessAttrs: attribute.NewSet(signalAttr, attribute.String("result", "success")),
+		enqueueFailureAttrs: attribute.NewSet(signalAttr, attribute.String("result", "failure")),
+	}
+}
+
+func (r *centralQueueRuntime) start(consume centralQueueConsumeFunc, logger *zap.Logger) {
+	if r == nil {
+		return
+	}
+	r.ctx, r.cancel = context.WithCancel(context.Background())
+	r.recordState(r.ctx)
+	for i := 0; i < r.numConsumers; i++ {
+		r.wg.Add(1)
+		go r.runConsumer(consume, logger)
+	}
+}
+
+func (r *centralQueueRuntime) runConsumer(consume centralQueueConsumeFunc, logger *zap.Logger) {
+	defer r.wg.Done()
+	for {
+		window, ok := r.queue.nextWindow(r.ctx)
+		if !ok {
+			return
+		}
+		r.recordWindow(r.ctx, window)
+		if err := consume(r.ctx, window); err != nil {
+			if r.stopping.Load() {
+				r.recordError(err)
+				return
+			}
+			r.queue.requeueFront(window)
+			r.recordState(r.ctx)
+			if logger != nil {
+				logger.Debug("failed to send central queue window", zap.Error(err))
+			}
+			if !centralQueueSleep(r.ctx, centralQueueSendRetryBackoff) {
+				return
+			}
+		}
+	}
+}
+
+func (r *centralQueueRuntime) shutdown(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	r.stopping.Store(true)
+	r.queue.stop()
+	if err := waitForInflight(ctx, &r.wg); err != nil {
+		if r.cancel != nil {
+			r.cancel()
+		}
+		return err
+	}
+	if r.cancel != nil {
+		r.cancel()
+	}
+	return errors.Join(r.err, r.codec.Close())
+}
+
+func (r *centralQueueRuntime) enqueue(ctx context.Context, item centralQueueItem) error {
+	err := r.queue.enqueue(ctx, item)
+	if err != nil {
+		if r.telemetry != nil {
+			r.telemetry.LoadbalancerCentralQueueEnqueueTotal.Add(ctx, 1, metric.WithAttributeSet(r.enqueueFailureAttrs))
+		}
+		r.recordState(ctx)
+		return err
+	}
+	if r.telemetry != nil {
+		r.telemetry.LoadbalancerCentralQueueEnqueueTotal.Add(ctx, 1, metric.WithAttributeSet(r.enqueueSuccessAttrs))
+	}
+	r.recordState(ctx)
+	return nil
+}
+
+func (r *centralQueueRuntime) recordWindow(ctx context.Context, window centralQueueWindow) {
+	if r.telemetry == nil {
+		return
+	}
+	attrs := metric.WithAttributeSet(r.signalAttrs)
+	r.telemetry.LoadbalancerCentralQueueWindowCompressedBytes.Record(ctx, int64(window.compressedBytes), attrs)
+	r.telemetry.LoadbalancerCentralQueueWindowUncompressedBytes.Record(ctx, int64(window.uncompressedBytes), attrs)
+	r.telemetry.LoadbalancerCentralQueueWindowItems.Record(ctx, int64(window.itemCount), attrs)
+	r.telemetry.LoadbalancerCentralQueueWindowPayloads.Record(ctx, int64(len(window.items)), attrs)
+	r.recordState(ctx)
+}
+
+func (r *centralQueueRuntime) recordState(ctx context.Context) {
+	if r.telemetry == nil {
+		return
+	}
+	attrs := metric.WithAttributeSet(r.signalAttrs)
+	now := r.queue.settings.now()
+	r.telemetry.LoadbalancerCentralQueueCapacityBytes.Record(ctx, r.queue.settings.capacityBytes, attrs)
+	r.telemetry.LoadbalancerCentralQueueSizeBytes.Record(ctx, r.queue.currentBytes(), attrs)
+	r.telemetry.LoadbalancerCentralQueueActiveLanes.Record(ctx, int64(r.queue.activeLaneCount(r.signal)), attrs)
+	r.telemetry.LoadbalancerCentralQueueOldestItemAge.Record(ctx, r.queue.oldestItemAge(r.signal, now).Milliseconds(), attrs)
+}
+
+func (r *centralQueueRuntime) recordError(err error) {
+	r.errMu.Lock()
+	defer r.errMu.Unlock()
+	r.err = errors.Join(r.err, err)
+}
+
+func centralQueueSleep(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}

--- a/exporter/loadbalancingexporter/central_queue_runtime.go
+++ b/exporter/loadbalancingexporter/central_queue_runtime.go
@@ -31,6 +31,7 @@ type centralQueueRuntime struct {
 	signalAttrs         attribute.Set
 	enqueueSuccessAttrs attribute.Set
 	enqueueFailureAttrs attribute.Set
+	flushReasonAttrs    map[centralQueueFlushReason]attribute.Set
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -53,6 +54,12 @@ func newCentralQueueRuntime(cfg CentralQueueConfig, signal centralQueueSignal, t
 		signalAttrs:         attribute.NewSet(signalAttr),
 		enqueueSuccessAttrs: attribute.NewSet(signalAttr, attribute.String("result", "success")),
 		enqueueFailureAttrs: attribute.NewSet(signalAttr, attribute.String("result", "failure")),
+		flushReasonAttrs: map[centralQueueFlushReason]attribute.Set{
+			centralQueueFlushReasonTargetReached:      attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonTargetReached))),
+			centralQueueFlushReasonHardCap:            attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonHardCap))),
+			centralQueueFlushReasonMaxDelayLowTraffic: attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonMaxDelayLowTraffic))),
+			centralQueueFlushReasonShutdown:           attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonShutdown))),
+		},
 	}
 }
 
@@ -136,7 +143,19 @@ func (r *centralQueueRuntime) recordWindow(ctx context.Context, window centralQu
 	r.telemetry.LoadbalancerCentralQueueWindowUncompressedBytes.Record(ctx, int64(window.uncompressedBytes), attrs)
 	r.telemetry.LoadbalancerCentralQueueWindowItems.Record(ctx, int64(window.itemCount), attrs)
 	r.telemetry.LoadbalancerCentralQueueWindowPayloads.Record(ctx, int64(len(window.items)), attrs)
+	reasonAttrs := metric.WithAttributeSet(r.flushAttrs(window.flushReason))
+	r.telemetry.LoadbalancerCentralQueueWindowFlushTotal.Add(ctx, 1, reasonAttrs)
+	if window.compressedBytes < int(r.queue.settings.batching.TargetCompressedBytes) {
+		r.telemetry.LoadbalancerCentralQueueWindowUnderfilledTotal.Add(ctx, 1, reasonAttrs)
+	}
 	r.recordState(ctx)
+}
+
+func (r *centralQueueRuntime) flushAttrs(reason centralQueueFlushReason) attribute.Set {
+	if attrs, ok := r.flushReasonAttrs[reason]; ok {
+		return attrs
+	}
+	return attribute.NewSet(attribute.String("signal", string(r.signal)), attribute.String("reason", string(reason)))
 }
 
 func (r *centralQueueRuntime) recordState(ctx context.Context) {

--- a/exporter/loadbalancingexporter/central_queue_runtime_test.go
+++ b/exporter/loadbalancingexporter/central_queue_runtime_test.go
@@ -1,0 +1,48 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCentralQueueRuntimeShutdownStopsRetryingFailedWindow(t *testing.T) {
+	cfg := CentralQueueConfig{
+		Enabled:            true,
+		PayloadCompression: QueuePayloadCompressionNone,
+		CapacityBytes:      4096,
+		NumConsumers:       1,
+		RequestBatching: CentralQueueBatchingConfig{
+			TargetCompressedBytes: 100,
+			MaxCompressedBytes:    1000,
+			MaxUncompressedBytes:  1000,
+			MaxMergedItems:        10,
+			MaxDelay:              time.Millisecond,
+			LaneCount:             1,
+		},
+	}
+	runtime := newCentralQueueRuntime(cfg, centralQueueSignalLogs, nil)
+	var attempts atomic.Int64
+	runtime.start(func(context.Context, centralQueueWindow) error {
+		attempts.Add(1)
+		return errors.New("backend failed")
+	}, nil)
+
+	require.NoError(t, runtime.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+	require.Eventually(t, func() bool {
+		return attempts.Load() > 0
+	}, time.Second, time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	err := runtime.shutdown(ctx)
+	require.ErrorContains(t, err, "backend failed")
+	require.Less(t, attempts.Load(), int64(10))
+}

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -1,0 +1,240 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCentralQueueAdmissionUsesCompressedBytes(t *testing.T) {
+	q := newCentralQueueForTest(centralQueueTestSettings(100))
+	item := centralQueueTestItem(centralQueueSignalLogs, 1, 60, 600, 10)
+
+	require.NoError(t, q.enqueue(t.Context(), item))
+	require.Equal(t, int64(60), q.currentBytes())
+	require.ErrorIs(t, q.enqueue(t.Context(), item), errCentralQueueFull)
+	require.Equal(t, int64(60), q.currentBytes())
+}
+
+func TestCentralQueueWindowCoalescesByLane(t *testing.T) {
+	q := newCentralQueueForTest(centralQueueTestSettings(4096))
+	keyA := centralQueueKey{signal: centralQueueSignalMetrics, backendID: defaultCentralQueueBackendID, laneID: 1}
+	keyB := centralQueueKey{signal: centralQueueSignalMetrics, backendID: defaultCentralQueueBackendID, laneID: 2}
+
+	require.NoError(t, q.enqueue(t.Context(), centralQueueItem{key: keyA, compressedBytes: 100, uncompressedBytes: 200, itemCount: 1, enqueuedAt: time.Unix(1, 0)}))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueItem{key: keyB, compressedBytes: 100, uncompressedBytes: 200, itemCount: 1, enqueuedAt: time.Unix(2, 0)}))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueItem{key: keyA, compressedBytes: 100, uncompressedBytes: 200, itemCount: 1, enqueuedAt: time.Unix(3, 0)}))
+
+	window, ok := q.nextWindow(t.Context())
+	require.True(t, ok)
+	require.Equal(t, keyA, window.key)
+	require.Len(t, window.items, 2)
+	require.Equal(t, 200, window.compressedBytes)
+	require.Equal(t, time.Unix(1, 0), window.oldestEnqueuedAt)
+
+	window, ok = q.nextWindow(t.Context())
+	require.True(t, ok)
+	require.Equal(t, keyB, window.key)
+	require.Len(t, window.items, 1)
+}
+
+func TestCentralQueueWindowStopsAtTargetCompressedBytes(t *testing.T) {
+	settings := centralQueueTestSettings(4096)
+	settings.batching.TargetCompressedBytes = 250
+	settings.batching.MaxCompressedBytes = 1000
+	q := newCentralQueueForTest(settings)
+
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+
+	window, ok := q.nextWindow(t.Context())
+	require.True(t, ok)
+	require.Len(t, window.items, 3)
+	require.Equal(t, 300, window.compressedBytes)
+	require.Equal(t, int64(100), q.currentBytes())
+}
+
+func TestCentralQueueWindowHonorsHardCaps(t *testing.T) {
+	settings := centralQueueTestSettings(4096)
+	settings.batching.TargetCompressedBytes = 1000
+	settings.batching.MaxCompressedBytes = 250
+	settings.batching.MaxUncompressedBytes = 1000
+	settings.batching.MaxMergedItems = 10
+	q := newCentralQueueForTest(settings)
+
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+
+	window, ok := q.nextWindow(t.Context())
+	require.True(t, ok)
+	require.Len(t, window.items, 2)
+	require.Equal(t, 200, window.compressedBytes)
+	require.Equal(t, int64(100), q.currentBytes())
+}
+
+func TestCentralQueueRejectsOversizedItem(t *testing.T) {
+	settings := centralQueueTestSettings(4096)
+	settings.batching.MaxCompressedBytes = 250
+	q := newCentralQueueForTest(settings)
+
+	err := q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 251, 300, 1))
+	require.ErrorIs(t, err, errCentralQueueItemTooLarge)
+	require.Zero(t, q.currentBytes())
+}
+
+func TestCentralQueueRequeueFrontPreservesBytesAndOrder(t *testing.T) {
+	settings := centralQueueTestSettings(4096)
+	settings.batching.TargetCompressedBytes = 200
+	q := newCentralQueueForTest(settings)
+
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+	window, ok := q.nextWindow(t.Context())
+	require.True(t, ok)
+	require.Equal(t, int64(0), q.currentBytes())
+
+	q.requeueFront(window)
+	require.Equal(t, int64(200), q.currentBytes())
+
+	next, ok := q.nextWindow(t.Context())
+	require.True(t, ok)
+	require.Equal(t, window.key, next.key)
+	require.Len(t, next.items, 2)
+}
+
+func TestCentralQueueWaitsForMaxDelayBeforeSmallWindow(t *testing.T) {
+	settings := centralQueueTestSettings(4096)
+	settings.batching.TargetCompressedBytes = 1000
+	settings.batching.MaxDelay = 20 * time.Millisecond
+	q := newCentralQueueForTest(settings)
+
+	require.NoError(t, q.enqueue(t.Context(), centralQueueItem{
+		key:               centralQueueKey{signal: centralQueueSignalLogs, backendID: defaultCentralQueueBackendID, laneID: 1},
+		compressedBytes:   100,
+		uncompressedBytes: 200,
+		itemCount:         1,
+		enqueuedAt:        time.Now(),
+	}))
+
+	done := make(chan centralQueueWindow, 1)
+	go func() {
+		window, ok := q.nextWindow(t.Context())
+		require.True(t, ok)
+		done <- window
+	}()
+
+	select {
+	case <-done:
+		require.Fail(t, "window flushed before max delay")
+	case <-time.After(5 * time.Millisecond):
+	}
+
+	select {
+	case window := <-done:
+		require.Len(t, window.items, 1)
+	case <-time.After(250 * time.Millisecond):
+		require.Fail(t, "window did not flush after max delay")
+	}
+}
+
+func TestCentralQueueStopDrainsThenStops(t *testing.T) {
+	q := newCentralQueueForTest(centralQueueTestSettings(4096))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)))
+
+	q.stop()
+	require.ErrorIs(t, q.enqueue(t.Context(), centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1)), errCentralQueueStopped)
+
+	window, ok := q.nextWindow(t.Context())
+	require.True(t, ok)
+	require.Len(t, window.items, 1)
+
+	_, ok = q.nextWindow(t.Context())
+	require.False(t, ok)
+}
+
+func TestCentralQueueNextWindowReturnsOnContextCancel(t *testing.T) {
+	q := newCentralQueueForTest(centralQueueTestSettings(4096))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, ok := q.nextWindow(ctx)
+	require.False(t, ok)
+}
+
+func TestCentralQueueOldestAgeAndLaneCount(t *testing.T) {
+	q := newCentralQueueForTest(centralQueueTestSettings(4096))
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueue(t.Context(), centralQueueItem{
+		key:               centralQueueKey{signal: centralQueueSignalLogs, backendID: defaultCentralQueueBackendID, laneID: 1},
+		compressedBytes:   100,
+		uncompressedBytes: 200,
+		itemCount:         1,
+		enqueuedAt:        now.Add(-5 * time.Second),
+	}))
+	require.NoError(t, q.enqueue(t.Context(), centralQueueItem{
+		key:               centralQueueKey{signal: centralQueueSignalLogs, backendID: defaultCentralQueueBackendID, laneID: 2},
+		compressedBytes:   100,
+		uncompressedBytes: 200,
+		itemCount:         1,
+		enqueuedAt:        now.Add(-3 * time.Second),
+	}))
+
+	require.Equal(t, 2, q.activeLaneCount(centralQueueSignalLogs))
+	require.Equal(t, 5*time.Second, q.oldestItemAge(centralQueueSignalLogs, now))
+	require.Zero(t, q.oldestItemAge(centralQueueSignalMetrics, now))
+}
+
+func TestCentralQueueEnqueueHonorsContext(t *testing.T) {
+	q := newCentralQueueForTest(centralQueueTestSettings(4096))
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := q.enqueue(ctx, centralQueueTestItem(centralQueueSignalLogs, 1, 100, 200, 1))
+	require.True(t, errors.Is(err, context.Canceled))
+	require.Zero(t, q.currentBytes())
+}
+
+func newCentralQueueForTest(settings centralQueueSettings) *centralQueue {
+	if settings.now == nil {
+		settings.now = time.Now
+	}
+	return newCentralQueue(settings)
+}
+
+func centralQueueTestSettings(capacity int64) centralQueueSettings {
+	return centralQueueSettings{
+		capacityBytes: capacity,
+		batching: CentralQueueBatchingConfig{
+			TargetCompressedBytes: 256,
+			MaxCompressedBytes:    1024,
+			MaxUncompressedBytes:  2048,
+			MaxMergedItems:        10,
+			MaxDelay:              250 * time.Millisecond,
+			LaneCount:             64,
+		},
+		now: time.Now,
+	}
+}
+
+func centralQueueTestItem(signal centralQueueSignal, laneID uint32, compressedBytes, uncompressedBytes, itemCount int) centralQueueItem {
+	return centralQueueItem{
+		key: centralQueueKey{
+			signal:    signal,
+			backendID: defaultCentralQueueBackendID,
+			laneID:    laneID,
+		},
+		compressedBytes:   compressedBytes,
+		uncompressedBytes: uncompressedBytes,
+		itemCount:         itemCount,
+		enqueuedAt:        time.Now().Add(-time.Second),
+	}
+}

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -59,6 +59,7 @@ func TestCentralQueueWindowStopsAtTargetCompressedBytes(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, window.items, 3)
 	require.Equal(t, 300, window.compressedBytes)
+	require.Equal(t, centralQueueFlushReasonTargetReached, window.flushReason)
 	require.Equal(t, int64(100), q.currentBytes())
 }
 
@@ -78,6 +79,7 @@ func TestCentralQueueWindowHonorsHardCaps(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, window.items, 2)
 	require.Equal(t, 200, window.compressedBytes)
+	require.Equal(t, centralQueueFlushReasonHardCap, window.flushReason)
 	require.Equal(t, int64(100), q.currentBytes())
 }
 
@@ -141,6 +143,7 @@ func TestCentralQueueWaitsForMaxDelayBeforeSmallWindow(t *testing.T) {
 	select {
 	case window := <-done:
 		require.Len(t, window.items, 1)
+		require.Equal(t, centralQueueFlushReasonMaxDelayLowTraffic, window.flushReason)
 	case <-time.After(250 * time.Millisecond):
 		require.Fail(t, "window did not flush after max delay")
 	}
@@ -156,6 +159,7 @@ func TestCentralQueueStopDrainsThenStops(t *testing.T) {
 	window, ok := q.nextWindow(t.Context())
 	require.True(t, ok)
 	require.Len(t, window.items, 1)
+	require.Equal(t, centralQueueFlushReasonShutdown, window.flushReason)
 
 	_, ok = q.nextWindow(t.Context())
 	require.False(t, ok)

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	TimeoutSettings           exporterhelper.TimeoutConfig `mapstructure:",squash"`
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 	QueueSettings             QueueSettings        `mapstructure:"sending_queue"`
+	CentralQueue              CentralQueueConfig   `mapstructure:"central_queue"`
 	LogBatcher                LogBatcherConfig     `mapstructure:"log_batcher"`
 	LogRouting                LogRoutingConfig     `mapstructure:"log_routing"`
 	MetricBatcher             MetricBatcherConfig  `mapstructure:"metric_batcher"`
@@ -241,6 +242,13 @@ func (cfg *Config) Validate() error {
 	if err := cfg.QueueSettings.Validate(); err != nil {
 		return err
 	}
+	cfg.CentralQueue.ApplyDefaults()
+	if err := cfg.CentralQueue.Validate(); err != nil {
+		return err
+	}
+	if err := cfg.validateSingleBacklogOwner(); err != nil {
+		return err
+	}
 	if err := cfg.LogBatcher.Validate(); err != nil {
 		return err
 	}
@@ -248,6 +256,30 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 	return cfg.EndpointHealth.Validate()
+}
+
+func (cfg *Config) validateSingleBacklogOwner() error {
+	if cfg.CentralQueue.Enabled {
+		if cfg.QueueSettings.QueueConfig.HasValue() {
+			return errors.New("central_queue.enabled cannot be combined with sending_queue.enabled because central queue mode must be the only backlog owner")
+		}
+		if cfg.LogBatcher.Enabled {
+			return errors.New("central_queue.enabled cannot be combined with log_batcher.enabled because central queue mode must be the only backlog owner")
+		}
+		if cfg.MetricBatcher.Enabled {
+			return errors.New("central_queue.enabled cannot be combined with metric_batcher.enabled because central queue mode must be the only backlog owner")
+		}
+	}
+	if !cfg.QueueSettings.QueueConfig.HasValue() {
+		return nil
+	}
+	if cfg.LogBatcher.Enabled {
+		return errors.New("sending_queue cannot be enabled with log_batcher because central queue mode must be the only backlog owner")
+	}
+	if cfg.MetricBatcher.Enabled {
+		return errors.New("sending_queue cannot be enabled with metric_batcher because central queue mode must be the only backlog owner")
+	}
+	return nil
 }
 
 func (c LogBatcherConfig) Validate() error {

--- a/exporter/loadbalancingexporter/config.schema.yaml
+++ b/exporter/loadbalancingexporter/config.schema.yaml
@@ -54,7 +54,6 @@ $defs:
       payload_compression:
         type: string
         enum:
-          - none
           - snappy
           - zstd
       request_batching:

--- a/exporter/loadbalancingexporter/config.schema.yaml
+++ b/exporter/loadbalancingexporter/config.schema.yaml
@@ -18,6 +18,47 @@ $defs:
       timeout:
         type: string
         format: duration
+  central_queue_batching_config:
+    type: object
+    properties:
+      lane_count:
+        type: integer
+        minimum: 1
+      max_compressed_bytes:
+        type: integer
+        minimum: 1
+      max_delay:
+        type: string
+        format: duration
+        description: Must be greater than 0 when central_queue.enabled is true.
+      max_merged_items:
+        type: integer
+        minimum: 1
+      max_uncompressed_bytes:
+        type: integer
+        minimum: 1
+      target_compressed_bytes:
+        type: integer
+        minimum: 1
+  central_queue_config:
+    type: object
+    properties:
+      capacity_bytes:
+        type: integer
+        minimum: 1
+      enabled:
+        type: boolean
+      num_consumers:
+        type: integer
+        minimum: 1
+      payload_compression:
+        type: string
+        enum:
+          - none
+          - snappy
+          - zstd
+      request_batching:
+        $ref: central_queue_batching_config
   dns_resolver:
     description: DNSResolver defines the configuration for the DNS resolver
     type: object
@@ -131,6 +172,8 @@ $defs:
 description: Config defines configuration for the exporter.
 type: object
 properties:
+  central_queue:
+    $ref: central_queue_config
   endpoint_health:
     $ref: endpoint_health_config
   log_routing:

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -167,6 +167,11 @@ func TestCentralQueueValidate(t *testing.T) {
 			errString: "central_queue.payload_compression",
 		},
 		{
+			name:      "none compression",
+			mutate:    func(c *CentralQueueConfig) { c.PayloadCompression = QueuePayloadCompressionNone },
+			errString: "central_queue.payload_compression",
+		},
+		{
 			name:      "zero capacity",
 			mutate:    func(c *CentralQueueConfig) { c.CapacityBytes = -1 },
 			errString: "central_queue.capacity_bytes",

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -121,6 +121,125 @@ func TestConfigValidateMetricBatcher(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 }
 
+func TestConfigValidateSingleBacklogOwner(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.QueueSettings.QueueConfig = configoptional.Some(exporterhelper.NewDefaultQueueConfig())
+	require.NoError(t, cfg.Validate())
+
+	cfg.LogBatcher.Enabled = true
+	require.ErrorContains(t, cfg.Validate(), "sending_queue cannot be enabled with log_batcher because central queue mode must be the only backlog owner")
+
+	cfg.LogBatcher.Enabled = false
+	cfg.MetricBatcher.Enabled = true
+	require.ErrorContains(t, cfg.Validate(), "sending_queue cannot be enabled with metric_batcher because central queue mode must be the only backlog owner")
+
+	cfg.QueueSettings.QueueConfig = configoptional.None[exporterhelper.QueueBatchConfig]()
+	require.NoError(t, cfg.Validate())
+}
+
+func TestCentralQueueDefaultConfig(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	require.False(t, cfg.CentralQueue.Enabled)
+
+	cfg.CentralQueue.Enabled = true
+	require.NoError(t, cfg.Validate())
+
+	require.Equal(t, QueuePayloadCompressionZstd, cfg.CentralQueue.PayloadCompression)
+	require.Equal(t, int64(16<<30), cfg.CentralQueue.CapacityBytes)
+	require.Equal(t, 60, cfg.CentralQueue.NumConsumers)
+	require.Equal(t, int64(256<<10), cfg.CentralQueue.RequestBatching.TargetCompressedBytes)
+	require.Equal(t, int64(1<<20), cfg.CentralQueue.RequestBatching.MaxCompressedBytes)
+	require.Equal(t, int64(4<<20), cfg.CentralQueue.RequestBatching.MaxUncompressedBytes)
+	require.Equal(t, 10000, cfg.CentralQueue.RequestBatching.MaxMergedItems)
+	require.Equal(t, 250*time.Millisecond, cfg.CentralQueue.RequestBatching.MaxDelay)
+	require.Equal(t, 64, cfg.CentralQueue.RequestBatching.LaneCount)
+}
+
+func TestCentralQueueValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*CentralQueueConfig)
+		errString string
+	}{
+		{
+			name:      "invalid compression",
+			mutate:    func(c *CentralQueueConfig) { c.PayloadCompression = QueuePayloadCompression("brotli") },
+			errString: "central_queue.payload_compression",
+		},
+		{
+			name:      "zero capacity",
+			mutate:    func(c *CentralQueueConfig) { c.CapacityBytes = -1 },
+			errString: "central_queue.capacity_bytes",
+		},
+		{
+			name:      "zero consumers",
+			mutate:    func(c *CentralQueueConfig) { c.NumConsumers = -1 },
+			errString: "central_queue.num_consumers",
+		},
+		{
+			name:      "zero target bytes",
+			mutate:    func(c *CentralQueueConfig) { c.RequestBatching.TargetCompressedBytes = -1 },
+			errString: "central_queue.request_batching.target_compressed_bytes",
+		},
+		{
+			name: "max below target",
+			mutate: func(c *CentralQueueConfig) {
+				c.RequestBatching.TargetCompressedBytes = 100
+				c.RequestBatching.MaxCompressedBytes = 99
+			},
+			errString: "central_queue.request_batching.max_compressed_bytes",
+		},
+		{
+			name:      "zero uncompressed cap",
+			mutate:    func(c *CentralQueueConfig) { c.RequestBatching.MaxUncompressedBytes = -1 },
+			errString: "central_queue.request_batching.max_uncompressed_bytes",
+		},
+		{
+			name:      "zero merged items",
+			mutate:    func(c *CentralQueueConfig) { c.RequestBatching.MaxMergedItems = -1 },
+			errString: "central_queue.request_batching.max_merged_items",
+		},
+		{
+			name:      "zero delay",
+			mutate:    func(c *CentralQueueConfig) { c.RequestBatching.MaxDelay = -time.Millisecond },
+			errString: "central_queue.request_batching.max_delay",
+		},
+		{
+			name:      "zero lanes",
+			mutate:    func(c *CentralQueueConfig) { c.RequestBatching.LaneCount = -1 },
+			errString: "central_queue.request_batching.lane_count",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			cfg.CentralQueue.Enabled = true
+			cfg.CentralQueue.ApplyDefaults()
+			tt.mutate(&cfg.CentralQueue)
+
+			require.ErrorContains(t, cfg.Validate(), tt.errString)
+		})
+	}
+}
+
+func TestCentralQueueRejectsMultipleBacklogOwners(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	cfg.CentralQueue.Enabled = true
+	cfg.QueueSettings.QueueConfig = configoptional.Some(exporterhelper.NewDefaultQueueConfig())
+	require.ErrorContains(t, cfg.Validate(), "central_queue.enabled cannot be combined with sending_queue.enabled")
+
+	cfg = createDefaultConfig().(*Config)
+	cfg.CentralQueue.Enabled = true
+	cfg.LogBatcher.Enabled = true
+	require.ErrorContains(t, cfg.Validate(), "central_queue.enabled cannot be combined with log_batcher.enabled")
+
+	cfg = createDefaultConfig().(*Config)
+	cfg.CentralQueue.Enabled = true
+	cfg.MetricBatcher.Enabled = true
+	require.ErrorContains(t, cfg.Validate(), "central_queue.enabled cannot be combined with metric_batcher.enabled")
+}
+
 func TestConfigValidateEndpointHealth(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	require.False(t, cfg.EndpointHealth.Enabled)
@@ -429,6 +548,52 @@ func TestLoadConfigWithLogRouting(t *testing.T) {
 
 	require.NoError(t, conf.Unmarshal(cfg))
 	require.True(t, cfg.LogRouting.IgnoreTraceID)
+}
+
+func TestLoadConfigWithCentralQueue(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	conf := confmap.NewFromStringMap(map[string]any{
+		"protocol": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "localhost:4317",
+				"tls": map[string]any{
+					"insecure": true,
+				},
+			},
+		},
+		"resolver": map[string]any{
+			"static": map[string]any{
+				"hostnames": []string{"localhost:4317"},
+			},
+		},
+		"central_queue": map[string]any{
+			"enabled":             true,
+			"payload_compression": "zstd",
+			"capacity_bytes":      4096,
+			"num_consumers":       3,
+			"request_batching": map[string]any{
+				"target_compressed_bytes": 512,
+				"max_compressed_bytes":    1024,
+				"max_uncompressed_bytes":  2048,
+				"max_merged_items":        11,
+				"max_delay":               "150ms",
+				"lane_count":              7,
+			},
+		},
+	})
+
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.NoError(t, cfg.Validate())
+	require.True(t, cfg.CentralQueue.Enabled)
+	require.Equal(t, QueuePayloadCompressionZstd, cfg.CentralQueue.PayloadCompression)
+	require.Equal(t, int64(4096), cfg.CentralQueue.CapacityBytes)
+	require.Equal(t, 3, cfg.CentralQueue.NumConsumers)
+	require.Equal(t, int64(512), cfg.CentralQueue.RequestBatching.TargetCompressedBytes)
+	require.Equal(t, int64(1024), cfg.CentralQueue.RequestBatching.MaxCompressedBytes)
+	require.Equal(t, int64(2048), cfg.CentralQueue.RequestBatching.MaxUncompressedBytes)
+	require.Equal(t, 11, cfg.CentralQueue.RequestBatching.MaxMergedItems)
+	require.Equal(t, 150*time.Millisecond, cfg.CentralQueue.RequestBatching.MaxDelay)
+	require.Equal(t, 7, cfg.CentralQueue.RequestBatching.LaneCount)
 }
 
 func TestLoadConfigWithMetricBatcher(t *testing.T) {

--- a/exporter/loadbalancingexporter/documentation.md
+++ b/exporter/loadbalancingexporter/documentation.md
@@ -55,7 +55,7 @@ Number of times a backend endpoint was quarantined.
 | Name | Description | Values | Semantic Convention |
 | ---- | ----------- | ------ | ------------------- |
 | endpoint | The endpoint of the backend | Any Str | - |
-| reason | Low-cardinality endpoint health reason | Any Str | - |
+| reason | Low-cardinality reason | Any Str | - |
 
 ### otelcol_loadbalancer_backend_request_bytes
 
@@ -116,7 +116,7 @@ Number of endpoint-failure reroute attempts.
 | ---- | ----------- | ------ | ------------------- |
 | signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
 | result | Reroute result | Str: ``success``, ``failure``, ``skipped`` | - |
-| reason | Low-cardinality endpoint health reason | Any Str | - |
+| reason | Low-cardinality reason | Any Str | - |
 
 ### otelcol_loadbalancer_backend_stale_total
 
@@ -160,7 +160,7 @@ Number of times a backend endpoint was admitted after quarantine.
 | Name | Description | Values | Semantic Convention |
 | ---- | ----------- | ------ | ------------------- |
 | endpoint | The endpoint of the backend | Any Str | - |
-| reason | Low-cardinality endpoint health reason | Any Str | - |
+| reason | Low-cardinality reason | Any Str | - |
 
 ### otelcol_loadbalancer_central_queue_active_lanes
 
@@ -247,6 +247,21 @@ Compressed bytes drained from the central queue for each backend request window.
 | ---- | ----------- | ------ | ------------------- |
 | signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
 
+### otelcol_loadbalancer_central_queue_window_flush_total
+
+Number of central queue windows flushed by bounded reason.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {windows} | Sum | Int | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+| reason | Low-cardinality reason | Any Str | - |
+
 ### otelcol_loadbalancer_central_queue_window_items
 
 Number of signal items coalesced in each central queue backend request window.
@@ -288,6 +303,21 @@ Uncompressed bytes represented by each central queue backend request window.
 | Name | Description | Values | Semantic Convention |
 | ---- | ----------- | ------ | ------------------- |
 | signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_central_queue_window_underfilled_total
+
+Number of central queue windows sent below target compressed bytes by bounded reason.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {windows} | Sum | Int | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+| reason | Low-cardinality reason | Any Str | - |
 
 ### otelcol_loadbalancer_num_backend_updates
 

--- a/exporter/loadbalancingexporter/documentation.md
+++ b/exporter/loadbalancingexporter/documentation.md
@@ -57,6 +57,51 @@ Number of times a backend endpoint was quarantined.
 | endpoint | The endpoint of the backend | Any Str | - |
 | reason | Low-cardinality endpoint health reason | Any Str | - |
 
+### otelcol_loadbalancer_backend_request_bytes
+
+Backend request payload size in bytes.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Histogram | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| endpoint | The endpoint of the backend | Any Str | - |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_backend_request_items
+
+Number of signal items in each backend request.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {items} | Histogram | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| endpoint | The endpoint of the backend | Any Str | - |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_backend_request_total
+
+Number of backend requests sent by signal.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {requests} | Sum | Int | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| endpoint | The endpoint of the backend | Any Str | - |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
 ### otelcol_loadbalancer_backend_reroute_total
 
 Number of endpoint-failure reroute attempts.
@@ -116,6 +161,133 @@ Number of times a backend endpoint was admitted after quarantine.
 | ---- | ----------- | ------ | ------------------- |
 | endpoint | The endpoint of the backend | Any Str | - |
 | reason | Low-cardinality endpoint health reason | Any Str | - |
+
+### otelcol_loadbalancer_central_queue_active_lanes
+
+Number of central queue lanes with queued telemetry.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {lanes} | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_central_queue_capacity_bytes
+
+Configured central queue capacity in compressed bytes.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_central_queue_enqueue_total
+
+Number of central queue enqueue attempts by result.
+
+| Unit | Metric Type | Value Type | Monotonic | Stability |
+| ---- | ----------- | ---------- | --------- | --------- |
+| {items} | Sum | Int | true | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+| result | Reroute result | Str: ``success``, ``failure``, ``skipped`` | - |
+
+### otelcol_loadbalancer_central_queue_oldest_item_age
+
+Age in milliseconds of the oldest item waiting in the central queue.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| ms | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_central_queue_size_bytes
+
+Current central queue size in compressed bytes.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Gauge | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_central_queue_window_compressed_bytes
+
+Compressed bytes drained from the central queue for each backend request window.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Histogram | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_central_queue_window_items
+
+Number of signal items coalesced in each central queue backend request window.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {items} | Histogram | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_central_queue_window_payloads
+
+Number of queued payloads merged into each central queue backend request window.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| {payloads} | Histogram | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
+
+### otelcol_loadbalancer_central_queue_window_uncompressed_bytes
+
+Uncompressed bytes represented by each central queue backend request window.
+
+| Unit | Metric Type | Value Type | Stability |
+| ---- | ----------- | ---------- | --------- |
+| By | Histogram | Int | Development |
+
+#### Attributes
+
+| Name | Description | Values | Semantic Convention |
+| ---- | ----------- | ------ | ------------------- |
+| signal | Telemetry signal | Str: ``traces``, ``logs``, ``metrics`` | - |
 
 ### otelcol_loadbalancer_num_backend_updates
 

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -226,6 +226,9 @@ func shutdownWithCodec(shutdown component.ShutdownFunc, codec *queuePayloadCodec
 }
 
 func queueConfigForExport(cfg *Config) (configoptional.Optional[exporterhelper.QueueBatchConfig], bool) {
+	if cfg.CentralQueue.Enabled {
+		return configoptional.None[exporterhelper.QueueBatchConfig](), false
+	}
 	if !cfg.QueueSettings.QueueConfig.HasValue() {
 		return configoptional.None[exporterhelper.QueueBatchConfig](), false
 	}

--- a/exporter/loadbalancingexporter/generated_package_test.go
+++ b/exporter/loadbalancingexporter/generated_package_test.go
@@ -3,9 +3,8 @@
 package loadbalancingexporter
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/exporter/loadbalancingexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/loadbalancingexporter/internal/metadata/generated_telemetry.go
@@ -43,9 +43,11 @@ type TelemetryBuilder struct {
 	LoadbalancerCentralQueueOldestItemAge           metric.Int64Gauge
 	LoadbalancerCentralQueueSizeBytes               metric.Int64Gauge
 	LoadbalancerCentralQueueWindowCompressedBytes   metric.Int64Histogram
+	LoadbalancerCentralQueueWindowFlushTotal        metric.Int64Counter
 	LoadbalancerCentralQueueWindowItems             metric.Int64Histogram
 	LoadbalancerCentralQueueWindowPayloads          metric.Int64Histogram
 	LoadbalancerCentralQueueWindowUncompressedBytes metric.Int64Histogram
+	LoadbalancerCentralQueueWindowUnderfilledTotal  metric.Int64Counter
 	LoadbalancerNumBackendUpdates                   metric.Int64Counter
 	LoadbalancerNumBackends                         metric.Int64Gauge
 	LoadbalancerNumResolutions                      metric.Int64Counter
@@ -183,6 +185,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueWindowFlushTotal, err = builder.meter.Int64Counter(
+		"otelcol_loadbalancer_central_queue_window_flush_total",
+		metric.WithDescription("Number of central queue windows flushed by bounded reason. [Development]"),
+		metric.WithUnit("{windows}"),
+	)
+	errs = errors.Join(errs, err)
 	builder.LoadbalancerCentralQueueWindowItems, err = builder.meter.Int64Histogram(
 		"otelcol_loadbalancer_central_queue_window_items",
 		metric.WithDescription("Number of signal items coalesced in each central queue backend request window. [Development]"),
@@ -199,6 +207,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_loadbalancer_central_queue_window_uncompressed_bytes",
 		metric.WithDescription("Uncompressed bytes represented by each central queue backend request window. [Development]"),
 		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueWindowUnderfilledTotal, err = builder.meter.Int64Counter(
+		"otelcol_loadbalancer_central_queue_window_underfilled_total",
+		metric.WithDescription("Number of central queue windows sent below target compressed bytes by bounded reason. [Development]"),
+		metric.WithUnit("{windows}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.LoadbalancerNumBackendUpdates, err = builder.meter.Int64Counter(

--- a/exporter/loadbalancingexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/loadbalancingexporter/internal/metadata/generated_telemetry.go
@@ -6,9 +6,10 @@ import (
 	"errors"
 	"sync"
 
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+
+	"go.opentelemetry.io/collector/component"
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
@@ -22,20 +23,32 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter                                metric.Meter
-	mu                                   sync.Mutex
-	registrations                        []metric.Registration
-	LoadbalancerBackendFailOpenTotal     metric.Int64Counter
-	LoadbalancerBackendLatency           metric.Int64Histogram
-	LoadbalancerBackendOutcome           metric.Int64Counter
-	LoadbalancerBackendQuarantineTotal   metric.Int64Counter
-	LoadbalancerBackendRerouteTotal      metric.Int64Counter
-	LoadbalancerBackendStaleTotal        metric.Int64Counter
-	LoadbalancerBackendState             metric.Int64Gauge
-	LoadbalancerBackendUnquarantineTotal metric.Int64Counter
-	LoadbalancerNumBackendUpdates        metric.Int64Counter
-	LoadbalancerNumBackends              metric.Int64Gauge
-	LoadbalancerNumResolutions           metric.Int64Counter
+	meter                                           metric.Meter
+	mu                                              sync.Mutex
+	registrations                                   []metric.Registration
+	LoadbalancerBackendFailOpenTotal                metric.Int64Counter
+	LoadbalancerBackendLatency                      metric.Int64Histogram
+	LoadbalancerBackendOutcome                      metric.Int64Counter
+	LoadbalancerBackendQuarantineTotal              metric.Int64Counter
+	LoadbalancerBackendRequestBytes                 metric.Int64Histogram
+	LoadbalancerBackendRequestItems                 metric.Int64Histogram
+	LoadbalancerBackendRequestTotal                 metric.Int64Counter
+	LoadbalancerBackendRerouteTotal                 metric.Int64Counter
+	LoadbalancerBackendStaleTotal                   metric.Int64Counter
+	LoadbalancerBackendState                        metric.Int64Gauge
+	LoadbalancerBackendUnquarantineTotal            metric.Int64Counter
+	LoadbalancerCentralQueueActiveLanes             metric.Int64Gauge
+	LoadbalancerCentralQueueCapacityBytes           metric.Int64Gauge
+	LoadbalancerCentralQueueEnqueueTotal            metric.Int64Counter
+	LoadbalancerCentralQueueOldestItemAge           metric.Int64Gauge
+	LoadbalancerCentralQueueSizeBytes               metric.Int64Gauge
+	LoadbalancerCentralQueueWindowCompressedBytes   metric.Int64Histogram
+	LoadbalancerCentralQueueWindowItems             metric.Int64Histogram
+	LoadbalancerCentralQueueWindowPayloads          metric.Int64Histogram
+	LoadbalancerCentralQueueWindowUncompressedBytes metric.Int64Histogram
+	LoadbalancerNumBackendUpdates                   metric.Int64Counter
+	LoadbalancerNumBackends                         metric.Int64Gauge
+	LoadbalancerNumResolutions                      metric.Int64Counter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -92,6 +105,24 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithUnit("{quarantines}"),
 	)
 	errs = errors.Join(errs, err)
+	builder.LoadbalancerBackendRequestBytes, err = builder.meter.Int64Histogram(
+		"otelcol_loadbalancer_backend_request_bytes",
+		metric.WithDescription("Backend request payload size in bytes. [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerBackendRequestItems, err = builder.meter.Int64Histogram(
+		"otelcol_loadbalancer_backend_request_items",
+		metric.WithDescription("Number of signal items in each backend request. [Development]"),
+		metric.WithUnit("{items}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerBackendRequestTotal, err = builder.meter.Int64Counter(
+		"otelcol_loadbalancer_backend_request_total",
+		metric.WithDescription("Number of backend requests sent by signal. [Development]"),
+		metric.WithUnit("{requests}"),
+	)
+	errs = errors.Join(errs, err)
 	builder.LoadbalancerBackendRerouteTotal, err = builder.meter.Int64Counter(
 		"otelcol_loadbalancer_backend_reroute_total",
 		metric.WithDescription("Number of endpoint-failure reroute attempts. [Development]"),
@@ -114,6 +145,60 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		"otelcol_loadbalancer_backend_unquarantine_total",
 		metric.WithDescription("Number of times a backend endpoint was admitted after quarantine. [Development]"),
 		metric.WithUnit("{unquarantines}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueActiveLanes, err = builder.meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_active_lanes",
+		metric.WithDescription("Number of central queue lanes with queued telemetry. [Development]"),
+		metric.WithUnit("{lanes}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueCapacityBytes, err = builder.meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_capacity_bytes",
+		metric.WithDescription("Configured central queue capacity in compressed bytes. [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueEnqueueTotal, err = builder.meter.Int64Counter(
+		"otelcol_loadbalancer_central_queue_enqueue_total",
+		metric.WithDescription("Number of central queue enqueue attempts by result. [Development]"),
+		metric.WithUnit("{items}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueOldestItemAge, err = builder.meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_oldest_item_age",
+		metric.WithDescription("Age in milliseconds of the oldest item waiting in the central queue. [Development]"),
+		metric.WithUnit("ms"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueSizeBytes, err = builder.meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_size_bytes",
+		metric.WithDescription("Current central queue size in compressed bytes. [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueWindowCompressedBytes, err = builder.meter.Int64Histogram(
+		"otelcol_loadbalancer_central_queue_window_compressed_bytes",
+		metric.WithDescription("Compressed bytes drained from the central queue for each backend request window. [Development]"),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueWindowItems, err = builder.meter.Int64Histogram(
+		"otelcol_loadbalancer_central_queue_window_items",
+		metric.WithDescription("Number of signal items coalesced in each central queue backend request window. [Development]"),
+		metric.WithUnit("{items}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueWindowPayloads, err = builder.meter.Int64Histogram(
+		"otelcol_loadbalancer_central_queue_window_payloads",
+		metric.WithDescription("Number of queued payloads merged into each central queue backend request window. [Development]"),
+		metric.WithUnit("{payloads}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.LoadbalancerCentralQueueWindowUncompressedBytes, err = builder.meter.Int64Histogram(
+		"otelcol_loadbalancer_central_queue_window_uncompressed_bytes",
+		metric.WithDescription("Uncompressed bytes represented by each central queue backend request window. [Development]"),
+		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
 	builder.LoadbalancerNumBackendUpdates, err = builder.meter.Int64Counter(

--- a/exporter/loadbalancingexporter/internal/metadata/generated_telemetry_test.go
+++ b/exporter/loadbalancingexporter/internal/metadata/generated_telemetry_test.go
@@ -6,14 +6,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/metric"
 	embeddedmetric "go.opentelemetry.io/otel/metric/embedded"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 	embeddedtrace "go.opentelemetry.io/otel/trace/embedded"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 type mockMeter struct {

--- a/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest.go
@@ -279,6 +279,22 @@ func AssertEqualLoadbalancerCentralQueueWindowCompressedBytes(t *testing.T, tt *
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualLoadbalancerCentralQueueWindowFlushTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_window_flush_total",
+		Description: "Number of central queue windows flushed by bounded reason. [Development]",
+		Unit:        "{windows}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_window_flush_total")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualLoadbalancerCentralQueueWindowItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_loadbalancer_central_queue_window_items",
@@ -320,6 +336,22 @@ func AssertEqualLoadbalancerCentralQueueWindowUncompressedBytes(t *testing.T, tt
 		},
 	}
 	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_window_uncompressed_bytes")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueWindowUnderfilledTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_window_underfilled_total",
+		Description: "Number of central queue windows sent below target compressed bytes by bounded reason. [Development]",
+		Unit:        "{windows}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_window_underfilled_total")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest.go
@@ -84,6 +84,52 @@ func AssertEqualLoadbalancerBackendQuarantineTotal(t *testing.T, tt *componentte
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }
 
+func AssertEqualLoadbalancerBackendRequestBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_backend_request_bytes",
+		Description: "Backend request payload size in bytes. [Development]",
+		Unit:        "By",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_backend_request_bytes")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerBackendRequestItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_backend_request_items",
+		Description: "Number of signal items in each backend request. [Development]",
+		Unit:        "{items}",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_backend_request_items")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerBackendRequestTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_backend_request_total",
+		Description: "Number of backend requests sent by signal. [Development]",
+		Unit:        "{requests}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_backend_request_total")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
 func AssertEqualLoadbalancerBackendRerouteTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_loadbalancer_backend_reroute_total",
@@ -142,6 +188,138 @@ func AssertEqualLoadbalancerBackendUnquarantineTotal(t *testing.T, tt *component
 		},
 	}
 	got, err := tt.GetMetric("otelcol_loadbalancer_backend_unquarantine_total")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueActiveLanes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_active_lanes",
+		Description: "Number of central queue lanes with queued telemetry. [Development]",
+		Unit:        "{lanes}",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_active_lanes")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueCapacityBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_capacity_bytes",
+		Description: "Configured central queue capacity in compressed bytes. [Development]",
+		Unit:        "By",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_capacity_bytes")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueEnqueueTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_enqueue_total",
+		Description: "Number of central queue enqueue attempts by result. [Development]",
+		Unit:        "{items}",
+		Data: metricdata.Sum[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			IsMonotonic: true,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_enqueue_total")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueOldestItemAge(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_oldest_item_age",
+		Description: "Age in milliseconds of the oldest item waiting in the central queue. [Development]",
+		Unit:        "ms",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_oldest_item_age")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueSizeBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_size_bytes",
+		Description: "Current central queue size in compressed bytes. [Development]",
+		Unit:        "By",
+		Data: metricdata.Gauge[int64]{
+			DataPoints: dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_size_bytes")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueWindowCompressedBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_window_compressed_bytes",
+		Description: "Compressed bytes drained from the central queue for each backend request window. [Development]",
+		Unit:        "By",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_window_compressed_bytes")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueWindowItems(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_window_items",
+		Description: "Number of signal items coalesced in each central queue backend request window. [Development]",
+		Unit:        "{items}",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_window_items")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueWindowPayloads(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_window_payloads",
+		Description: "Number of queued payloads merged into each central queue backend request window. [Development]",
+		Unit:        "{payloads}",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_window_payloads")
+	require.NoError(t, err)
+	metricdatatest.AssertEqual(t, want, got, opts...)
+}
+
+func AssertEqualLoadbalancerCentralQueueWindowUncompressedBytes(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.HistogramDataPoint[int64], opts ...metricdatatest.Option) {
+	want := metricdata.Metrics{
+		Name:        "otelcol_loadbalancer_central_queue_window_uncompressed_bytes",
+		Description: "Uncompressed bytes represented by each central queue backend request window. [Development]",
+		Unit:        "By",
+		Data: metricdata.Histogram[int64]{
+			Temporality: metricdata.CumulativeTemporality,
+			DataPoints:  dps,
+		},
+	}
+	got, err := tt.GetMetric("otelcol_loadbalancer_central_queue_window_uncompressed_bytes")
 	require.NoError(t, err)
 	metricdatatest.AssertEqual(t, want, got, opts...)
 }

--- a/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
+
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 )
@@ -23,10 +24,22 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.LoadbalancerBackendLatency.Record(context.Background(), 1)
 	tb.LoadbalancerBackendOutcome.Add(context.Background(), 1)
 	tb.LoadbalancerBackendQuarantineTotal.Add(context.Background(), 1)
+	tb.LoadbalancerBackendRequestBytes.Record(context.Background(), 1)
+	tb.LoadbalancerBackendRequestItems.Record(context.Background(), 1)
+	tb.LoadbalancerBackendRequestTotal.Add(context.Background(), 1)
 	tb.LoadbalancerBackendRerouteTotal.Add(context.Background(), 1)
 	tb.LoadbalancerBackendStaleTotal.Add(context.Background(), 1)
 	tb.LoadbalancerBackendState.Record(context.Background(), 1)
 	tb.LoadbalancerBackendUnquarantineTotal.Add(context.Background(), 1)
+	tb.LoadbalancerCentralQueueActiveLanes.Record(context.Background(), 1)
+	tb.LoadbalancerCentralQueueCapacityBytes.Record(context.Background(), 1)
+	tb.LoadbalancerCentralQueueEnqueueTotal.Add(context.Background(), 1)
+	tb.LoadbalancerCentralQueueOldestItemAge.Record(context.Background(), 1)
+	tb.LoadbalancerCentralQueueSizeBytes.Record(context.Background(), 1)
+	tb.LoadbalancerCentralQueueWindowCompressedBytes.Record(context.Background(), 1)
+	tb.LoadbalancerCentralQueueWindowItems.Record(context.Background(), 1)
+	tb.LoadbalancerCentralQueueWindowPayloads.Record(context.Background(), 1)
+	tb.LoadbalancerCentralQueueWindowUncompressedBytes.Record(context.Background(), 1)
 	tb.LoadbalancerNumBackendUpdates.Add(context.Background(), 1)
 	tb.LoadbalancerNumBackends.Record(context.Background(), 1)
 	tb.LoadbalancerNumResolutions.Add(context.Background(), 1)
@@ -42,6 +55,15 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualLoadbalancerBackendQuarantineTotal(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerBackendRequestBytes(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerBackendRequestItems(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerBackendRequestTotal(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualLoadbalancerBackendRerouteTotal(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
@@ -53,6 +75,33 @@ func TestSetupTelemetry(t *testing.T) {
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualLoadbalancerBackendUnquarantineTotal(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueActiveLanes(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueCapacityBytes(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueEnqueueTotal(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueOldestItemAge(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueSizeBytes(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueWindowCompressedBytes(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueWindowItems(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueWindowPayloads(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueWindowUncompressedBytes(t, testTel,
+		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualLoadbalancerNumBackendUpdates(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},

--- a/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest_test.go
+++ b/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest_test.go
@@ -10,9 +10,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 
-	"go.opentelemetry.io/collector/component/componenttest"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 func TestSetupTelemetry(t *testing.T) {
@@ -37,9 +36,11 @@ func TestSetupTelemetry(t *testing.T) {
 	tb.LoadbalancerCentralQueueOldestItemAge.Record(context.Background(), 1)
 	tb.LoadbalancerCentralQueueSizeBytes.Record(context.Background(), 1)
 	tb.LoadbalancerCentralQueueWindowCompressedBytes.Record(context.Background(), 1)
+	tb.LoadbalancerCentralQueueWindowFlushTotal.Add(context.Background(), 1)
 	tb.LoadbalancerCentralQueueWindowItems.Record(context.Background(), 1)
 	tb.LoadbalancerCentralQueueWindowPayloads.Record(context.Background(), 1)
 	tb.LoadbalancerCentralQueueWindowUncompressedBytes.Record(context.Background(), 1)
+	tb.LoadbalancerCentralQueueWindowUnderfilledTotal.Add(context.Background(), 1)
 	tb.LoadbalancerNumBackendUpdates.Add(context.Background(), 1)
 	tb.LoadbalancerNumBackends.Record(context.Background(), 1)
 	tb.LoadbalancerNumResolutions.Add(context.Background(), 1)
@@ -94,6 +95,9 @@ func TestSetupTelemetry(t *testing.T) {
 	AssertEqualLoadbalancerCentralQueueWindowCompressedBytes(t, testTel,
 		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueWindowFlushTotal(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
+		metricdatatest.IgnoreTimestamp())
 	AssertEqualLoadbalancerCentralQueueWindowItems(t, testTel,
 		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
 		metricdatatest.IgnoreTimestamp())
@@ -102,6 +106,9 @@ func TestSetupTelemetry(t *testing.T) {
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualLoadbalancerCentralQueueWindowUncompressedBytes(t, testTel,
 		[]metricdata.HistogramDataPoint[int64]{{}}, metricdatatest.IgnoreValue(),
+		metricdatatest.IgnoreTimestamp())
+	AssertEqualLoadbalancerCentralQueueWindowUnderfilledTotal(t, testTel,
+		[]metricdata.DataPoint[int64]{{Value: 1}},
 		metricdatatest.IgnoreTimestamp())
 	AssertEqualLoadbalancerNumBackendUpdates(t, testTel,
 		[]metricdata.DataPoint[int64]{{Value: 1}},

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -933,3 +933,37 @@ func (lb *loadBalancer) exporterAndEndpoint(identifier []byte) (*wrappedExporter
 
 	return exp, endpointWithPort(endpoint), nil
 }
+
+func (lb *loadBalancer) randomExporterAndEndpoint() (*wrappedExporter, string, error) {
+	lb.refreshExpiredEndpointHealth(context.Background())
+
+	lb.updateLock.RLock()
+	defer lb.updateLock.RUnlock()
+
+	if len(lb.exporters) == 0 {
+		return nil, "", errExporterIsStopping
+	}
+	start := rand.IntN(len(lb.exporters))
+	index := 0
+	for endpoint, exp := range lb.exporters {
+		if index < start {
+			index++
+			continue
+		}
+		if !exp.isStopping() {
+			return exp, endpointWithPort(endpoint), nil
+		}
+		index++
+	}
+	index = 0
+	for endpoint, exp := range lb.exporters {
+		if index >= start {
+			break
+		}
+		if !exp.isStopping() {
+			return exp, endpointWithPort(endpoint), nil
+		}
+		index++
+	}
+	return nil, "", errExporterIsStopping
+}

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -940,30 +940,24 @@ func (lb *loadBalancer) randomExporterAndEndpoint() (*wrappedExporter, string, e
 	lb.updateLock.RLock()
 	defer lb.updateLock.RUnlock()
 
-	if len(lb.exporters) == 0 {
+	if lb.ring == nil || len(lb.ring.items) == 0 {
 		return nil, "", errExporterIsStopping
 	}
-	start := rand.IntN(len(lb.exporters))
-	index := 0
-	for endpoint, exp := range lb.exporters {
-		if index < start {
-			index++
+	var missingExporterErr error
+	start := rand.IntN(len(lb.ring.items))
+	for offset := range len(lb.ring.items) {
+		endpoint := endpointWithPort(lb.ring.items[(start+offset)%len(lb.ring.items)].endpoint)
+		exp, found := lb.exporters[endpoint]
+		if !found {
+			missingExporterErr = fmt.Errorf("couldn't find the exporter for the endpoint %q", endpoint)
 			continue
 		}
 		if !exp.isStopping() {
-			return exp, endpointWithPort(endpoint), nil
+			return exp, endpoint, nil
 		}
-		index++
 	}
-	index = 0
-	for endpoint, exp := range lb.exporters {
-		if index >= start {
-			break
-		}
-		if !exp.isStopping() {
-			return exp, endpointWithPort(endpoint), nil
-		}
-		index++
+	if missingExporterErr != nil {
+		return nil, "", missingExporterErr
 	}
 	return nil, "", errExporterIsStopping
 }

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -173,6 +173,21 @@ func TestWithDNSResolverNoEndpoints(t *testing.T) {
 	assert.Empty(t, e)
 }
 
+func TestRandomExporterAndEndpointUsesEligibleRing(t *testing.T) {
+	lb := &loadBalancer{
+		ring:           newHashRing([]string{"eligible:4317"}),
+		endpointHealth: newEndpointHealthManager(endpointHealthSettings{}),
+		exporters: map[string]*wrappedExporter{
+			"stale:4317": newWrappedExporter(mockComponent{}, "stale:4317"),
+		},
+	}
+
+	_, endpoint, err := lb.randomExporterAndEndpoint()
+
+	require.ErrorContains(t, err, "eligible:4317")
+	require.Empty(t, endpoint)
+}
+
 func TestMultipleResolvers(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := &Config{

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -29,6 +29,7 @@ var _ exporter.Logs = (*logExporterImp)(nil)
 type logExporterImp struct {
 	loadBalancer *loadBalancer
 	batcher      *logBatcher
+	centralQueue *centralQueueRuntime
 
 	logger        *zap.Logger
 	started       atomic.Bool
@@ -63,6 +64,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 		ignoreTraceID: cfg.(*Config).LogRouting.IgnoreTraceID,
 		randomTraceID: random,
 	}
+	logExporter.centralQueue = newLogCentralQueueRuntime(cfg.(*Config).CentralQueue, logExporter.ignoreTraceID, telemetry)
 	if cfg.(*Config).LogBatcher.Enabled {
 		logBatcherCfg := cfg.(*Config).LogBatcher
 		logExporter.batcher, err = newLogBatcher(
@@ -96,6 +98,9 @@ func (e *logExporterImp) Start(ctx context.Context, host component.Host) error {
 	if err := e.loadBalancer.Start(ctx, host); err != nil {
 		return err
 	}
+	if e.centralQueue != nil {
+		e.centralQueue.start(e.consumeLogCentralQueueWindow, e.logger)
+	}
 	e.started.Store(true)
 	return nil
 }
@@ -108,6 +113,9 @@ func (e *logExporterImp) Shutdown(ctx context.Context) error {
 	if e.batcher != nil {
 		err = e.batcher.Shutdown(ctx)
 	}
+	if e.centralQueue != nil {
+		err = errors.Join(err, e.centralQueue.shutdown(ctx))
+	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))
 	return err
 }
@@ -115,6 +123,9 @@ func (e *logExporterImp) Shutdown(ctx context.Context) error {
 func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	if !e.started.Load() {
 		return errExporterIsStopping
+	}
+	if e.centralQueue != nil {
+		return e.consumeLogsCentralQueue(ctx, ld)
 	}
 	if e.batcher == nil {
 		var errs error
@@ -292,6 +303,7 @@ func (e *logExporterImp) consumeBatchWithDecision(ctx context.Context, le *wrapp
 	}
 	defer le.doneConsume()
 
+	recordBackendRequest(ctx, e.telemetry, le.endpoint, backendRequestSignalLogs, ld.LogRecordCount(), (&plog.ProtoMarshaler{}).LogsSize(ld))
 	start := time.Now()
 	err := le.ConsumeLogs(ctx, ld)
 	duration := time.Since(start)

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -270,6 +270,28 @@ func TestConsumeLogsEmitsOnlyParentExporterMetrics(t *testing.T) {
 	assert.IsType(t, tracenoop.NewTracerProvider(), childSettings[0].TracerProvider)
 }
 
+func TestConsumeLogsRecordsBackendRequestMetrics(t *testing.T) {
+	ts, _, telemetry := getTelemetryAssetsWithReader(t)
+	p, err := newLogsExporter(ts, simpleConfig())
+	require.NoError(t, err)
+	p.loadBalancer.componentFactory = func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockLogsExporter(), nil
+	}
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	ld := simpleLogs()
+	require.NoError(t, p.ConsumeLogs(t.Context(), ld))
+
+	attrs := attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("signal", "logs"))
+	assertInt64CounterDataPoint(t, telemetry, "otelcol_loadbalancer_backend_request_total", attrs, 1)
+	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_backend_request_items", attrs, int64(ld.LogRecordCount()))
+	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_backend_request_bytes", attrs, int64((&plog.ProtoMarshaler{}).LogsSize(ld)))
+}
+
 func TestConsumeLogsWithQueueCompressionAndInMemoryQueue(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	sink := new(consumertest.LogsSink)

--- a/exporter/loadbalancingexporter/metadata.yaml
+++ b/exporter/loadbalancingexporter/metadata.yaml
@@ -89,6 +89,31 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+    loadbalancer_backend_request_bytes:
+      attributes: [endpoint, signal]
+      enabled: true
+      stability: development
+      description: Backend request payload size in bytes.
+      unit: By
+      histogram:
+        value_type: int
+    loadbalancer_backend_request_items:
+      attributes: [endpoint, signal]
+      enabled: true
+      stability: development
+      description: Number of signal items in each backend request.
+      unit: "{items}"
+      histogram:
+        value_type: int
+    loadbalancer_backend_request_total:
+      attributes: [endpoint, signal]
+      enabled: true
+      stability: development
+      description: Number of backend requests sent by signal.
+      unit: "{requests}"
+      sum:
+        value_type: int
+        monotonic: true
     loadbalancer_backend_reroute_total:
       attributes: [signal, result, reason]
       enabled: true
@@ -124,6 +149,79 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+    loadbalancer_central_queue_active_lanes:
+      attributes: [signal]
+      enabled: true
+      stability: development
+      description: Number of central queue lanes with queued telemetry.
+      unit: "{lanes}"
+      gauge:
+        value_type: int
+    loadbalancer_central_queue_capacity_bytes:
+      attributes: [signal]
+      enabled: true
+      stability: development
+      description: Configured central queue capacity in compressed bytes.
+      unit: By
+      gauge:
+        value_type: int
+    loadbalancer_central_queue_enqueue_total:
+      attributes: [signal, result]
+      enabled: true
+      stability: development
+      description: Number of central queue enqueue attempts by result.
+      unit: "{items}"
+      sum:
+        value_type: int
+        monotonic: true
+    loadbalancer_central_queue_oldest_item_age:
+      attributes: [signal]
+      enabled: true
+      stability: development
+      description: Age in milliseconds of the oldest item waiting in the central queue.
+      unit: ms
+      gauge:
+        value_type: int
+    loadbalancer_central_queue_size_bytes:
+      attributes: [signal]
+      enabled: true
+      stability: development
+      description: Current central queue size in compressed bytes.
+      unit: By
+      gauge:
+        value_type: int
+    loadbalancer_central_queue_window_compressed_bytes:
+      attributes: [signal]
+      enabled: true
+      stability: development
+      description: Compressed bytes drained from the central queue for each backend request window.
+      unit: By
+      histogram:
+        value_type: int
+    loadbalancer_central_queue_window_items:
+      attributes: [signal]
+      enabled: true
+      stability: development
+      description: Number of signal items coalesced in each central queue backend request window.
+      unit: "{items}"
+      histogram:
+        value_type: int
+    loadbalancer_central_queue_window_payloads:
+      attributes: [signal]
+      enabled: true
+      stability: development
+      description: Number of queued payloads merged into each central queue backend request window.
+      unit: "{payloads}"
+      histogram:
+        value_type: int
+    loadbalancer_central_queue_window_uncompressed_bytes:
+      attributes: [signal]
+      enabled: true
+      stability: development
+      description: Uncompressed bytes represented by each central queue backend request window.
+      unit: By
+      histogram:
+        value_type: int
 
     loadbalancer_num_backend_updates:
       attributes: [resolver]

--- a/exporter/loadbalancingexporter/metadata.yaml
+++ b/exporter/loadbalancingexporter/metadata.yaml
@@ -17,7 +17,7 @@ attributes:
     description: The endpoint of the backend
     type: string
   reason:
-    description: Low-cardinality endpoint health reason
+    description: Low-cardinality reason
     type: string
   resolver:
     description: Resolver used
@@ -198,6 +198,15 @@ telemetry:
       unit: By
       histogram:
         value_type: int
+    loadbalancer_central_queue_window_flush_total:
+      attributes: [signal, reason]
+      enabled: true
+      stability: development
+      description: Number of central queue windows flushed by bounded reason.
+      unit: "{windows}"
+      sum:
+        value_type: int
+        monotonic: true
     loadbalancer_central_queue_window_items:
       attributes: [signal]
       enabled: true
@@ -222,6 +231,15 @@ telemetry:
       unit: By
       histogram:
         value_type: int
+    loadbalancer_central_queue_window_underfilled_total:
+      attributes: [signal, reason]
+      enabled: true
+      stability: development
+      description: Number of central queue windows sent below target compressed bytes by bounded reason.
+      unit: "{windows}"
+      sum:
+        value_type: int
+        monotonic: true
 
     loadbalancer_num_backend_updates:
       attributes: [resolver]

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -35,6 +35,7 @@ const metricBatcherEnqueueBackoff = 2 * time.Millisecond
 type metricExporterImp struct {
 	loadBalancer *loadBalancer
 	batcher      *metricBatcher
+	centralQueue *centralQueueRuntime
 	routingKey   routingKey
 
 	logger    *zap.Logger
@@ -66,6 +67,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 		telemetry:    telemetry,
 		logger:       params.Logger,
 	}
+	metricExporter.centralQueue = newMetricCentralQueueRuntime(cfg.(*Config).CentralQueue, telemetry)
 
 	switch cfg.(*Config).RoutingKey {
 	case svcRoutingStr, "":
@@ -113,6 +115,9 @@ func (e *metricExporterImp) Start(ctx context.Context, host component.Host) erro
 	if err := e.loadBalancer.Start(ctx, host); err != nil {
 		return err
 	}
+	if e.centralQueue != nil {
+		e.centralQueue.start(e.consumeMetricCentralQueueWindow, e.logger)
+	}
 	e.started.Store(true)
 	return nil
 }
@@ -124,6 +129,9 @@ func (e *metricExporterImp) Shutdown(ctx context.Context) error {
 	var err error
 	if e.batcher != nil {
 		err = e.batcher.Shutdown(ctx)
+	}
+	if e.centralQueue != nil {
+		err = errors.Join(err, e.centralQueue.shutdown(ctx))
 	}
 	err = errors.Join(err, e.loadBalancer.Shutdown(ctx))
 	return err
@@ -137,6 +145,10 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 	batches, err := e.splitMetricsByRouting(md)
 	if err != nil {
 		return err
+	}
+
+	if e.centralQueue != nil {
+		return e.consumeMetricsCentralQueue(ctx, batches)
 	}
 
 	if e.batcher != nil {
@@ -362,6 +374,7 @@ func (e *metricExporterImp) consumeMetricsByExporterAttempt(
 			failedMetrics = pmetric.NewMetrics()
 			mds.CopyTo(failedMetrics)
 		}
+		recordBackendRequest(ctx, e.telemetry, exp.endpoint, backendRequestSignalMetrics, mds.DataPointCount(), (&pmetric.ProtoMarshaler{}).MetricsSize(mds))
 		start := time.Now()
 		err := exp.ConsumeMetrics(ctx, mds)
 		duration := time.Since(start)
@@ -408,6 +421,7 @@ func (e *metricExporterImp) consumeBatch(ctx context.Context, we *wrappedExporte
 	}
 	defer we.doneConsume()
 
+	recordBackendRequest(ctx, e.telemetry, we.endpoint, backendRequestSignalMetrics, md.DataPointCount(), (&pmetric.ProtoMarshaler{}).MetricsSize(md))
 	start := time.Now()
 	err := we.ConsumeMetrics(ctx, md)
 	duration := time.Since(start)
@@ -496,6 +510,7 @@ func (e *metricExporterImp) rerouteDrainBatch(ctx context.Context, md pmetric.Me
 	var errs error
 	needsCleanup = false
 	for exp, mds := range metricsByExporter {
+		recordBackendRequest(ctx, e.telemetry, exp.endpoint, backendRequestSignalMetrics, mds.DataPointCount(), (&pmetric.ProtoMarshaler{}).MetricsSize(mds))
 		start := time.Now()
 		err = exp.ConsumeMetrics(ctx, mds)
 		duration := time.Since(start)

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -723,6 +723,29 @@ func TestConsumeMetrics_SingleEndpoint(t *testing.T) {
 	}
 }
 
+func TestConsumeMetricsRecordsBackendRequestMetrics(t *testing.T) {
+	ts, _, telemetry := getTelemetryAssetsWithReader(t)
+	p, err := newMetricsExporter(ts, serviceBasedRoutingConfig())
+	require.NoError(t, err)
+	p.loadBalancer.componentFactory = func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockMetricsExporter(), nil
+	}
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	md := singleDataPointMetric("request-metric")
+	md.ResourceMetrics().At(0).Resource().Attributes().PutStr(serviceNameKey, serviceName1)
+	require.NoError(t, p.ConsumeMetrics(t.Context(), md))
+
+	attrs := attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("signal", "metrics"))
+	assertInt64CounterDataPoint(t, telemetry, "otelcol_loadbalancer_backend_request_total", attrs, 1)
+	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_backend_request_items", attrs, int64(md.DataPointCount()))
+	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_backend_request_bytes", attrs, int64((&pmetric.ProtoMarshaler{}).MetricsSize(md)))
+}
+
 func TestConsumeMetricsReroutesEndpointLocalFailure(t *testing.T) {
 	ts, tb, telemetry := getTelemetryAssetsWithReader(t)
 	cfg := endpoint2Config()

--- a/exporter/loadbalancingexporter/telemetry_utils_test.go
+++ b/exporter/loadbalancingexporter/telemetry_utils_test.go
@@ -11,6 +11,8 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 )
@@ -35,4 +37,71 @@ func getTelemetryAssetsWithReader(t *testing.T) (exporter.Settings, *metadata.Te
 	tb, err := metadata.NewTelemetryBuilder(s.TelemetrySettings)
 	require.NoError(t, err)
 	return s, tb, telemetry
+}
+
+func assertInt64CounterDataPoint(
+	t *testing.T,
+	telemetry *componenttest.Telemetry,
+	metricName string,
+	attrs attribute.Set,
+	value int64,
+) {
+	t.Helper()
+
+	got, err := telemetry.GetMetric(metricName)
+	require.NoError(t, err)
+	sum, ok := got.Data.(metricdata.Sum[int64])
+	require.True(t, ok)
+	for _, dp := range sum.DataPoints {
+		if dp.Attributes.Equals(&attrs) {
+			require.Equal(t, value, dp.Value)
+			return
+		}
+	}
+	require.Failf(t, "missing data point", "metric=%s attrs=%v", metricName, attrs)
+}
+
+func assertInt64HistogramDataPoint(
+	t *testing.T,
+	telemetry *componenttest.Telemetry,
+	metricName string,
+	attrs attribute.Set,
+	sumValue int64,
+) {
+	t.Helper()
+
+	got, err := telemetry.GetMetric(metricName)
+	require.NoError(t, err)
+	histogram, ok := got.Data.(metricdata.Histogram[int64])
+	require.True(t, ok)
+	for _, dp := range histogram.DataPoints {
+		if dp.Attributes.Equals(&attrs) {
+			require.Equal(t, uint64(1), dp.Count)
+			require.Equal(t, sumValue, dp.Sum)
+			return
+		}
+	}
+	require.Failf(t, "missing data point", "metric=%s attrs=%v", metricName, attrs)
+}
+
+func assertInt64GaugeDataPoint(
+	t *testing.T,
+	telemetry *componenttest.Telemetry,
+	metricName string,
+	attrs attribute.Set,
+	value int64,
+) {
+	t.Helper()
+
+	got, err := telemetry.GetMetric(metricName)
+	require.NoError(t, err)
+	gauge, ok := got.Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	for _, dp := range gauge.DataPoints {
+		if dp.Attributes.Equals(&attrs) {
+			require.Equal(t, value, dp.Value)
+			return
+		}
+	}
+	require.Failf(t, "missing data point", "metric=%s attrs=%v", metricName, attrs)
 }

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -151,6 +151,7 @@ func (e *traceExporterImp) consumeTraces(ctx context.Context, td ptrace.Traces, 
 			retryTraces = ptrace.NewTraces()
 			td.CopyTo(retryTraces)
 		}
+		recordBackendRequest(ctx, e.telemetry, exp.endpoint, backendRequestSignalTraces, td.SpanCount(), (&ptrace.ProtoMarshaler{}).TracesSize(td))
 		start := time.Now()
 		err := exp.ConsumeTraces(ctx, td)
 		exp.doneConsume()

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -163,6 +163,28 @@ func TestConsumeTraces(t *testing.T) {
 	assert.NoError(t, res)
 }
 
+func TestConsumeTracesRecordsBackendRequestMetrics(t *testing.T) {
+	ts, _, telemetry := getTelemetryAssetsWithReader(t)
+	p, err := newTracesExporter(ts, simpleConfig())
+	require.NoError(t, err)
+	p.loadBalancer.componentFactory = func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockTracesExporter(), nil
+	}
+
+	require.NoError(t, p.Start(t.Context(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(t.Context()))
+	}()
+
+	td := simpleTraces()
+	require.NoError(t, p.ConsumeTraces(t.Context(), td))
+
+	attrs := attribute.NewSet(attribute.String("endpoint", "endpoint-1:4317"), attribute.String("signal", "traces"))
+	assertInt64CounterDataPoint(t, telemetry, "otelcol_loadbalancer_backend_request_total", attrs, 1)
+	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_backend_request_items", attrs, int64(td.SpanCount()))
+	assertInt64HistogramDataPoint(t, telemetry, "otelcol_loadbalancer_backend_request_bytes", attrs, int64((&ptrace.ProtoMarshaler{}).TracesSize(td)))
+}
+
 // This test validates that exporter is can concurrently change the endpoints while consuming traces.
 func TestConsumeTraces_ConcurrentResolverChange(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)


### PR DESCRIPTION
loadbalancingexporter: Compressed central queue coalescing

Adds an optional central queue for LB logs and metrics that keeps queued OTLP payloads compressed, enforces compressed-byte capacity, coalesces by backend lane, and chooses an endpoint only when sending. Also adds backend request and central queue telemetry so request size and queue pressure are visible.

Description:
- Add `central_queue` config, validation, schema, docs, and exporterhelper queue exclusion when enabled.
- Add compressed central queue runtime for metrics and ignore-trace-id logs, with retry/requeue and bounded shutdown behavior.
- Add queue/request telemetry plus unit and integration coverage for coalescing, retry, shutdown, and metric emission.

Tests:
- `go test . -count=1` from `exporter/loadbalancingexporter`
- `make fmt` from `exporter/loadbalancingexporter`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new optional buffering/sending path (`central_queue`) for logs/metrics and changes exporter behavior/throughput characteristics when enabled; misconfiguration or tuning issues could impact memory usage, batching, and delivery latency.
> 
> **Overview**
> Adds an opt-in `central_queue` mode to `loadbalancingexporter` for **logs (only when `log_routing.ignore_trace_id` is true)** and **metrics**, buffering OTLP payloads **compressed in-memory**, enforcing capacity by compressed bytes, coalescing queued payloads by lane, and selecting a backend endpoint only at send time (with retry/requeue semantics and bounded shutdown).
> 
> Extends telemetry with new **backend request** metrics (`*_backend_request_{total,items,bytes}`) and **central queue** pressure/flush metrics, and wires these into traces/logs/metrics send paths.
> 
> Updates config validation/schema/docs to include `central_queue` settings and to enforce that only one backlog mechanism is enabled (mutually exclusive with `sending_queue`, `log_batcher`, and `metric_batcher`), with added tests covering coalescing, retries, shutdown behavior, config validation, and metric emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2259ad03252df0a0b74cd079c905dcefdff11069. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional compressed central queue to `loadbalancingexporter` for logs and metrics that coalesces payloads by backend lane and picks the endpoint only at send time. Adds backend request metrics and central-queue rollout telemetry.

- **New Features**
  - `central_queue` config for logs/metrics; stores queued OTLP payloads compressed and enforces capacity by compressed bytes.
  - Coalesces small payloads per backend lane; for random-routed logs, pre-batches by backend to avoid lane fragmentation; selects endpoint when the window is sent.
  - Retries/requeues failed windows with bounded shutdown behavior.
  - Emits backend request telemetry for traces/logs/metrics: `otelcol_loadbalancer_backend_request_total`, `otelcol_loadbalancer_backend_request_items`, `otelcol_loadbalancer_backend_request_bytes`, plus central-queue flush-reason and underfilled-window metrics.

- **Migration**
  - Off by default. When `central_queue.enabled: true`, it cannot be combined with `sending_queue`, `log_batcher`, or `metric_batcher` (central queue must be the only backlog).
  - Logs require `log_routing.ignore_trace_id: true` to use the central queue.
  - Schema, validation, and docs updated; `sending_queue` is automatically disabled when `central_queue` is enabled.

<sup>Written for commit 2259ad03252df0a0b74cd079c905dcefdff11069. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional central queue for coalescing/sending compressed telemetry with configurable compression, capacity, lanes, and batching.
  * Backend-request telemetry: counts, item counts, and payload size histograms per endpoint and signal.

* **Documentation**
  * Updated README, schema, and metadata to document central queue settings and new telemetry metrics.

* **Tests**
  * Extensive tests covering central queue behavior, enqueue/requeue, batching, shutdown, and backend-request telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->