### PR TITLE
feat(loadbalancingexporter): add central queue parallel consumers

### DIFF
--- a/.chloggen/loadbalancing-central-queue-parallel-consumers.yaml
+++ b/.chloggen/loadbalancing-central-queue-parallel-consumers.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add configurable parallel consumers for the compressed central queue.
+issues: [64]
+subtext: |-
+  Adds `central_queue.num_consumers` and active/configured consumer metrics so
+  load-balanced logs and metrics can keep target-sized request windows while
+  sending multiple central queue windows concurrently.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -159,6 +159,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `target_compressed_bytes` is the soft compressed-size target for one backend request assembled from queued payloads. Default: `262144` (`256 KiB`).
   * `max_batch_delay` bounds how long a small backend lane can wait for more queued payloads before dispatch. Default: `250ms`.
   * `lane_count` controls how many backend lanes routing keys are coalesced into before a backend endpoint is selected. Default: `64`.
+  * `num_consumers` sets the number of parallel central queue drain workers per signal exporter. Default: `20`.
   * Queued payloads stay compressed until dispatch. Central queue capacity is enforced on compressed bytes; request windows are decoded only after a lane is leased, merged, and ready to send.
   * Central queue mode is incompatible with `sending_queue.enabled=true`, `protocol.otlp.sending_queue`, `log_batcher.enabled=true`, and `metric_batcher.enabled=true`. Child OTLP exporter queues are disabled while central queue mode is active.
 
@@ -530,6 +531,9 @@ The following metrics are recorded by this exporter:
   * `otelcol_loadbalancer_metric_batch_pending_oldest_datapoint_age_max` reports the maximum pending oldest-datapoint age across all backend endpoints.
   * `otelcol_loadbalancer_metric_batch_flush_oldest_datapoint_age` records the age of the oldest metric datapoint in each flushed batch.
 * When central queue mode is active, `otelcol_loadbalancer_central_queue_oldest_item_age` reports the age in milliseconds of the oldest item waiting in the central queue.
+* Central queue worker metrics show whether each LB pod is draining queue windows in parallel:
+  * `otelcol_loadbalancer_central_queue_configured_consumers` reports configured drain workers per signal exporter.
+  * `otelcol_loadbalancer_central_queue_active_consumers` reports drain workers currently processing or sending a leased queue window.
 * Central queue window metrics show whether request coalescing is addressing small backend requests:
   * `otelcol_loadbalancer_central_queue_window_compressed_bytes` reports compressed bytes leased into each request window.
   * `otelcol_loadbalancer_central_queue_window_uncompressed_bytes` reports decoded OTLP bytes in each merged request window.

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -178,12 +178,13 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 		return nil, errCentralQueueInflightFull
 	}
 	readyInflightBlocked := false
-	for _, candidate := range fallbackCandidates {
+	for i := range fallbackCandidates {
+		candidate := &fallbackCandidates[i]
 		if q.windowInflightBlockedLocked(candidate.window) {
 			readyInflightBlocked = true
 			continue
 		}
-		return q.leaseWindowCandidateLocked(candidate), nil
+		return q.leaseWindowCandidateLocked(*candidate), nil
 	}
 	if readyInflightBlocked {
 		return nil, errCentralQueueInflightFull

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -256,7 +256,8 @@ func (q *centralQueue) windowWouldExceedLimit(window centralQueueWindow, item ce
 }
 
 func (q *centralQueue) windowInflightBlockedLocked(window centralQueueWindow) bool {
-	return q.currentInflightBytes+int64(window.uncompressedBytes) > q.settings.maxInflightUncompressedBytes
+	return q.settings.maxInflightUncompressedBytes > 0 &&
+		q.currentInflightBytes+int64(window.uncompressedBytes) > q.settings.maxInflightUncompressedBytes
 }
 
 func (q *centralQueue) leaseWindowCandidateLocked(candidate centralQueueWindowCandidate) *centralQueueLease {

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -148,8 +148,9 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 	}
 
 	nowUnixNano := now.UnixNano()
-	readyInflightBlocked := false
 	evaluatedRoutingKeys := make(map[string]struct{})
+	var fallbackCandidates []centralQueueWindowCandidate
+	targetInflightBlocked := false
 	for _, item := range q.items {
 		if item.nextAttemptUnixNano > nowUnixNano {
 			continue
@@ -163,24 +164,26 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 		if !ok {
 			continue
 		}
-		if q.currentInflightBytes+int64(candidate.window.uncompressedBytes) > q.settings.maxInflightUncompressedBytes {
+		if candidate.window.flushReason != centralQueueFlushReasonTargetReached {
+			fallbackCandidates = append(fallbackCandidates, candidate)
+			continue
+		}
+		if q.windowInflightBlockedLocked(candidate.window) {
+			targetInflightBlocked = true
+			continue
+		}
+		return q.leaseWindowCandidateLocked(candidate), nil
+	}
+	if targetInflightBlocked {
+		return nil, errCentralQueueInflightFull
+	}
+	readyInflightBlocked := false
+	for _, candidate := range fallbackCandidates {
+		if q.windowInflightBlockedLocked(candidate.window) {
 			readyInflightBlocked = true
 			continue
 		}
-
-		q.removeWindowLocked(candidate.indexes)
-		q.currentInflightBytes += int64(candidate.window.uncompressedBytes)
-		snapshot := q.snapshotLocked()
-		q.settings.telemetry.record(context.Background(), snapshot)
-		q.settings.telemetry.recordWindow(context.Background(), candidate.window, q.settings.targetCompressedBytes)
-		lease := &centralQueueLease{
-			queue:  q,
-			window: candidate.window,
-		}
-		if len(candidate.window.items) > 0 {
-			lease.item = candidate.window.items[0]
-		}
-		return lease, nil
+		return q.leaseWindowCandidateLocked(candidate), nil
 	}
 	if readyInflightBlocked {
 		return nil, errCentralQueueInflightFull
@@ -250,6 +253,26 @@ func (q *centralQueue) buildWindowCandidateLocked(routingKey []byte, now time.Ti
 func (q *centralQueue) windowWouldExceedLimit(window centralQueueWindow, item centralQueueItem) bool {
 	return q.settings.maxUncompressedBatchBytes > 0 &&
 		window.uncompressedBytes+item.uncompressedBytes > q.settings.maxUncompressedBatchBytes
+}
+
+func (q *centralQueue) windowInflightBlockedLocked(window centralQueueWindow) bool {
+	return q.currentInflightBytes+int64(window.uncompressedBytes) > q.settings.maxInflightUncompressedBytes
+}
+
+func (q *centralQueue) leaseWindowCandidateLocked(candidate centralQueueWindowCandidate) *centralQueueLease {
+	q.removeWindowLocked(candidate.indexes)
+	q.currentInflightBytes += int64(candidate.window.uncompressedBytes)
+	snapshot := q.snapshotLocked()
+	q.settings.telemetry.record(context.Background(), snapshot)
+	q.settings.telemetry.recordWindow(context.Background(), candidate.window, q.settings.targetCompressedBytes)
+	lease := &centralQueueLease{
+		queue:  q,
+		window: candidate.window,
+	}
+	if len(candidate.window.items) > 0 {
+		lease.item = candidate.window.items[0]
+	}
+	return lease
 }
 
 func (q *centralQueue) removeItemLocked(index int) {

--- a/exporter/loadbalancingexporter/central_queue_telemetry.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry.go
@@ -26,6 +26,8 @@ type centralQueueTelemetry struct {
 	retries              metric.Int64Counter
 	decodeFailures       metric.Int64Counter
 	inflightUncompressed metric.Int64Gauge
+	configuredConsumers  metric.Int64Gauge
+	activeConsumers      metric.Int64Gauge
 	windowCompressed     metric.Int64Histogram
 	windowFlush          metric.Int64Counter
 	windowUncompressed   metric.Int64Histogram
@@ -107,6 +109,18 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 		"otelcol_loadbalancer_central_queue_inflight_uncompressed_bytes",
 		metric.WithDescription("Uncompressed bytes currently leased from the central load-balancing queue."),
 		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	t.configuredConsumers, err = meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_configured_consumers",
+		metric.WithDescription("Configured central queue drain workers for the signal exporter."),
+		metric.WithUnit("{workers}"),
+	)
+	errs = errors.Join(errs, err)
+	t.activeConsumers, err = meter.Int64Gauge(
+		"otelcol_loadbalancer_central_queue_active_consumers",
+		metric.WithDescription("Central queue drain workers currently processing or sending a leased window."),
+		metric.WithUnit("{workers}"),
 	)
 	errs = errors.Join(errs, err)
 	t.windowCompressed, err = meter.Int64Histogram(
@@ -202,6 +216,20 @@ func (t *centralQueueTelemetry) recordDecodeFailure(ctx context.Context, dropped
 		return
 	}
 	t.decodeFailures.Add(ctx, droppedItems, t.signalAttrs)
+}
+
+func (t *centralQueueTelemetry) recordConfiguredConsumers(ctx context.Context, consumers int64) {
+	if t == nil {
+		return
+	}
+	t.configuredConsumers.Record(ctx, consumers, t.signalAttrs)
+}
+
+func (t *centralQueueTelemetry) recordActiveConsumers(ctx context.Context, consumers int64) {
+	if t == nil {
+		return
+	}
+	t.activeConsumers.Record(ctx, consumers, t.signalAttrs)
 }
 
 func (t *centralQueueTelemetry) recordWindow(ctx context.Context, window centralQueueWindow, targetCompressedBytes int64) {

--- a/exporter/loadbalancingexporter/central_queue_telemetry_test.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry_test.go
@@ -32,6 +32,8 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 	telemetry.recordRejected(t.Context(), 7)
 	telemetry.recordRetry(t.Context())
 	telemetry.recordDecodeFailure(t.Context(), 5)
+	telemetry.recordConfiguredConsumers(t.Context(), 20)
+	telemetry.recordActiveConsumers(t.Context(), 3)
 	telemetry.recordWindow(t.Context(), centralQueueWindow{
 		items:             []centralQueueItem{{}, {}},
 		compressedBytes:   32,
@@ -47,6 +49,8 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 	requireCentralQueueFloatGauge(t, reader, "otelcol_loadbalancer_central_queue_saturation", "1", attrs, 0.5)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_items", "{items}", attrs, 3)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_inflight_uncompressed_bytes", "By", attrs, 80)
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_configured_consumers", "{workers}", attrs, 20)
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_active_consumers", "{workers}", attrs, 3)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_oldest_item_age", "ms", attrs, 125)
 	requireCentralQueueIntSum(t, reader, "otelcol_loadbalancer_central_queue_rejected_compressed_bytes", "By", attrs, 7)
 	requireCentralQueueIntSum(t, reader, "otelcol_loadbalancer_central_queue_retries", "{retries}", attrs, 1)

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -46,6 +46,30 @@ func TestCentralQueueLeaseReservesInflightUncompressedBytes(t *testing.T) {
 	require.EqualValues(t, 0, q.inflightUncompressedBytes())
 }
 
+func TestCentralQueueLeaseTreatsZeroInflightBudgetAsUnlimited(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:        100,
+		maxUncompressedBatchBytes: 100,
+		targetCompressedBytes:     10,
+		maxBatchDelay:             time.Second,
+	})
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 40, count: 1}))
+	require.NoError(t, q.enqueue(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-b"), compressedBytes: 10, uncompressedBytes: 40, count: 1}))
+
+	first, err := q.tryLease(time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.EqualValues(t, 40, q.inflightUncompressedBytes())
+
+	second, err := q.tryLease(time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.EqualValues(t, 80, q.inflightUncompressedBytes())
+
+	first.done()
+	second.done()
+}
+
 func TestCentralQueueLeaseReservesCompressedBytesUntilDoneOrRequeue(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:           10,

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -98,6 +98,58 @@ func TestCentralQueueLeaseCoalescesReadyItemsByRoutingKey(t *testing.T) {
 	require.EqualValues(t, 10, q.compressedBytes())
 }
 
+func TestCentralQueueLeasePrefersTargetWindowOverOlderUnderfilledWindow(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                250 * time.Millisecond,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("older"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("target"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now.Add(10*time.Millisecond)))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("target"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now.Add(20*time.Millisecond)))
+
+	lease, err := q.tryLease(now.Add(250 * time.Millisecond))
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.Equal(t, []byte("target"), lease.window.routingKey)
+	require.Len(t, lease.window.items, 2)
+	require.Equal(t, centralQueueFlushReasonTargetReached, lease.window.flushReason)
+	require.Equal(t, 1, q.len())
+
+	lease.done()
+	require.EqualValues(t, 10, q.compressedBytes())
+}
+
+func TestCentralQueueLeaseDoesNotLeaseUnderfilledWindowWhenTargetWindowIsInflightBlocked(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 50,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                250 * time.Millisecond,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("inflight"), compressedBytes: 20, uncompressedBytes: 30, count: 1}, now))
+	inflightLease, err := q.tryLease(now)
+	require.NoError(t, err)
+	require.NotNil(t, inflightLease)
+
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("older"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("target"), compressedBytes: 10, uncompressedBytes: 15, count: 1}, now.Add(10*time.Millisecond)))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("target"), compressedBytes: 10, uncompressedBytes: 15, count: 1}, now.Add(20*time.Millisecond)))
+
+	lease, err := q.tryLease(now.Add(250 * time.Millisecond))
+	require.ErrorIs(t, err, errCentralQueueInflightFull)
+	require.Nil(t, lease)
+	require.Equal(t, 3, q.len())
+	require.EqualValues(t, 30, q.inflightUncompressedBytes())
+
+	inflightLease.done()
+}
+
 func TestCentralQueueLeaseDoesNotCoalesceDifferentRoutingKeys(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:           100,

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -236,7 +236,7 @@ const (
 	defaultCentralQueueMaxBatchDelay             = 250 * time.Millisecond
 	defaultCentralQueueLaneCount                 = 64
 	// Keep default drain parallelism high enough for hot LB pods while avoiding
-	// the goroutine and in-flight memory footprint of the BigID hot profile.
+	// the goroutine and in-flight memory footprint of larger tuned deployments.
 	defaultCentralQueueNumConsumers = 20
 )
 

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -235,6 +235,7 @@ const (
 	defaultCentralQueueTargetCompressedBytes     = int64(256 << 10)
 	defaultCentralQueueMaxBatchDelay             = 250 * time.Millisecond
 	defaultCentralQueueLaneCount                 = 64
+	defaultCentralQueueNumConsumers              = 20
 )
 
 type CentralQueueConfig struct {
@@ -246,6 +247,7 @@ type CentralQueueConfig struct {
 	TargetCompressedBytes        int64                   `mapstructure:"target_compressed_bytes"`
 	MaxBatchDelay                time.Duration           `mapstructure:"max_batch_delay"`
 	LaneCount                    int                     `mapstructure:"lane_count"`
+	NumConsumers                 int                     `mapstructure:"num_consumers"`
 }
 
 func (q QueueSettings) Validate() error {
@@ -348,6 +350,9 @@ func (c CentralQueueConfig) Validate() error {
 	}
 	if c.LaneCount <= 0 {
 		return errors.New("central_queue.lane_count must be greater than 0 when central_queue.enabled=true")
+	}
+	if c.NumConsumers <= 0 {
+		return errors.New("central_queue.num_consumers must be greater than 0 when central_queue.enabled=true")
 	}
 	return nil
 }

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -235,7 +235,9 @@ const (
 	defaultCentralQueueTargetCompressedBytes     = int64(256 << 10)
 	defaultCentralQueueMaxBatchDelay             = 250 * time.Millisecond
 	defaultCentralQueueLaneCount                 = 64
-	defaultCentralQueueNumConsumers              = 20
+	// Keep default drain parallelism high enough for hot LB pods while avoiding
+	// the goroutine and in-flight memory footprint of the BigID hot profile.
+	defaultCentralQueueNumConsumers = 20
 )
 
 type CentralQueueConfig struct {

--- a/exporter/loadbalancingexporter/config.schema.yaml
+++ b/exporter/loadbalancingexporter/config.schema.yaml
@@ -28,6 +28,11 @@ $defs:
         type: integer
         minimum: 1
         description: Number of backend lanes used to coalesce routing keys before late endpoint selection.
+      num_consumers:
+        type: integer
+        minimum: 1
+        default: 20
+        description: Number of parallel workers draining central queue request windows per signal exporter.
       payload_compression:
         type: string
         enum:

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -141,6 +141,7 @@ func TestCentralQueueDefaultDisabled(t *testing.T) {
 	require.Equal(t, int64(256<<10), cfg.CentralQueue.TargetCompressedBytes)
 	require.Equal(t, 250*time.Millisecond, cfg.CentralQueue.MaxBatchDelay)
 	require.Equal(t, 64, cfg.CentralQueue.LaneCount)
+	require.Equal(t, 20, cfg.CentralQueue.NumConsumers)
 	require.NoError(t, cfg.Validate())
 }
 
@@ -202,6 +203,11 @@ func TestCentralQueueValidation(t *testing.T) {
 			name:        "missing lane count",
 			mutate:      func(c *CentralQueueConfig) { c.LaneCount = 0 },
 			expectedErr: "central_queue.lane_count",
+		},
+		{
+			name:        "missing num consumers",
+			mutate:      func(c *CentralQueueConfig) { c.NumConsumers = 0 },
+			expectedErr: "central_queue.num_consumers",
 		},
 	}
 

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -61,6 +61,7 @@ func createDefaultConfig() component.Config {
 			TargetCompressedBytes:        defaultCentralQueueTargetCompressedBytes,
 			MaxBatchDelay:                defaultCentralQueueMaxBatchDelay,
 			LaneCount:                    defaultCentralQueueLaneCount,
+			NumConsumers:                 defaultCentralQueueNumConsumers,
 		},
 		LogBatcher: LogBatcherConfig{
 			Enabled:            false,

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -41,6 +41,8 @@ type logExporterImp struct {
 	randomTraceID            func() pcommon.TraceID
 	centralQueueByteBatching bool
 	centralQueueLaneCount    int
+	centralQueueNumConsumers int
+	centralActiveConsumers   atomic.Int64
 	centralCancel            context.CancelFunc
 	centralWG                sync.WaitGroup
 }
@@ -72,6 +74,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 		randomTraceID:            random,
 		centralQueueByteBatching: cfg.(*Config).centralQueueByteBatchingEnabled(),
 		centralQueueLaneCount:    cfg.(*Config).CentralQueue.LaneCount,
+		centralQueueNumConsumers: cfg.(*Config).CentralQueue.NumConsumers,
 	}
 	if cfg.(*Config).CentralQueue.Enabled {
 		centralCfg := cfg.(*Config).CentralQueue
@@ -126,10 +129,22 @@ func (e *logExporterImp) Start(ctx context.Context, host component.Host) error {
 	if e.centralQueue != nil {
 		dispatchCtx, cancel := context.WithCancel(context.Background())
 		e.centralCancel = cancel
-		e.centralWG.Add(1)
-		go e.runCentralQueue(dispatchCtx)
+		e.startCentralQueueConsumers(dispatchCtx)
 	}
 	return nil
+}
+
+func (e *logExporterImp) startCentralQueueConsumers(ctx context.Context) {
+	consumers := e.centralQueueNumConsumers
+	if consumers <= 0 {
+		consumers = defaultCentralQueueNumConsumers
+	}
+	e.centralQueue.settings.telemetry.recordConfiguredConsumers(ctx, int64(consumers))
+	e.centralQueue.settings.telemetry.recordActiveConsumers(ctx, e.centralActiveConsumers.Load())
+	for i := 0; i < consumers; i++ {
+		e.centralWG.Add(1)
+		go e.runCentralQueue(ctx)
+	}
 }
 
 func (e *logExporterImp) Shutdown(ctx context.Context) error {
@@ -241,7 +256,7 @@ func (e *logExporterImp) runCentralQueue(ctx context.Context) {
 			continue
 		}
 
-		err = e.consumeCentralQueueLogWindow(ctx, lease.window)
+		err = e.consumeActiveCentralQueueLogWindow(ctx, lease.window)
 		if err == nil {
 			lease.done()
 			continue
@@ -259,6 +274,16 @@ func (e *logExporterImp) runCentralQueue(ctx context.Context) {
 			e.logger.Warn("failed to requeue central log queue item", zap.Error(requeueErr), zap.Error(err))
 		}
 	}
+}
+
+func (e *logExporterImp) consumeActiveCentralQueueLogWindow(ctx context.Context, window centralQueueWindow) error {
+	active := e.centralActiveConsumers.Add(1)
+	e.centralQueue.settings.telemetry.recordActiveConsumers(ctx, active)
+	defer func() {
+		active := e.centralActiveConsumers.Add(-1)
+		e.centralQueue.settings.telemetry.recordActiveConsumers(ctx, active)
+	}()
+	return e.consumeCentralQueueLogWindow(ctx, window)
 }
 
 func (e *logExporterImp) consumeCentralQueueLogItem(ctx context.Context, item centralQueueItem) error {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -568,6 +568,73 @@ func TestLogsCentralQueueDoesNotDrainSynchronously(t *testing.T) {
 	}
 }
 
+func TestLogsCentralQueueConsumersSendWindowsConcurrently(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := endpoint2Config()
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	var calls atomic.Int64
+
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(context.Context, plog.Logs) error {
+			if endpoint == "endpoint-1:4317" {
+				calls.Add(1)
+				started <- struct{}{}
+				<-release
+			}
+			return nil
+		}), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.endpointHealth.reconcile([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.ring = newHashRing([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1:4317", "endpoint-2:4317"})
+	route := findRoutingIDForEndpoint(t, lb.ring, "endpoint-1:4317")
+
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1024 * 1024,
+			maxInflightUncompressedBytes: 1024 * 1024,
+			maxUncompressedBatchBytes:    1024 * 1024,
+			targetCompressedBytes:        1,
+			maxBatchDelay:                time.Second,
+		}),
+		centralCodec:             codec,
+		loadBalancer:             lb,
+		logger:                   ts.Logger,
+		telemetry:                tb,
+		centralQueueNumConsumers: 2,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	p.startCentralQueueConsumers(ctx)
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		p.centralQueue.stop()
+		cancel()
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+		defer waitCancel()
+		require.NoError(t, waitForInflight(waitCtx, &p.centralWG))
+	})
+
+	first, err := newCentralQueueLogsItem([]byte(route), simpleLogs(), codec, time.Now())
+	require.NoError(t, err)
+	second, err := newCentralQueueLogsItem([]byte(route), simpleLogs(), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(first))
+	require.NoError(t, p.centralQueue.enqueue(second))
+
+	require.Eventually(t, func() bool { return len(started) == 2 }, time.Second, 10*time.Millisecond)
+	require.Equal(t, int64(2), calls.Load())
+	releaseOnce.Do(func() { close(release) })
+}
+
 func TestConsumeLogsEmitsOnlyParentExporterMetrics(t *testing.T) {
 	ctx := t.Context()
 	shutdownCtx := context.Background() //nolint:usetesting // Context must outlive test for cleanup

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -614,11 +614,12 @@ func TestLogsCentralQueueConsumersSendWindowsConcurrently(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	p.startCentralQueueConsumers(ctx)
+	cleanupCtx := context.WithoutCancel(t.Context())
 	t.Cleanup(func() {
 		releaseOnce.Do(func() { close(release) })
 		p.centralQueue.stop()
 		cancel()
-		waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+		waitCtx, waitCancel := context.WithTimeout(cleanupCtx, time.Second)
 		defer waitCancel()
 		require.NoError(t, waitForInflight(waitCtx, &p.centralWG))
 	})

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -40,12 +40,14 @@ type metricExporterImp struct {
 	centralCodec *queuePayloadCodec
 	routingKey   routingKey
 
-	logger                *zap.Logger
-	started               atomic.Bool
-	telemetry             *metadata.TelemetryBuilder
-	centralQueueLaneCount int
-	centralCancel         context.CancelFunc
-	centralWG             sync.WaitGroup
+	logger                   *zap.Logger
+	started                  atomic.Bool
+	telemetry                *metadata.TelemetryBuilder
+	centralQueueLaneCount    int
+	centralQueueNumConsumers int
+	centralActiveConsumers   atomic.Int64
+	centralCancel            context.CancelFunc
+	centralWG                sync.WaitGroup
 }
 
 func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metricExporterImp, error) {
@@ -67,11 +69,12 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 	}
 
 	metricExporter := metricExporterImp{
-		loadBalancer:          lb,
-		routingKey:            svcRouting,
-		telemetry:             telemetry,
-		logger:                params.Logger,
-		centralQueueLaneCount: cfg.(*Config).CentralQueue.LaneCount,
+		loadBalancer:             lb,
+		routingKey:               svcRouting,
+		telemetry:                telemetry,
+		logger:                   params.Logger,
+		centralQueueLaneCount:    cfg.(*Config).CentralQueue.LaneCount,
+		centralQueueNumConsumers: cfg.(*Config).CentralQueue.NumConsumers,
 	}
 	if cfg.(*Config).CentralQueue.Enabled {
 		centralCfg := cfg.(*Config).CentralQueue
@@ -141,10 +144,22 @@ func (e *metricExporterImp) Start(ctx context.Context, host component.Host) erro
 	if e.centralQueue != nil {
 		dispatchCtx, cancel := context.WithCancel(context.Background())
 		e.centralCancel = cancel
-		e.centralWG.Add(1)
-		go e.runCentralQueue(dispatchCtx)
+		e.startCentralQueueConsumers(dispatchCtx)
 	}
 	return nil
+}
+
+func (e *metricExporterImp) startCentralQueueConsumers(ctx context.Context) {
+	consumers := e.centralQueueNumConsumers
+	if consumers <= 0 {
+		consumers = defaultCentralQueueNumConsumers
+	}
+	e.centralQueue.settings.telemetry.recordConfiguredConsumers(ctx, int64(consumers))
+	e.centralQueue.settings.telemetry.recordActiveConsumers(ctx, e.centralActiveConsumers.Load())
+	for i := 0; i < consumers; i++ {
+		e.centralWG.Add(1)
+		go e.runCentralQueue(ctx)
+	}
 }
 
 func (e *metricExporterImp) Shutdown(ctx context.Context) error {
@@ -230,7 +245,7 @@ func (e *metricExporterImp) runCentralQueue(ctx context.Context) {
 			continue
 		}
 
-		err = e.consumeCentralQueueMetricWindow(ctx, lease.window)
+		err = e.consumeActiveCentralQueueMetricWindow(ctx, lease.window)
 		if err == nil {
 			lease.done()
 			continue
@@ -248,6 +263,16 @@ func (e *metricExporterImp) runCentralQueue(ctx context.Context) {
 			e.logger.Warn("failed to requeue central metric queue item", zap.Error(requeueErr), zap.Error(err))
 		}
 	}
+}
+
+func (e *metricExporterImp) consumeActiveCentralQueueMetricWindow(ctx context.Context, window centralQueueWindow) error {
+	active := e.centralActiveConsumers.Add(1)
+	e.centralQueue.settings.telemetry.recordActiveConsumers(ctx, active)
+	defer func() {
+		active := e.centralActiveConsumers.Add(-1)
+		e.centralQueue.settings.telemetry.recordActiveConsumers(ctx, active)
+	}()
+	return e.consumeCentralQueueMetricWindow(ctx, window)
 }
 
 func (e *metricExporterImp) consumeCentralQueueMetricItem(ctx context.Context, item centralQueueItem) error {

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -584,11 +584,12 @@ func TestMetricsCentralQueueConsumersSendWindowsConcurrently(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	p.startCentralQueueConsumers(ctx)
+	cleanupCtx := context.WithoutCancel(t.Context())
 	t.Cleanup(func() {
 		releaseOnce.Do(func() { close(release) })
 		p.centralQueue.stop()
 		cancel()
-		waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+		waitCtx, waitCancel := context.WithTimeout(cleanupCtx, time.Second)
 		defer waitCancel()
 		require.NoError(t, waitForInflight(waitCtx, &p.centralWG))
 	})

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -538,6 +538,73 @@ func TestMetricsCentralQueueDoesNotDirectReroute(t *testing.T) {
 	assert.Zero(t, calls["endpoint-2:4317"])
 }
 
+func TestMetricsCentralQueueConsumersSendWindowsConcurrently(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := endpoint2Config()
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	var calls atomic.Int64
+
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockMetricsExporter(func(context.Context, pmetric.Metrics) error {
+			if endpoint == "endpoint-1:4317" {
+				calls.Add(1)
+				started <- struct{}{}
+				<-release
+			}
+			return nil
+		}), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.endpointHealth.reconcile([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.ring = newHashRing([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1:4317", "endpoint-2:4317"})
+	route := findRoutingIDForEndpoint(t, lb.ring, "endpoint-1:4317")
+
+	p := &metricExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1024 * 1024,
+			maxInflightUncompressedBytes: 1024 * 1024,
+			maxUncompressedBatchBytes:    1024 * 1024,
+			targetCompressedBytes:        1,
+			maxBatchDelay:                time.Second,
+		}),
+		centralCodec:             codec,
+		loadBalancer:             lb,
+		logger:                   ts.Logger,
+		telemetry:                tb,
+		centralQueueNumConsumers: 2,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	p.startCentralQueueConsumers(ctx)
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		p.centralQueue.stop()
+		cancel()
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), time.Second)
+		defer waitCancel()
+		require.NoError(t, waitForInflight(waitCtx, &p.centralWG))
+	})
+
+	first, err := newCentralQueueMetricsItem([]byte(route), metricsWithServiceNames(route), codec, time.Now())
+	require.NoError(t, err)
+	second, err := newCentralQueueMetricsItem([]byte(route), metricsWithServiceNames(route), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(first))
+	require.NoError(t, p.centralQueue.enqueue(second))
+
+	require.Eventually(t, func() bool { return len(started) == 2 }, time.Second, 10*time.Millisecond)
+	require.Equal(t, int64(2), calls.Load())
+	releaseOnce.Do(func() { close(release) })
+}
+
 // loadMetricsMap will parse the given yaml file into a map[string]pmetric.Metrics
 func loadMetricsMap(t *testing.T, path string) map[string]pmetric.Metrics {
 	b, err := os.ReadFile(path)


### PR DESCRIPTION
Sanitized Sawmills fork metadata.

Summary: adds central queue parallel consumer support for loadbalancing exporter queue-drain behavior.

Verification: covered by the cleaned commit history and PR checks.