### PR TITLE
feat(loadbalancingexporter): coalesce random central queue logs

### DIFF
--- a/.chloggen/loadbalancing-central-queue-random-log-coalescing.yaml
+++ b/.chloggen/loadbalancing-central-queue-random-log-coalescing.yaml
@@ -1,0 +1,10 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Coalesce randomly routed log payloads into larger central queue request windows.
+issues: [63]
+subtext: |-
+  Uses a shared queue routing key for random log routing and selects the backend
+  when the coalesced central queue window is sent. Adds flush-reason telemetry
+  so operators can tell whether request windows are target-sized, delay-flushed,
+  hard-capped, or draining on shutdown.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -535,4 +535,6 @@ The following metrics are recorded by this exporter:
   * `otelcol_loadbalancer_central_queue_window_uncompressed_bytes` reports decoded OTLP bytes in each merged request window.
   * `otelcol_loadbalancer_central_queue_window_items` reports log records or metric datapoints in each merged request window.
   * `otelcol_loadbalancer_central_queue_window_payloads` reports how many compressed queue payloads were merged into each request window.
+  * `otelcol_loadbalancer_central_queue_window_flush_total` counts request windows by flush reason: `target_reached`, `hard_cap`, `max_delay_low_traffic`, or `shutdown`.
+  * `otelcol_loadbalancer_central_queue_window_underfilled_total` counts request windows that were sent below the configured compressed byte target, split by flush reason.
   * `otelcol_loadbalancer_central_queue_decode_failures` counts log records or metric datapoints dropped because a queued compressed payload could not be decoded.

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -57,7 +57,17 @@ type centralQueueWindow struct {
 	count             int
 	oldestEnqueuedAt  int64
 	maxAttempt        int
+	flushReason       centralQueueFlushReason
 }
+
+type centralQueueFlushReason string
+
+const (
+	centralQueueFlushReasonTargetReached      centralQueueFlushReason = "target_reached"
+	centralQueueFlushReasonHardCap            centralQueueFlushReason = "hard_cap"
+	centralQueueFlushReasonMaxDelayLowTraffic centralQueueFlushReason = "max_delay_low_traffic"
+	centralQueueFlushReasonShutdown           centralQueueFlushReason = "shutdown"
+)
 
 type centralQueueWindowCandidate struct {
 	window  centralQueueWindow
@@ -162,7 +172,7 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 		q.currentInflightBytes += int64(candidate.window.uncompressedBytes)
 		snapshot := q.snapshotLocked()
 		q.settings.telemetry.record(context.Background(), snapshot)
-		q.settings.telemetry.recordWindow(context.Background(), candidate.window)
+		q.settings.telemetry.recordWindow(context.Background(), candidate.window, q.settings.targetCompressedBytes)
 		lease := &centralQueueLease{
 			queue:  q,
 			window: candidate.window,
@@ -209,6 +219,7 @@ func (q *centralQueue) buildWindowCandidateLocked(routingKey []byte, now time.Ti
 			candidate.window.oldestEnqueuedAt = item.enqueuedAtUnixNano
 		}
 		if int64(candidate.window.compressedBytes) >= q.settings.targetCompressedBytes {
+			candidate.window.flushReason = centralQueueFlushReasonTargetReached
 			return candidate, true
 		}
 	}
@@ -216,11 +227,21 @@ func (q *centralQueue) buildWindowCandidateLocked(routingKey []byte, now time.Ti
 	if len(candidate.window.items) == 0 {
 		return centralQueueWindowCandidate{}, false
 	}
-	if q.stopped || blockedByHardLimit || q.settings.maxBatchDelay <= 0 {
+	if q.stopped {
+		candidate.window.flushReason = centralQueueFlushReasonShutdown
+		return candidate, true
+	}
+	if blockedByHardLimit {
+		candidate.window.flushReason = centralQueueFlushReasonHardCap
+		return candidate, true
+	}
+	if q.settings.maxBatchDelay <= 0 {
+		candidate.window.flushReason = centralQueueFlushReasonMaxDelayLowTraffic
 		return candidate, true
 	}
 	oldest := time.Unix(0, candidate.window.oldestEnqueuedAt)
 	if !oldest.IsZero() && now.Sub(oldest) >= q.settings.maxBatchDelay {
+		candidate.window.flushReason = centralQueueFlushReasonMaxDelayLowTraffic
 		return candidate, true
 	}
 	return centralQueueWindowCandidate{}, false
@@ -429,4 +450,8 @@ func centralQueueLaneRoutingKey(signal signalKind, routingKey []byte, laneCount 
 	laneRoutingKey[len(signal)] = 0
 	binary.BigEndian.PutUint32(laneRoutingKey[len(signal)+1:], lane)
 	return laneRoutingKey
+}
+
+func centralQueueRandomLogsRoutingKey() []byte {
+	return []byte("logs\x00random")
 }

--- a/exporter/loadbalancingexporter/central_queue_telemetry.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry.go
@@ -16,6 +16,7 @@ import (
 )
 
 type centralQueueTelemetry struct {
+	signal               signalKind
 	signalAttrs          metric.MeasurementOption
 	compressedBytes      metric.Int64Gauge
 	compressedCapacity   metric.Int64Gauge
@@ -26,13 +27,16 @@ type centralQueueTelemetry struct {
 	decodeFailures       metric.Int64Counter
 	inflightUncompressed metric.Int64Gauge
 	windowCompressed     metric.Int64Histogram
+	windowFlush          metric.Int64Counter
 	windowUncompressed   metric.Int64Histogram
 	windowItems          metric.Int64Histogram
 	windowPayloads       metric.Int64Histogram
+	windowUnderfilled    metric.Int64Counter
 	oldestItemAge        metric.Int64ObservableGauge
 	oldestItemAgeReg     metric.Registration
 	oldestItemAgeMu      sync.RWMutex
 	oldestItemAgeMillis  func() int64
+	flushReasonAttrs     map[centralQueueFlushReason]metric.MeasurementOption
 }
 
 type centralQueueSnapshot struct {
@@ -46,8 +50,16 @@ type centralQueueSnapshot struct {
 func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signalKind) (*centralQueueTelemetry, error) {
 	meter := metadata.Meter(settings)
 	var err, errs error
+	signalAttr := attribute.String("signal", string(signal))
 	t := &centralQueueTelemetry{
-		signalAttrs: metric.WithAttributeSet(attribute.NewSet(attribute.String("signal", string(signal)))),
+		signal:      signal,
+		signalAttrs: metric.WithAttributeSet(attribute.NewSet(signalAttr)),
+		flushReasonAttrs: map[centralQueueFlushReason]metric.MeasurementOption{
+			centralQueueFlushReasonTargetReached:      metric.WithAttributeSet(attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonTargetReached)))),
+			centralQueueFlushReasonHardCap:            metric.WithAttributeSet(attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonHardCap)))),
+			centralQueueFlushReasonMaxDelayLowTraffic: metric.WithAttributeSet(attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonMaxDelayLowTraffic)))),
+			centralQueueFlushReasonShutdown:           metric.WithAttributeSet(attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonShutdown)))),
+		},
 	}
 	t.compressedBytes, err = meter.Int64Gauge(
 		"otelcol_loadbalancer_central_queue_compressed_bytes",
@@ -104,6 +116,12 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 		metric.WithExplicitBucketBoundaries(1024, 4096, 16384, 65536, 262144, 1048576, 4194304),
 	)
 	errs = errors.Join(errs, err)
+	t.windowFlush, err = meter.Int64Counter(
+		"otelcol_loadbalancer_central_queue_window_flush_total",
+		metric.WithDescription("Central load-balancing queue windows flushed by bounded reason."),
+		metric.WithUnit("{windows}"),
+	)
+	errs = errors.Join(errs, err)
 	t.windowUncompressed, err = meter.Int64Histogram(
 		"otelcol_loadbalancer_central_queue_window_uncompressed_bytes",
 		metric.WithDescription("Estimated uncompressed OTLP bytes in each central load-balancing queue window before decode and send."),
@@ -123,6 +141,12 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 		metric.WithDescription("Compressed queue payloads merged into each central load-balancing queue window."),
 		metric.WithUnit("{payloads}"),
 		metric.WithExplicitBucketBoundaries(1, 2, 4, 8, 16, 32, 64, 128),
+	)
+	errs = errors.Join(errs, err)
+	t.windowUnderfilled, err = meter.Int64Counter(
+		"otelcol_loadbalancer_central_queue_window_underfilled_total",
+		metric.WithDescription("Central load-balancing queue windows sent below target compressed bytes by bounded reason."),
+		metric.WithUnit("{windows}"),
 	)
 	errs = errors.Join(errs, err)
 	t.oldestItemAge, err = meter.Int64ObservableGauge(
@@ -180,7 +204,7 @@ func (t *centralQueueTelemetry) recordDecodeFailure(ctx context.Context, dropped
 	t.decodeFailures.Add(ctx, droppedItems, t.signalAttrs)
 }
 
-func (t *centralQueueTelemetry) recordWindow(ctx context.Context, window centralQueueWindow) {
+func (t *centralQueueTelemetry) recordWindow(ctx context.Context, window centralQueueWindow, targetCompressedBytes int64) {
 	if t == nil {
 		return
 	}
@@ -188,6 +212,18 @@ func (t *centralQueueTelemetry) recordWindow(ctx context.Context, window central
 	t.windowUncompressed.Record(ctx, int64(window.uncompressedBytes), t.signalAttrs)
 	t.windowItems.Record(ctx, int64(window.count), t.signalAttrs)
 	t.windowPayloads.Record(ctx, int64(len(window.items)), t.signalAttrs)
+	reasonAttrs := t.flushAttrs(window.flushReason)
+	t.windowFlush.Add(ctx, 1, reasonAttrs)
+	if int64(window.compressedBytes) < targetCompressedBytes {
+		t.windowUnderfilled.Add(ctx, 1, reasonAttrs)
+	}
+}
+
+func (t *centralQueueTelemetry) flushAttrs(reason centralQueueFlushReason) metric.MeasurementOption {
+	if attrs, ok := t.flushReasonAttrs[reason]; ok {
+		return attrs
+	}
+	return metric.WithAttributeSet(attribute.NewSet(attribute.String("signal", string(t.signal)), attribute.String("reason", string(reason))))
 }
 
 func (t *centralQueueTelemetry) observeOldestItemAge(oldestItemAgeMillis func() int64) {

--- a/exporter/loadbalancingexporter/central_queue_telemetry_test.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry_test.go
@@ -37,9 +37,11 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 		compressedBytes:   32,
 		uncompressedBytes: 128,
 		count:             11,
-	})
+		flushReason:       centralQueueFlushReasonMaxDelayLowTraffic,
+	}, 64)
 
 	attrs := attribute.NewSet(attribute.String("signal", string(signalKindLogs)))
+	flushAttrs := attribute.NewSet(attribute.String("signal", string(signalKindLogs)), attribute.String("reason", string(centralQueueFlushReasonMaxDelayLowTraffic)))
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_compressed_bytes", "By", attrs, 50)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_compressed_capacity", "By", attrs, 100)
 	requireCentralQueueFloatGauge(t, reader, "otelcol_loadbalancer_central_queue_saturation", "1", attrs, 0.5)
@@ -53,6 +55,8 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 	requireCentralQueueIntHistogram(t, reader, "otelcol_loadbalancer_central_queue_window_uncompressed_bytes", "By", attrs, 128)
 	requireCentralQueueIntHistogram(t, reader, "otelcol_loadbalancer_central_queue_window_items", "{items}", attrs, 11)
 	requireCentralQueueIntHistogram(t, reader, "otelcol_loadbalancer_central_queue_window_payloads", "{payloads}", attrs, 2)
+	requireCentralQueueIntSum(t, reader, "otelcol_loadbalancer_central_queue_window_flush_total", "{windows}", flushAttrs, 1)
+	requireCentralQueueIntSum(t, reader, "otelcol_loadbalancer_central_queue_window_underfilled_total", "{windows}", flushAttrs, 1)
 }
 
 func TestCentralQueueTelemetryOldestItemAgeReportsMultipleSignals(t *testing.T) {

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -90,6 +90,7 @@ func TestCentralQueueLeaseCoalescesReadyItemsByRoutingKey(t *testing.T) {
 	require.Len(t, lease.window.items, 2)
 	require.Equal(t, 20, lease.window.compressedBytes)
 	require.Equal(t, 40, lease.window.uncompressedBytes)
+	require.Equal(t, centralQueueFlushReasonTargetReached, lease.window.flushReason)
 	require.Equal(t, 1, q.len())
 	require.EqualValues(t, 30, q.compressedBytes())
 
@@ -113,6 +114,26 @@ func TestCentralQueueLeaseDoesNotCoalesceDifferentRoutingKeys(t *testing.T) {
 	require.NotNil(t, lease)
 	require.Equal(t, []byte("lane-a"), lease.window.routingKey)
 	require.Len(t, lease.window.items, 1)
+	require.Equal(t, centralQueueFlushReasonMaxDelayLowTraffic, lease.window.flushReason)
+}
+
+func TestCentralQueueLeaseMarksHardCapFlush(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    30,
+		targetCompressedBytes:        100,
+		maxBatchDelay:                time.Second,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+
+	lease, err := q.tryLease(now)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.Len(t, lease.window.items, 1)
+	require.Equal(t, centralQueueFlushReasonHardCap, lease.window.flushReason)
 }
 
 func TestCentralQueueLeaseWaitsForSmallWindowMaxDelay(t *testing.T) {
@@ -134,6 +155,7 @@ func TestCentralQueueLeaseWaitsForSmallWindowMaxDelay(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.Len(t, lease.window.items, 1)
+	require.Equal(t, centralQueueFlushReasonMaxDelayLowTraffic, lease.window.flushReason)
 }
 
 func TestCentralQueueRequeuesWholeCoalescedWindow(t *testing.T) {
@@ -382,12 +404,14 @@ func TestCentralQueueStopAllowsDrainingExistingItems(t *testing.T) {
 		maxCompressedBytes:           100,
 		maxInflightUncompressedBytes: 100,
 		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        100,
 	})
 	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindLogs, compressedBytes: 10, uncompressedBytes: 10, count: 1}))
 	q.stop()
 
 	lease, err := q.lease(t.Context())
 	require.NoError(t, err)
+	require.Equal(t, centralQueueFlushReasonShutdown, lease.window.flushReason)
 	lease.done()
 
 	_, err = q.lease(t.Context())

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -933,3 +933,31 @@ func (lb *loadBalancer) exporterAndEndpoint(identifier []byte) (*wrappedExporter
 
 	return exp, endpointWithPort(endpoint), nil
 }
+
+func (lb *loadBalancer) randomExporterAndEndpoint() (*wrappedExporter, string, error) {
+	lb.refreshExpiredEndpointHealth(context.Background())
+
+	lb.updateLock.RLock()
+	defer lb.updateLock.RUnlock()
+
+	if lb.ring == nil || len(lb.ring.items) == 0 {
+		return nil, "", errExporterIsStopping
+	}
+	var missingExporterErr error
+	start := rand.IntN(len(lb.ring.items))
+	for offset := range len(lb.ring.items) {
+		endpoint := endpointWithPort(lb.ring.items[(start+offset)%len(lb.ring.items)].endpoint)
+		exp, found := lb.exporters[endpoint]
+		if !found {
+			missingExporterErr = fmt.Errorf("couldn't find the exporter for the endpoint %q", endpoint)
+			continue
+		}
+		if !exp.isStopping() {
+			return exp, endpoint, nil
+		}
+	}
+	if missingExporterErr != nil {
+		return nil, "", missingExporterErr
+	}
+	return nil, "", errExporterIsStopping
+}

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -173,6 +173,21 @@ func TestWithDNSResolverNoEndpoints(t *testing.T) {
 	assert.Empty(t, e)
 }
 
+func TestRandomExporterAndEndpointUsesEligibleRing(t *testing.T) {
+	lb := &loadBalancer{
+		ring:           newHashRing([]string{"eligible:4317"}),
+		endpointHealth: newEndpointHealthManager(endpointHealthSettings{}),
+		exporters: map[string]*wrappedExporter{
+			"stale:4317": newWrappedExporter(mockComponent{}, "stale:4317"),
+		},
+	}
+
+	_, endpoint, err := lb.randomExporterAndEndpoint()
+
+	require.ErrorContains(t, err, "eligible:4317")
+	require.Empty(t, endpoint)
+}
+
 func TestMultipleResolvers(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := &Config{

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -185,7 +185,7 @@ func (e *logExporterImp) consumeLogsCentralQueue(_ context.Context, ld plog.Logs
 	for routingKey, logs := range batches {
 		queueRoutingKey := routingKey[:]
 		if e.ignoreTraceID {
-			queueRoutingKey = centralQueueLaneRoutingKey(signalKindLogs, queueRoutingKey, e.centralQueueLaneCount)
+			queueRoutingKey = centralQueueRandomLogsRoutingKey()
 		}
 		item, err := newCentralQueueLogsItem(queueRoutingKey, logs, e.centralCodec, now)
 		if err != nil {
@@ -306,7 +306,13 @@ func (e *logExporterImp) consumeCentralQueueLogWindow(ctx context.Context, windo
 	if !decodedAny {
 		return nil
 	}
-	le, _, err := e.loadBalancer.exporterAndEndpoint(window.routingKey)
+	var le *wrappedExporter
+	var err error
+	if e.ignoreTraceID {
+		le, _, err = e.loadBalancer.randomExporterAndEndpoint()
+	} else {
+		le, _, err = e.loadBalancer.exporterAndEndpoint(window.routingKey)
+	}
 	if err != nil {
 		return err
 	}

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -211,10 +211,11 @@ func TestConsumeLogsCentralQueueEnqueuesCompressedByRoutingKey(t *testing.T) {
 	require.NoError(t, plogtest.CompareLogs(logs, decoded))
 }
 
-func TestConsumeLogsCentralQueueCoalescesRandomRoutingByLane(t *testing.T) {
+func TestConsumeLogsCentralQueueCoalescesRandomRoutingBeforeLaneSelection(t *testing.T) {
 	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
 	t.Cleanup(func() { require.NoError(t, codec.Close()) })
-	var next byte
+	traceIDs := distinctCentralQueueLaneTraceIDs(t, 2, 64)
+	var next atomic.Int64
 	p := &logExporterImp{
 		centralQueue: newCentralQueue(centralQueueSettings{
 			maxCompressedBytes:           1 << 20,
@@ -224,10 +225,10 @@ func TestConsumeLogsCentralQueueCoalescesRandomRoutingByLane(t *testing.T) {
 		}),
 		centralCodec:          codec,
 		ignoreTraceID:         true,
-		centralQueueLaneCount: 1,
+		centralQueueLaneCount: 64,
 		randomTraceID: func() pcommon.TraceID {
-			next++
-			return pcommon.TraceID{next}
+			index := int(next.Add(1)-1) % len(traceIDs)
+			return traceIDs[index]
 		},
 	}
 	p.started.Store(true)
@@ -242,6 +243,7 @@ func TestConsumeLogsCentralQueueCoalescesRandomRoutingByLane(t *testing.T) {
 	require.NoError(t, err)
 	defer lease.done()
 	require.Len(t, lease.window.items, 2)
+	require.Equal(t, centralQueueRandomLogsRoutingKey(), lease.window.routingKey)
 
 	merged := plog.NewLogs()
 	for _, item := range lease.window.items {
@@ -1672,6 +1674,24 @@ func findTraceIDForEndpoint(tb testing.TB, ring *hashRing, endpoint string) pcom
 
 	require.FailNow(tb, "failed to find trace id for endpoint", "endpoint=%s", endpoint)
 	return pcommon.TraceID{}
+}
+
+func distinctCentralQueueLaneTraceIDs(t *testing.T, count, laneCount int) []pcommon.TraceID {
+	t.Helper()
+	traceIDs := make([]pcommon.TraceID, 0, count)
+	seen := make(map[string]struct{}, count)
+	for i := 1; len(traceIDs) < count && i < 10_000; i++ {
+		var traceID pcommon.TraceID
+		copy(traceID[:], strconv.Itoa(i))
+		laneKey := string(centralQueueLaneRoutingKey(signalKindLogs, traceID[:], laneCount))
+		if _, ok := seen[laneKey]; ok {
+			continue
+		}
+		seen[laneKey] = struct{}{}
+		traceIDs = append(traceIDs, traceID)
+	}
+	require.Len(t, traceIDs, count)
+	return traceIDs
 }
 
 func sharedResourceScopeLog(body string) plog.Logs {


### PR DESCRIPTION
## Summary
- coalesce random-routed logs in one central queue request stream before choosing a backend
- keep routed signals lane-aware while using late random backend selection for ignore_trace_id logs
- add central queue window flush reason and underfilled-window metrics for rollout proof

## Tests
- cd exporter/loadbalancingexporter && go test . -run 'TestConsumeLogsCentralQueue(CoalescesRandomRoutingBeforeLaneSelection|EnqueuesCompressedByRoutingKey)|TestCentralQueue(LeaseCoalescesReadyItemsByRoutingKey|LeaseDoesNotCoalesceDifferentRoutingKeys|LeaseMarksHardCapFlush|LeaseWaitsForSmallWindowMaxDelay|StopAllowsDrainingExistingItems)|TestCentralQueueTelemetryRecordsInstruments|TestRandomExporterAndEndpointUsesEligibleRing' -count=1\n- cd exporter/loadbalancingexporter && go test . -count=1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central-queue log routing when `log_routing.ignore_trace_id` is enabled by deferring backend selection until dispatch, which can alter load distribution and batching behavior. Adds new central-queue window metrics and flush-reason logic that could affect observability dashboards/alerts but is otherwise self-contained.
> 
> **Overview**
> When `central_queue` is enabled and `log_routing.ignore_trace_id=true`, log payloads are now enqueued under a *shared* routing key so they can be coalesced into larger request windows, and the backend endpoint is chosen randomly only when the window is dispatched (via `randomExporterAndEndpoint`).
> 
> Central queue windows now track a `flushReason` (`target_reached`, `hard_cap`, `max_delay_low_traffic`, `shutdown`) and emit new metrics `otelcol_loadbalancer_central_queue_window_flush_total` and `otelcol_loadbalancer_central_queue_window_underfilled_total` to show why windows flushed and whether they missed the compressed-byte target; docs and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4064897d972e277e60f139481f3918717a6ab7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->