### PR TITLE
loadbalancingexporter: retry central queue payloads independently

### DIFF
--- a/.chloggen/loadbalancingexporter-central-queue-per-item-retry.yaml
+++ b/.chloggen/loadbalancingexporter-central-queue-per-item-retry.yaml
@@ -1,0 +1,8 @@
+change_type: bug_fix
+component: exporter/loadbalancing
+note: Retry coalesced central queue payloads using each payload's own retry attempt.
+issues: [60]
+subtext: |-
+  Prevents fresh payloads coalesced with an older retrying payload from inheriting
+  the older payload's backoff delay.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -260,7 +260,7 @@ func (l *centralQueueLease) done() {
 	})
 }
 
-func (l *centralQueueLease) requeue(nextAttempt time.Time) error {
+func (l *centralQueueLease) requeue(now time.Time) error {
 	var err error
 	l.once.Do(func() {
 		l.queue.settings.telemetry.recordRetry(context.Background())
@@ -272,6 +272,7 @@ func (l *centralQueueLease) requeue(nextAttempt time.Time) error {
 			err = errCentralQueueStopped
 		} else {
 			for _, item := range l.window.items {
+				nextAttempt := now.Add(centralQueueRetryDelay(item.attempt))
 				item.attempt++
 				item.nextAttemptUnixNano = nextAttempt.UnixNano()
 				l.queue.items = append(l.queue.items, item)
@@ -283,10 +284,6 @@ func (l *centralQueueLease) requeue(nextAttempt time.Time) error {
 		l.queue.settings.telemetry.record(context.Background(), snapshot)
 	})
 	return err
-}
-
-func (l *centralQueueLease) retryDelay() time.Duration {
-	return centralQueueRetryDelay(l.window.maxAttempt)
 }
 
 func (q *centralQueue) stop() {

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -63,8 +63,9 @@ func TestCentralQueueLeaseReservesCompressedBytesUntilDoneOrRequeue(t *testing.T
 	require.Equal(t, 1, q.len())
 	require.EqualValues(t, 10, q.compressedBytes())
 
-	retryLease, err := q.lease(t.Context())
+	retryLease, err := q.tryLease(time.Now().Add(centralQueueInitialRetryDelay))
 	require.NoError(t, err)
+	require.NotNil(t, retryLease)
 	retryLease.done()
 	require.Zero(t, q.compressedBytes())
 }
@@ -143,7 +144,6 @@ func TestCentralQueueRequeuesWholeCoalescedWindow(t *testing.T) {
 		targetCompressedBytes:        20,
 	})
 	now := time.Unix(10, 0)
-	nextAttempt := now.Add(time.Second)
 	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
 	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
 
@@ -151,7 +151,7 @@ func TestCentralQueueRequeuesWholeCoalescedWindow(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.Len(t, lease.window.items, 2)
-	require.NoError(t, lease.requeue(nextAttempt))
+	require.NoError(t, lease.requeue(now))
 	require.Equal(t, 2, q.len())
 	require.EqualValues(t, 20, q.compressedBytes())
 
@@ -159,11 +159,39 @@ func TestCentralQueueRequeuesWholeCoalescedWindow(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, lease)
 
-	lease, err = q.tryLease(nextAttempt)
+	lease, err = q.tryLease(now.Add(centralQueueInitialRetryDelay))
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.Len(t, lease.window.items, 2)
 	require.Equal(t, 1, lease.window.maxAttempt)
+}
+
+func TestCentralQueueRequeueUsesPerItemRetryDelay(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 20, count: 1, attempt: 3}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+
+	lease, err := q.tryLease(now)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.Len(t, lease.window.items, 2)
+	require.Equal(t, 3, lease.window.maxAttempt)
+
+	require.NoError(t, lease.requeue(now))
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	require.Len(t, q.items, 2)
+	require.Equal(t, 4, q.items[0].attempt)
+	require.Equal(t, now.Add(centralQueueRetryDelay(3)).UnixNano(), q.items[0].nextAttemptUnixNano)
+	require.Equal(t, 1, q.items[1].attempt)
+	require.Equal(t, now.Add(centralQueueRetryDelay(0)).UnixNano(), q.items[1].nextAttemptUnixNano)
 }
 
 func TestCentralQueueSnapshotReportsOldestQueuedItemAge(t *testing.T) {
@@ -200,11 +228,11 @@ func TestCentralQueueSnapshotReportsOldestQueuedItemAge(t *testing.T) {
 	secondLease.done()
 	require.EqualValues(t, 300, snapshotAt(base.Add(300*time.Millisecond)).oldestItemAgeMillis)
 
-	retryLease, err := q.tryLease(base.Add(time.Second))
+	retryLease, err := q.tryLease(base.Add(time.Second + centralQueueInitialRetryDelay))
 	require.NoError(t, err)
 	require.NotNil(t, retryLease)
 	retryLease.done()
-	require.Zero(t, snapshotAt(base.Add(time.Second)).oldestItemAgeMillis)
+	require.Zero(t, snapshotAt(base.Add(time.Second+centralQueueInitialRetryDelay)).oldestItemAgeMillis)
 }
 
 func TestCentralQueueTelemetryOldestItemAgeAdvancesWithoutQueueMutation(t *testing.T) {
@@ -303,6 +331,7 @@ func TestCentralQueueRetriesDoNotGrowOldestEnqueuedHeap(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, lease)
 		require.NoError(t, lease.requeue(now))
+		now = now.Add(centralQueueMaxRetryDelay)
 	}
 
 	q.mu.Lock()

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -255,8 +255,7 @@ func (e *logExporterImp) runCentralQueue(ctx context.Context) {
 			lease.done()
 			continue
 		}
-		nextAttempt := time.Now().Add(lease.retryDelay())
-		if requeueErr := lease.requeue(nextAttempt); requeueErr != nil {
+		if requeueErr := lease.requeue(time.Now()); requeueErr != nil {
 			e.logger.Warn("failed to requeue central log queue item", zap.Error(requeueErr), zap.Error(err))
 		}
 	}

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -244,8 +244,7 @@ func (e *metricExporterImp) runCentralQueue(ctx context.Context) {
 			lease.done()
 			continue
 		}
-		nextAttempt := time.Now().Add(lease.retryDelay())
-		if requeueErr := lease.requeue(nextAttempt); requeueErr != nil {
+		if requeueErr := lease.requeue(time.Now()); requeueErr != nil {
 			e.logger.Warn("failed to requeue central metric queue item", zap.Error(requeueErr), zap.Error(err))
 		}
 	}


### PR DESCRIPTION
loadbalancingexporter: Retry coalesced central queue payloads independently

Follow-up to the central queue coalescing rollout. This fixes the review finding where a fresh payload coalesced with an older retrying payload inherited the older payload's backoff delay.

Changes:
- Schedule central queue retry timestamps per payload attempt instead of per coalesced window.
- Keep requeued payloads independently leaseable once their own retry delay expires.
- Add a regression test for mixed-attempt coalesced windows and a changelog entry.

Validation:
- go test . -count=1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit cdbd4c6fc728cee8c6091528e07e302aefd902be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `loadbalancingexporter` central queue retries so coalesced payloads retry independently. Prevents fresh items from inheriting backoff from older retries and reduces unnecessary delay.

- **Bug Fixes**
  - Compute retry per item based on its own attempt; no shared window delay.
  - Requeued items become leaseable independently when their delay expires.
  - Updated `centralQueueLease.requeue(now time.Time)` to set per-item `nextAttempt` and removed `retryDelay()`. Callers in `log_exporter.go` and `metrics_exporter.go` now pass `time.Now()`.
  - Added a regression test for mixed-attempt coalesced windows and a changelog entry.

<sup>Written for commit cdbd4c6fc728cee8c6091528e07e302aefd902be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

