### PR TITLE
feat(loadbalancingexporter): add central queue ready windows

### DIFF
--- a/.chloggen/loadbalancing-central-ready-window-scheduler.yaml
+++ b/.chloggen/loadbalancing-central-ready-window-scheduler.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add bounded ready-window scheduling metrics for the compressed central queue.
+issues: []
+subtext: |-
+  The compressed central queue now builds bounded ready request windows before
+  drain workers lease them, so parallel consumers preserve target-sized
+  windows while the ready backlog remains capped by `central_queue.num_consumers`.
+  New ready-window and scheduler-state gauges expose whether dispatch is limited
+  by waiting traffic, ready-window capacity, or in-flight uncompressed bytes.
+change_logs: [user]

--- a/.chloggen/loadbalancing-central-ready-window-scheduler.yaml
+++ b/.chloggen/loadbalancing-central-ready-window-scheduler.yaml
@@ -1,7 +1,7 @@
 change_type: enhancement
 component: exporter/loadbalancing
 note: Add bounded ready-window scheduling metrics for the compressed central queue.
-issues: []
+issues: [65]
 subtext: |-
   The compressed central queue now builds bounded ready request windows before
   drain workers lease them, so parallel consumers preserve target-sized

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -160,7 +160,8 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `max_batch_delay` bounds how long a small backend lane can wait for more queued payloads before dispatch. Default: `250ms`.
   * `lane_count` controls how many backend lanes routing keys are coalesced into before a backend endpoint is selected. Default: `64`.
   * `num_consumers` sets the number of parallel central queue drain workers per signal exporter. Default: `20`.
-  * Queued payloads stay compressed until dispatch. Central queue capacity is enforced on compressed bytes; request windows are decoded only after a lane is leased, merged, and ready to send.
+  * Queued payloads stay compressed until dispatch. Central queue capacity is enforced on compressed bytes; request windows are decoded only after a ready lane window is leased.
+  * The scheduler keeps a bounded set of ready request windows, limited by `num_consumers`. Ready windows reserve uncompressed in-flight budget before a worker leases them, so parallel consumers do not shrink request windows beyond `target_compressed_bytes` unless a bounded flush reason applies.
   * Central queue mode is incompatible with `sending_queue.enabled=true`, `protocol.otlp.sending_queue`, `log_batcher.enabled=true`, and `metric_batcher.enabled=true`. Child OTLP exporter queues are disabled while central queue mode is active.
 
 Simple example
@@ -534,6 +535,11 @@ The following metrics are recorded by this exporter:
 * Central queue worker metrics show whether each LB pod is draining queue windows in parallel:
   * `otelcol_loadbalancer_central_queue_configured_consumers` reports configured drain workers per signal exporter.
   * `otelcol_loadbalancer_central_queue_active_consumers` reports drain workers currently processing or sending a leased queue window.
+* Central queue scheduler metrics show the bounded ready-window state:
+  * `otelcol_loadbalancer_central_queue_ready_windows` reports request windows ready to be leased by drain workers.
+  * `otelcol_loadbalancer_central_queue_ready_window_limit` reports the ready-window bound, which follows `central_queue.num_consumers`.
+  * `otelcol_loadbalancer_central_queue_ready_uncompressed_bytes` reports uncompressed bytes reserved by ready windows.
+  * `otelcol_loadbalancer_central_queue_scheduler_state` reports the latest scheduler state as a gauge with `state` labels. The active state is `1`; other states are `0`. States are `ready`, `queue_empty`, `waiting`, `inflight_uncompressed_bytes`, `ready_window_limit`, and `stopped`.
 * Central queue window metrics show whether request coalescing is addressing small backend requests:
   * `otelcol_loadbalancer_central_queue_window_compressed_bytes` reports compressed bytes leased into each request window.
   * `otelcol_loadbalancer_central_queue_window_uncompressed_bytes` reports decoded OTLP bytes in each merged request window.

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -253,7 +253,8 @@ func (q *centralQueue) scheduleReadyWindowCandidatesLocked(candidates []centralQ
 	selected := make([]centralQueueWindowCandidate, 0, len(candidates))
 	pendingInflightBytes := q.currentInflightBytes
 	blocked := false
-	for _, candidate := range candidates {
+	for i := range candidates {
+		candidate := &candidates[i]
 		if len(q.ready)+len(selected) >= q.settings.maxReadyWindows {
 			break
 		}
@@ -261,7 +262,7 @@ func (q *centralQueue) scheduleReadyWindowCandidatesLocked(candidates []centralQ
 			blocked = true
 			continue
 		}
-		selected = append(selected, candidate)
+		selected = append(selected, *candidate)
 		pendingInflightBytes += int64(candidate.window.uncompressedBytes)
 	}
 
@@ -269,13 +270,15 @@ func (q *centralQueue) scheduleReadyWindowCandidatesLocked(candidates []centralQ
 		return false, blocked
 	}
 
-	for _, candidate := range selected {
+	for i := range selected {
+		candidate := &selected[i]
 		q.ready = append(q.ready, candidate.window)
 		q.currentInflightBytes += int64(candidate.window.uncompressedBytes)
 	}
 
 	indexesToRemove := make([]int, 0)
-	for _, candidate := range selected {
+	for i := range selected {
+		candidate := &selected[i]
 		indexesToRemove = append(indexesToRemove, candidate.indexes...)
 	}
 	sort.Ints(indexesToRemove)
@@ -521,7 +524,8 @@ func (q *centralQueue) schedulerSnapshotLocked(now time.Time) centralQueueSchedu
 			snapshot.state = centralQueueSchedulerStateWaiting
 			return snapshot
 		}
-		for _, candidate := range targetCandidates {
+		for i := range targetCandidates {
+			candidate := &targetCandidates[i]
 			if !q.windowInflightBlockedLocked(candidate.window) {
 				snapshot.state = centralQueueSchedulerStateReady
 				return snapshot
@@ -531,7 +535,8 @@ func (q *centralQueue) schedulerSnapshotLocked(now time.Time) centralQueueSchedu
 			snapshot.state = centralQueueSchedulerStateInflightBytes
 			return snapshot
 		}
-		for _, candidate := range fallbackCandidates {
+		for i := range fallbackCandidates {
+			candidate := &fallbackCandidates[i]
 			if !q.windowInflightBlockedLocked(candidate.window) {
 				snapshot.state = centralQueueSchedulerStateReady
 				return snapshot

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -182,22 +182,24 @@ func (q *centralQueue) prepareReadyWindowsLocked(now time.Time) centralQueueSche
 		targetCandidates, fallbackCandidates, hasReady := q.collectWindowCandidatesLocked(now)
 		if len(targetCandidates) == 0 && len(fallbackCandidates) == 0 {
 			if !hasReady {
-				return centralQueueSchedulerStateWaiting
+				return state
 			}
 			return state
 		}
 
 		scheduledTarget, blocked := q.scheduleReadyWindowCandidatesLocked(targetCandidates)
+		if !scheduledTarget && blocked {
+			return centralQueueSchedulerStateInflightBytes
+		}
 		if scheduledTarget {
 			state = centralQueueSchedulerStateReady
-			continue
-		}
-		if blocked {
-			return centralQueueSchedulerStateInflightBytes
 		}
 		if len(q.ready) >= q.settings.maxReadyWindows {
 			state = centralQueueSchedulerStateReady
 			continue
+		}
+		if scheduledTarget {
+			_, fallbackCandidates, _ = q.collectWindowCandidatesLocked(now)
 		}
 
 		scheduledFallback, blocked := q.scheduleReadyWindowCandidatesLocked(fallbackCandidates)

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/binary"
 	"hash/crc32"
+	"sort"
 	"sync"
 	"time"
 )
@@ -17,7 +18,15 @@ const centralQueueLeasePollInterval = 10 * time.Millisecond
 const (
 	centralQueueInitialRetryDelay = 100 * time.Millisecond
 	centralQueueMaxRetryDelay     = 5 * time.Second
+	centralQueueMaxRetryJitter    = 100 * time.Millisecond
 )
+
+func centralQueueReadyWindowLimit(consumers int) int {
+	if consumers <= 0 {
+		return defaultCentralQueueNumConsumers
+	}
+	return consumers
+}
 
 type centralQueueSettings struct {
 	maxCompressedBytes           int64
@@ -25,6 +34,7 @@ type centralQueueSettings struct {
 	maxUncompressedBatchBytes    int
 	targetCompressedBytes        int64
 	maxBatchDelay                time.Duration
+	maxReadyWindows              int
 	telemetry                    *centralQueueTelemetry
 }
 
@@ -34,6 +44,7 @@ type centralQueue struct {
 	mu      sync.Mutex
 	items   []centralQueueItem
 	stopped bool
+	ready   []centralQueueWindow
 
 	currentCompressedBytes int64
 	currentInflightBytes   int64
@@ -78,8 +89,12 @@ func newCentralQueue(settings centralQueueSettings) *centralQueue {
 	if settings.targetCompressedBytes <= 0 {
 		settings.targetCompressedBytes = 1
 	}
+	if settings.maxReadyWindows <= 0 {
+		settings.maxReadyWindows = 1
+	}
 	q := &centralQueue{settings: settings}
 	q.settings.telemetry.observeOldestItemAge(q.oldestItemAgeMillis)
+	q.settings.telemetry.observeSchedulerState(q.schedulerSnapshot)
 	return q
 }
 
@@ -140,6 +155,10 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
+	if lease := q.leaseReadyWindowLocked(); lease != nil {
+		return lease, nil
+	}
+
 	if len(q.items) == 0 {
 		if q.stopped {
 			return nil, errCentralQueueStopped
@@ -147,14 +166,61 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 		return nil, nil
 	}
 
+	state := q.prepareReadyWindowsLocked(now)
+	if lease := q.leaseReadyWindowLocked(); lease != nil {
+		return lease, nil
+	}
+	if state == centralQueueSchedulerStateInflightBytes {
+		return nil, errCentralQueueInflightFull
+	}
+	return nil, nil
+}
+
+func (q *centralQueue) prepareReadyWindowsLocked(now time.Time) centralQueueSchedulerState {
+	state := centralQueueSchedulerStateWaiting
+	for len(q.ready) < q.settings.maxReadyWindows {
+		targetCandidates, fallbackCandidates, hasReady := q.collectWindowCandidatesLocked(now)
+		if len(targetCandidates) == 0 && len(fallbackCandidates) == 0 {
+			if !hasReady {
+				return centralQueueSchedulerStateWaiting
+			}
+			return state
+		}
+
+		scheduledTarget, blocked := q.scheduleReadyWindowCandidatesLocked(targetCandidates)
+		if blocked {
+			return centralQueueSchedulerStateInflightBytes
+		}
+		if len(q.ready) >= q.settings.maxReadyWindows {
+			state = centralQueueSchedulerStateReady
+			continue
+		}
+
+		scheduledFallback, blocked := q.scheduleReadyWindowCandidatesLocked(fallbackCandidates)
+		if blocked {
+			return centralQueueSchedulerStateInflightBytes
+		}
+		if !scheduledTarget && !scheduledFallback {
+			return state
+		}
+		state = centralQueueSchedulerStateReady
+	}
+	return centralQueueSchedulerStateReadyWindowLimit
+}
+
+// collectWindowCandidatesLocked evaluates one candidate per routing key so a hot
+// lane cannot fill the bounded ready backlog before other ready lanes get a turn.
+func (q *centralQueue) collectWindowCandidatesLocked(now time.Time) ([]centralQueueWindowCandidate, []centralQueueWindowCandidate, bool) {
 	nowUnixNano := now.UnixNano()
 	evaluatedRoutingKeys := make(map[string]struct{})
-	var fallbackCandidates []centralQueueWindowCandidate
-	targetInflightBlocked := false
+	targetCandidates := make([]centralQueueWindowCandidate, 0)
+	fallbackCandidates := make([]centralQueueWindowCandidate, 0)
+	hasReady := false
 	for _, item := range q.items {
 		if item.nextAttemptUnixNano > nowUnixNano {
 			continue
 		}
+		hasReady = true
 		routingKey := string(item.routingKey)
 		if _, ok := evaluatedRoutingKeys[routingKey]; ok {
 			continue
@@ -168,28 +234,50 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 			fallbackCandidates = append(fallbackCandidates, candidate)
 			continue
 		}
-		if q.windowInflightBlockedLocked(candidate.window) {
-			targetInflightBlocked = true
+		targetCandidates = append(targetCandidates, candidate)
+	}
+	return targetCandidates, fallbackCandidates, hasReady
+}
+
+func (q *centralQueue) scheduleReadyWindowCandidatesLocked(candidates []centralQueueWindowCandidate) (bool, bool) {
+	if len(candidates) == 0 {
+		return false, false
+	}
+
+	selected := make([]centralQueueWindowCandidate, 0, len(candidates))
+	pendingInflightBytes := q.currentInflightBytes
+	blocked := false
+	for _, candidate := range candidates {
+		if len(q.ready)+len(selected) >= q.settings.maxReadyWindows {
+			break
+		}
+		if q.windowInflightBlockedWithBase(candidate.window, pendingInflightBytes) {
+			blocked = true
 			continue
 		}
-		return q.leaseWindowCandidateLocked(candidate), nil
+		selected = append(selected, candidate)
+		pendingInflightBytes += int64(candidate.window.uncompressedBytes)
 	}
-	if targetInflightBlocked {
-		return nil, errCentralQueueInflightFull
+
+	if len(selected) == 0 {
+		return false, blocked
 	}
-	readyInflightBlocked := false
-	for i := range fallbackCandidates {
-		candidate := &fallbackCandidates[i]
-		if q.windowInflightBlockedLocked(candidate.window) {
-			readyInflightBlocked = true
-			continue
-		}
-		return q.leaseWindowCandidateLocked(*candidate), nil
+
+	for _, candidate := range selected {
+		q.ready = append(q.ready, candidate.window)
+		q.currentInflightBytes += int64(candidate.window.uncompressedBytes)
 	}
-	if readyInflightBlocked {
-		return nil, errCentralQueueInflightFull
+
+	indexesToRemove := make([]int, 0)
+	for _, candidate := range selected {
+		indexesToRemove = append(indexesToRemove, candidate.indexes...)
 	}
-	return nil, nil
+	sort.Ints(indexesToRemove)
+	q.removeWindowLocked(indexesToRemove, false)
+
+	snapshot := q.snapshotLocked()
+	q.settings.telemetry.record(context.Background(), snapshot)
+	return true, blocked
 }
 
 func (q *centralQueue) buildWindowCandidateLocked(routingKey []byte, now time.Time) (centralQueueWindowCandidate, bool) {
@@ -257,22 +345,35 @@ func (q *centralQueue) windowWouldExceedLimit(window centralQueueWindow, item ce
 }
 
 func (q *centralQueue) windowInflightBlockedLocked(window centralQueueWindow) bool {
-	return q.settings.maxInflightUncompressedBytes > 0 &&
-		q.currentInflightBytes+int64(window.uncompressedBytes) > q.settings.maxInflightUncompressedBytes
+	return q.windowInflightBlockedWithBase(window, q.currentInflightBytes)
 }
 
-func (q *centralQueue) leaseWindowCandidateLocked(candidate centralQueueWindowCandidate) *centralQueueLease {
-	q.removeWindowLocked(candidate.indexes)
-	q.currentInflightBytes += int64(candidate.window.uncompressedBytes)
+func (q *centralQueue) windowInflightBlockedWithBase(window centralQueueWindow, inflightBytes int64) bool {
+	return q.settings.maxInflightUncompressedBytes > 0 &&
+		inflightBytes+int64(window.uncompressedBytes) > q.settings.maxInflightUncompressedBytes
+}
+
+func (q *centralQueue) leaseReadyWindowLocked() *centralQueueLease {
+	if len(q.ready) == 0 {
+		return nil
+	}
+
+	window := q.ready[0]
+	copy(q.ready, q.ready[1:])
+	q.ready[len(q.ready)-1] = centralQueueWindow{}
+	q.ready = q.ready[:len(q.ready)-1]
+	for _, item := range window.items {
+		q.untrackOldestEnqueuedAtLocked(item)
+	}
 	snapshot := q.snapshotLocked()
 	q.settings.telemetry.record(context.Background(), snapshot)
-	q.settings.telemetry.recordWindow(context.Background(), candidate.window, q.settings.targetCompressedBytes)
+	q.settings.telemetry.recordWindow(context.Background(), window, q.settings.targetCompressedBytes)
 	lease := &centralQueueLease{
 		queue:  q,
-		window: candidate.window,
+		window: window,
 	}
-	if len(candidate.window.items) > 0 {
-		lease.item = candidate.window.items[0]
+	if len(window.items) > 0 {
+		lease.item = window.items[0]
 	}
 	return lease
 }
@@ -283,9 +384,13 @@ func (q *centralQueue) removeItemLocked(index int) {
 	q.untrackOldestEnqueuedAtLocked(removed)
 }
 
-func (q *centralQueue) removeWindowLocked(indexes []int) {
+func (q *centralQueue) removeWindowLocked(indexes []int, untrack bool) {
 	for i := len(indexes) - 1; i >= 0; i-- {
-		q.removeItemLocked(indexes[i])
+		if untrack {
+			q.removeItemLocked(indexes[i])
+			continue
+		}
+		q.items = removeCentralQueueItem(q.items, indexes[i])
 	}
 }
 
@@ -318,7 +423,7 @@ func (l *centralQueueLease) requeue(now time.Time) error {
 			err = errCentralQueueStopped
 		} else {
 			for _, item := range l.window.items {
-				nextAttempt := now.Add(centralQueueRetryDelay(item.attempt))
+				nextAttempt := now.Add(centralQueueRetryDelayWithJitter(item))
 				item.attempt++
 				item.nextAttemptUnixNano = nextAttempt.UnixNano()
 				l.queue.items = append(l.queue.items, item)
@@ -337,6 +442,7 @@ func (q *centralQueue) stop() {
 	q.stopped = true
 	q.mu.Unlock()
 	q.settings.telemetry.stopObservingOldestItemAge()
+	q.settings.telemetry.stopObservingSchedulerState()
 }
 
 func (q *centralQueue) compressedBytes() int64 {
@@ -354,7 +460,7 @@ func (q *centralQueue) inflightUncompressedBytes() int64 {
 func (q *centralQueue) len() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	return len(q.items)
+	return len(q.items) + q.readyItemCountLocked()
 }
 
 func (q *centralQueue) snapshotLocked() centralQueueSnapshot {
@@ -365,10 +471,69 @@ func (q *centralQueue) snapshotLockedAt(now time.Time) centralQueueSnapshot {
 	return centralQueueSnapshot{
 		compressedBytes:      q.currentCompressedBytes,
 		compressedCapacity:   q.settings.maxCompressedBytes,
-		items:                int64(len(q.items)),
+		items:                int64(len(q.items) + q.readyItemCountLocked()),
 		inflightUncompressed: q.currentInflightBytes,
 		oldestItemAgeMillis:  q.oldestItemAgeMillisLocked(now),
 	}
+}
+
+func (q *centralQueue) readyItemCountLocked() int {
+	count := 0
+	for _, window := range q.ready {
+		count += len(window.items)
+	}
+	return count
+}
+
+func (q *centralQueue) schedulerSnapshot() centralQueueSchedulerSnapshot {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return q.schedulerSnapshotLocked(time.Now())
+}
+
+func (q *centralQueue) schedulerSnapshotLocked(now time.Time) centralQueueSchedulerSnapshot {
+	snapshot := centralQueueSchedulerSnapshot{
+		readyWindows:     int64(len(q.ready)),
+		readyWindowLimit: int64(q.settings.maxReadyWindows),
+		state:            centralQueueSchedulerStateWaiting,
+	}
+	for _, window := range q.ready {
+		snapshot.readyUncompressed += int64(window.uncompressedBytes)
+	}
+	switch {
+	case len(q.ready) >= q.settings.maxReadyWindows:
+		snapshot.state = centralQueueSchedulerStateReadyWindowLimit
+	case len(q.ready) > 0:
+		snapshot.state = centralQueueSchedulerStateReady
+	case len(q.items) == 0 && q.stopped:
+		snapshot.state = centralQueueSchedulerStateStopped
+	case len(q.items) == 0:
+		snapshot.state = centralQueueSchedulerStateQueueEmpty
+	default:
+		targetCandidates, fallbackCandidates, hasReady := q.collectWindowCandidatesLocked(now)
+		if !hasReady || len(targetCandidates)+len(fallbackCandidates) == 0 {
+			snapshot.state = centralQueueSchedulerStateWaiting
+			return snapshot
+		}
+		for _, candidate := range targetCandidates {
+			if !q.windowInflightBlockedLocked(candidate.window) {
+				snapshot.state = centralQueueSchedulerStateReady
+				return snapshot
+			}
+		}
+		if len(targetCandidates) > 0 {
+			snapshot.state = centralQueueSchedulerStateInflightBytes
+			return snapshot
+		}
+		for _, candidate := range fallbackCandidates {
+			if !q.windowInflightBlockedLocked(candidate.window) {
+				snapshot.state = centralQueueSchedulerStateReady
+				return snapshot
+			}
+		}
+		snapshot.state = centralQueueSchedulerStateInflightBytes
+	}
+	return snapshot
 }
 
 func (q *centralQueue) oldestItemAgeMillis() int64 {
@@ -459,6 +624,24 @@ func centralQueueRetryDelay(attempt int) time.Duration {
 	shift := min(attempt, 6)
 	delay := centralQueueInitialRetryDelay * time.Duration(1<<shift)
 	return min(delay, centralQueueMaxRetryDelay)
+}
+
+func centralQueueRetryDelayWithJitter(item centralQueueItem) time.Duration {
+	delay := centralQueueRetryDelay(item.attempt)
+	jitterLimit := centralQueueRetryJitterLimit(delay)
+	if jitterLimit <= 0 {
+		return delay
+	}
+	hashInput := make([]byte, len(item.routingKey)+16)
+	copy(hashInput, item.routingKey)
+	binary.BigEndian.PutUint64(hashInput[len(item.routingKey):], uint64(item.enqueuedAtUnixNano))
+	binary.BigEndian.PutUint64(hashInput[len(item.routingKey)+8:], uint64(item.attempt))
+	jitter := time.Duration(crc32.ChecksumIEEE(hashInput) % uint32(jitterLimit+1))
+	return delay + jitter
+}
+
+func centralQueueRetryJitterLimit(delay time.Duration) time.Duration {
+	return min(delay/10, centralQueueMaxRetryJitter)
 }
 
 func centralQueueLaneRoutingKey(signal signalKind, routingKey []byte, laneCount int) []byte {

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -188,6 +188,10 @@ func (q *centralQueue) prepareReadyWindowsLocked(now time.Time) centralQueueSche
 		}
 
 		scheduledTarget, blocked := q.scheduleReadyWindowCandidatesLocked(targetCandidates)
+		if scheduledTarget {
+			state = centralQueueSchedulerStateReady
+			continue
+		}
 		if blocked {
 			return centralQueueSchedulerStateInflightBytes
 		}

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -179,11 +179,8 @@ func (q *centralQueue) tryLease(now time.Time) (*centralQueueLease, error) {
 func (q *centralQueue) prepareReadyWindowsLocked(now time.Time) centralQueueSchedulerState {
 	state := centralQueueSchedulerStateWaiting
 	for len(q.ready) < q.settings.maxReadyWindows {
-		targetCandidates, fallbackCandidates, hasReady := q.collectWindowCandidatesLocked(now)
+		targetCandidates, fallbackCandidates, _ := q.collectWindowCandidatesLocked(now)
 		if len(targetCandidates) == 0 && len(fallbackCandidates) == 0 {
-			if !hasReady {
-				return state
-			}
 			return state
 		}
 

--- a/exporter/loadbalancingexporter/central_queue_telemetry.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry.go
@@ -244,7 +244,7 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	if err == nil {
+	if errs == nil {
 		t.schedulerStateReg, err = meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
 			t.schedulerStateMu.RLock()
 			schedulerSnapshot := t.schedulerSnapshot

--- a/exporter/loadbalancingexporter/central_queue_telemetry.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry.go
@@ -38,7 +38,15 @@ type centralQueueTelemetry struct {
 	oldestItemAgeReg     metric.Registration
 	oldestItemAgeMu      sync.RWMutex
 	oldestItemAgeMillis  func() int64
+	readyWindows         metric.Int64ObservableGauge
+	readyWindowLimit     metric.Int64ObservableGauge
+	readyUncompressed    metric.Int64ObservableGauge
+	schedulerState       metric.Int64ObservableGauge
+	schedulerStateReg    metric.Registration
+	schedulerStateMu     sync.RWMutex
+	schedulerSnapshot    func() centralQueueSchedulerSnapshot
 	flushReasonAttrs     map[centralQueueFlushReason]metric.MeasurementOption
+	schedulerStateAttrs  map[centralQueueSchedulerState]metric.MeasurementOption
 }
 
 type centralQueueSnapshot struct {
@@ -47,6 +55,33 @@ type centralQueueSnapshot struct {
 	items                int64
 	inflightUncompressed int64
 	oldestItemAgeMillis  int64
+}
+
+type centralQueueSchedulerSnapshot struct {
+	readyWindows      int64
+	readyWindowLimit  int64
+	readyUncompressed int64
+	state             centralQueueSchedulerState
+}
+
+type centralQueueSchedulerState string
+
+const (
+	centralQueueSchedulerStateReady            centralQueueSchedulerState = "ready"
+	centralQueueSchedulerStateQueueEmpty       centralQueueSchedulerState = "queue_empty"
+	centralQueueSchedulerStateWaiting          centralQueueSchedulerState = "waiting"
+	centralQueueSchedulerStateInflightBytes    centralQueueSchedulerState = "inflight_uncompressed_bytes"
+	centralQueueSchedulerStateReadyWindowLimit centralQueueSchedulerState = "ready_window_limit"
+	centralQueueSchedulerStateStopped          centralQueueSchedulerState = "stopped"
+)
+
+var centralQueueSchedulerStates = []centralQueueSchedulerState{
+	centralQueueSchedulerStateReady,
+	centralQueueSchedulerStateQueueEmpty,
+	centralQueueSchedulerStateWaiting,
+	centralQueueSchedulerStateInflightBytes,
+	centralQueueSchedulerStateReadyWindowLimit,
+	centralQueueSchedulerStateStopped,
 }
 
 func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signalKind) (*centralQueueTelemetry, error) {
@@ -62,6 +97,10 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 			centralQueueFlushReasonMaxDelayLowTraffic: metric.WithAttributeSet(attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonMaxDelayLowTraffic)))),
 			centralQueueFlushReasonShutdown:           metric.WithAttributeSet(attribute.NewSet(signalAttr, attribute.String("reason", string(centralQueueFlushReasonShutdown)))),
 		},
+		schedulerStateAttrs: make(map[centralQueueSchedulerState]metric.MeasurementOption, len(centralQueueSchedulerStates)),
+	}
+	for _, state := range centralQueueSchedulerStates {
+		t.schedulerStateAttrs[state] = metric.WithAttributeSet(attribute.NewSet(signalAttr, attribute.String("state", string(state))))
 	}
 	t.compressedBytes, err = meter.Int64Gauge(
 		"otelcol_loadbalancer_central_queue_compressed_bytes",
@@ -107,7 +146,7 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 	errs = errors.Join(errs, err)
 	t.inflightUncompressed, err = meter.Int64Gauge(
 		"otelcol_loadbalancer_central_queue_inflight_uncompressed_bytes",
-		metric.WithDescription("Uncompressed bytes currently leased from the central load-balancing queue."),
+		metric.WithDescription("Uncompressed bytes currently reserved by ready or leased central load-balancing queue windows."),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
@@ -179,6 +218,53 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 			}
 			return nil
 		}, t.oldestItemAge)
+		errs = errors.Join(errs, err)
+	}
+	t.readyWindows, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_central_queue_ready_windows",
+		metric.WithDescription("Central load-balancing request windows ready to be leased by drain workers."),
+		metric.WithUnit("{windows}"),
+	)
+	errs = errors.Join(errs, err)
+	t.readyWindowLimit, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_central_queue_ready_window_limit",
+		metric.WithDescription("Configured maximum central load-balancing request windows that may wait ready before workers lease them."),
+		metric.WithUnit("{windows}"),
+	)
+	errs = errors.Join(errs, err)
+	t.readyUncompressed, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_central_queue_ready_uncompressed_bytes",
+		metric.WithDescription("Uncompressed bytes reserved by central load-balancing request windows waiting ready before workers lease them."),
+		metric.WithUnit("By"),
+	)
+	errs = errors.Join(errs, err)
+	t.schedulerState, err = meter.Int64ObservableGauge(
+		"otelcol_loadbalancer_central_queue_scheduler_state",
+		metric.WithDescription("Latest central load-balancing queue scheduler state. The active state is reported as 1 and other states as 0."),
+		metric.WithUnit("1"),
+	)
+	errs = errors.Join(errs, err)
+	if err == nil {
+		t.schedulerStateReg, err = meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
+			t.schedulerStateMu.RLock()
+			schedulerSnapshot := t.schedulerSnapshot
+			t.schedulerStateMu.RUnlock()
+			if schedulerSnapshot == nil {
+				return nil
+			}
+			snapshot := schedulerSnapshot()
+			observer.ObserveInt64(t.readyWindows, snapshot.readyWindows, t.signalAttrs)
+			observer.ObserveInt64(t.readyWindowLimit, snapshot.readyWindowLimit, t.signalAttrs)
+			observer.ObserveInt64(t.readyUncompressed, snapshot.readyUncompressed, t.signalAttrs)
+			for _, state := range centralQueueSchedulerStates {
+				value := int64(0)
+				if snapshot.state == state {
+					value = 1
+				}
+				observer.ObserveInt64(t.schedulerState, value, t.schedulerStateAttrs[state])
+			}
+			return nil
+		}, t.readyWindows, t.readyWindowLimit, t.readyUncompressed, t.schedulerState)
 		errs = errors.Join(errs, err)
 	}
 	return t, errs
@@ -272,6 +358,29 @@ func (t *centralQueueTelemetry) stopObservingOldestItemAge() {
 	t.oldestItemAgeReg = nil
 	t.oldestItemAgeMillis = nil
 	t.oldestItemAgeMu.Unlock()
+	if registration != nil {
+		_ = registration.Unregister()
+	}
+}
+
+func (t *centralQueueTelemetry) observeSchedulerState(schedulerSnapshot func() centralQueueSchedulerSnapshot) {
+	if t == nil {
+		return
+	}
+	t.schedulerStateMu.Lock()
+	defer t.schedulerStateMu.Unlock()
+	t.schedulerSnapshot = schedulerSnapshot
+}
+
+func (t *centralQueueTelemetry) stopObservingSchedulerState() {
+	if t == nil {
+		return
+	}
+	t.schedulerStateMu.Lock()
+	registration := t.schedulerStateReg
+	t.schedulerStateReg = nil
+	t.schedulerSnapshot = nil
+	t.schedulerStateMu.Unlock()
 	if registration != nil {
 		_ = registration.Unregister()
 	}

--- a/exporter/loadbalancingexporter/central_queue_telemetry.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry.go
@@ -226,25 +226,29 @@ func newCentralQueueTelemetry(settings component.TelemetrySettings, signal signa
 		metric.WithUnit("{windows}"),
 	)
 	errs = errors.Join(errs, err)
+	schedulerErrs := err
 	t.readyWindowLimit, err = meter.Int64ObservableGauge(
 		"otelcol_loadbalancer_central_queue_ready_window_limit",
 		metric.WithDescription("Configured maximum central load-balancing request windows that may wait ready before workers lease them."),
 		metric.WithUnit("{windows}"),
 	)
 	errs = errors.Join(errs, err)
+	schedulerErrs = errors.Join(schedulerErrs, err)
 	t.readyUncompressed, err = meter.Int64ObservableGauge(
 		"otelcol_loadbalancer_central_queue_ready_uncompressed_bytes",
 		metric.WithDescription("Uncompressed bytes reserved by central load-balancing request windows waiting ready before workers lease them."),
 		metric.WithUnit("By"),
 	)
 	errs = errors.Join(errs, err)
+	schedulerErrs = errors.Join(schedulerErrs, err)
 	t.schedulerState, err = meter.Int64ObservableGauge(
 		"otelcol_loadbalancer_central_queue_scheduler_state",
 		metric.WithDescription("Latest central load-balancing queue scheduler state. The active state is reported as 1 and other states as 0."),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)
-	if errs == nil {
+	schedulerErrs = errors.Join(schedulerErrs, err)
+	if schedulerErrs == nil {
 		t.schedulerStateReg, err = meter.RegisterCallback(func(_ context.Context, observer metric.Observer) error {
 			t.schedulerStateMu.RLock()
 			schedulerSnapshot := t.schedulerSnapshot

--- a/exporter/loadbalancingexporter/central_queue_telemetry_test.go
+++ b/exporter/loadbalancingexporter/central_queue_telemetry_test.go
@@ -21,6 +21,14 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 	telemetry, err := newCentralQueueTelemetry(reader.NewTelemetrySettings(), signalKindLogs)
 	require.NoError(t, err)
 	telemetry.observeOldestItemAge(func() int64 { return 125 })
+	telemetry.observeSchedulerState(func() centralQueueSchedulerSnapshot {
+		return centralQueueSchedulerSnapshot{
+			readyWindows:      2,
+			readyWindowLimit:  4,
+			readyUncompressed: 48,
+			state:             centralQueueSchedulerStateWaiting,
+		}
+	})
 
 	telemetry.record(t.Context(), centralQueueSnapshot{
 		compressedBytes:      50,
@@ -49,6 +57,10 @@ func TestCentralQueueTelemetryRecordsInstruments(t *testing.T) {
 	requireCentralQueueFloatGauge(t, reader, "otelcol_loadbalancer_central_queue_saturation", "1", attrs, 0.5)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_items", "{items}", attrs, 3)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_inflight_uncompressed_bytes", "By", attrs, 80)
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_ready_windows", "{windows}", attrs, 2)
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_ready_window_limit", "{windows}", attrs, 4)
+	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_ready_uncompressed_bytes", "By", attrs, 48)
+	requireCentralQueueSchedulerState(t, reader, centralQueueSchedulerStateWaiting)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_configured_consumers", "{workers}", attrs, 20)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_active_consumers", "{workers}", attrs, 3)
 	requireCentralQueueIntGauge(t, reader, "otelcol_loadbalancer_central_queue_oldest_item_age", "ms", attrs, 125)
@@ -83,6 +95,25 @@ func TestCentralQueueTelemetryOldestItemAgeReportsMultipleSignals(t *testing.T) 
 	require.Len(t, gauge.DataPoints, 2)
 	requireCentralQueueIntGaugeDatapoint(t, gauge.DataPoints, attribute.NewSet(attribute.String("signal", string(signalKindLogs))), 125)
 	requireCentralQueueIntGaugeDatapoint(t, gauge.DataPoints, attribute.NewSet(attribute.String("signal", string(signalKindMetrics))), 250)
+}
+
+func requireCentralQueueSchedulerState(t *testing.T, reader *componenttest.Telemetry, activeState centralQueueSchedulerState) {
+	t.Helper()
+	metric, err := reader.GetMetric("otelcol_loadbalancer_central_queue_scheduler_state")
+	require.NoError(t, err)
+	require.Equal(t, "1", metric.Unit)
+	gauge, ok := metric.Data.(metricdata.Gauge[int64])
+	require.True(t, ok)
+	require.Len(t, gauge.DataPoints, len(centralQueueSchedulerStates))
+	for _, datapoint := range gauge.DataPoints {
+		value, ok := datapoint.Attributes.Value("state")
+		require.True(t, ok)
+		if value.AsString() == string(activeState) {
+			require.EqualValues(t, 1, datapoint.Value)
+			continue
+		}
+		require.Zero(t, datapoint.Value)
+	}
 }
 
 func requireCentralQueueIntGauge(t *testing.T, reader *componenttest.Telemetry, name, unit string, attrs attribute.Set, value int64) {

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -222,6 +222,37 @@ func TestCentralQueueReadyWindowsRecollectFallbackAfterTargetRemoval(t *testing.
 	require.Zero(t, q.compressedBytes())
 }
 
+func TestCentralQueueReadyWindowsDoNotLetHotTargetLaneStarveFallbackLane(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                250 * time.Millisecond,
+		maxReadyWindows:              2,
+	})
+	now := time.Unix(10, 0)
+	for range 4 {
+		require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("hot"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	}
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("fallback"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+
+	first, err := q.tryLease(now.Add(250 * time.Millisecond))
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, []byte("hot"), first.window.routingKey)
+	require.Equal(t, centralQueueFlushReasonTargetReached, first.window.flushReason)
+
+	second, err := q.tryLease(now.Add(250 * time.Millisecond))
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, []byte("fallback"), second.window.routingKey)
+	require.Equal(t, centralQueueFlushReasonMaxDelayLowTraffic, second.window.flushReason)
+
+	first.done()
+	second.done()
+}
+
 func TestCentralQueueReadyWindowsBuildTargetSizedWindowsBeforeConsumersLease(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:           100,

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -188,6 +188,40 @@ func TestCentralQueueReadyWindowsHandleInterleavedLaneItems(t *testing.T) {
 	require.Zero(t, q.compressedBytes())
 }
 
+func TestCentralQueueReadyWindowsRecollectFallbackAfterTargetRemoval(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                250 * time.Millisecond,
+		maxReadyWindows:              2,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("target"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("target"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("fallback"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+
+	lease, err := q.tryLease(now.Add(250 * time.Millisecond))
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.Equal(t, []byte("target"), lease.window.routingKey)
+	require.Len(t, lease.window.items, 2)
+	require.Equal(t, centralQueueFlushReasonTargetReached, lease.window.flushReason)
+
+	fallbackLease, err := q.tryLease(now.Add(250 * time.Millisecond))
+	require.NoError(t, err)
+	require.NotNil(t, fallbackLease)
+	require.Equal(t, []byte("fallback"), fallbackLease.window.routingKey)
+	require.Len(t, fallbackLease.window.items, 1)
+	require.Equal(t, centralQueueFlushReasonMaxDelayLowTraffic, fallbackLease.window.flushReason)
+
+	lease.done()
+	fallbackLease.done()
+	require.Zero(t, q.len())
+	require.Zero(t, q.compressedBytes())
+}
+
 func TestCentralQueueReadyWindowsBuildTargetSizedWindowsBeforeConsumersLease(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:           100,

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -87,7 +87,7 @@ func TestCentralQueueLeaseReservesCompressedBytesUntilDoneOrRequeue(t *testing.T
 	require.Equal(t, 1, q.len())
 	require.EqualValues(t, 10, q.compressedBytes())
 
-	retryLease, err := q.tryLease(time.Now().Add(centralQueueInitialRetryDelay))
+	retryLease, err := q.tryLease(time.Now().Add(centralQueueRetryDelayUpperBound(0)))
 	require.NoError(t, err)
 	require.NotNil(t, retryLease)
 	retryLease.done()
@@ -120,6 +120,132 @@ func TestCentralQueueLeaseCoalescesReadyItemsByRoutingKey(t *testing.T) {
 
 	lease.done()
 	require.EqualValues(t, 10, q.compressedBytes())
+}
+
+func TestCentralQueueReadyWindowsGiveEachReadyLaneATurnBeforeHotLaneRepeats(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                time.Second,
+		maxReadyWindows:              2,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("hot"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("hot"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("hot"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("hot"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("cold"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindMetrics, routingKey: []byte("cold"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+
+	first, err := q.tryLease(now)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, []byte("hot"), first.window.routingKey)
+	require.Equal(t, centralQueueFlushReasonTargetReached, first.window.flushReason)
+
+	second, err := q.tryLease(now)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, []byte("cold"), second.window.routingKey)
+	require.Equal(t, centralQueueFlushReasonTargetReached, second.window.flushReason)
+
+	first.done()
+	second.done()
+}
+
+func TestCentralQueueReadyWindowsHandleInterleavedLaneItems(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                time.Second,
+		maxReadyWindows:              2,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-b"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-b"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+
+	first, err := q.tryLease(now)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, []byte("lane-a"), first.window.routingKey)
+	require.Len(t, first.window.items, 2)
+
+	second, err := q.tryLease(now)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, []byte("lane-b"), second.window.routingKey)
+	require.Len(t, second.window.items, 2)
+
+	first.done()
+	second.done()
+	require.Zero(t, q.len())
+	require.Zero(t, q.compressedBytes())
+}
+
+func TestCentralQueueReadyWindowsBuildTargetSizedWindowsBeforeConsumersLease(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                time.Second,
+		maxReadyWindows:              4,
+	})
+	now := time.Unix(10, 0)
+	for range 8 {
+		require.NoError(t, q.enqueueAt(centralQueueItem{
+			signal:            signalKindLogs,
+			routingKey:        []byte("lane-a"),
+			compressedBytes:   10,
+			uncompressedBytes: 10,
+			count:             1,
+		}, now))
+	}
+
+	for range 4 {
+		lease, err := q.tryLease(now)
+		require.NoError(t, err)
+		require.NotNil(t, lease)
+		require.Equal(t, []byte("lane-a"), lease.window.routingKey)
+		require.Len(t, lease.window.items, 2)
+		require.Equal(t, 20, lease.window.compressedBytes)
+		require.Equal(t, centralQueueFlushReasonTargetReached, lease.window.flushReason)
+		lease.done()
+	}
+	require.Zero(t, q.len())
+	require.Zero(t, q.compressedBytes())
+}
+
+func TestCentralQueueReadyWindowsReserveInflightBudgetUntilLeasedWindowDone(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                time.Second,
+		maxReadyWindows:              2,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-b"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-b"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+
+	lease, err := q.tryLease(now)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.EqualValues(t, 80, q.inflightUncompressedBytes())
+	requireCentralQueueReadyWindows(t, q, 1)
+
+	lease.done()
+	require.EqualValues(t, 40, q.inflightUncompressedBytes())
+	requireCentralQueueReadyWindows(t, q, 1)
 }
 
 func TestCentralQueueLeasePrefersTargetWindowOverOlderUnderfilledWindow(t *testing.T) {
@@ -257,7 +383,7 @@ func TestCentralQueueRequeuesWholeCoalescedWindow(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, lease)
 
-	lease, err = q.tryLease(now.Add(centralQueueInitialRetryDelay))
+	lease, err = q.tryLease(now.Add(centralQueueRetryDelayUpperBound(0)))
 	require.NoError(t, err)
 	require.NotNil(t, lease)
 	require.Len(t, lease.window.items, 2)
@@ -287,9 +413,9 @@ func TestCentralQueueRequeueUsesPerItemRetryDelay(t *testing.T) {
 	defer q.mu.Unlock()
 	require.Len(t, q.items, 2)
 	require.Equal(t, 4, q.items[0].attempt)
-	require.Equal(t, now.Add(centralQueueRetryDelay(3)).UnixNano(), q.items[0].nextAttemptUnixNano)
+	requireNextAttemptWithinRetryDelay(t, now, 3, q.items[0].nextAttemptUnixNano)
 	require.Equal(t, 1, q.items[1].attempt)
-	require.Equal(t, now.Add(centralQueueRetryDelay(0)).UnixNano(), q.items[1].nextAttemptUnixNano)
+	requireNextAttemptWithinRetryDelay(t, now, 0, q.items[1].nextAttemptUnixNano)
 }
 
 func TestCentralQueueSnapshotReportsOldestQueuedItemAge(t *testing.T) {
@@ -326,11 +452,12 @@ func TestCentralQueueSnapshotReportsOldestQueuedItemAge(t *testing.T) {
 	secondLease.done()
 	require.EqualValues(t, 300, snapshotAt(base.Add(300*time.Millisecond)).oldestItemAgeMillis)
 
-	retryLease, err := q.tryLease(base.Add(time.Second + centralQueueInitialRetryDelay))
+	retryReadyAt := base.Add(time.Second + centralQueueRetryDelayUpperBound(0))
+	retryLease, err := q.tryLease(retryReadyAt)
 	require.NoError(t, err)
 	require.NotNil(t, retryLease)
 	retryLease.done()
-	require.Zero(t, snapshotAt(base.Add(time.Second+centralQueueInitialRetryDelay)).oldestItemAgeMillis)
+	require.Zero(t, snapshotAt(retryReadyAt).oldestItemAgeMillis)
 }
 
 func TestCentralQueueTelemetryOldestItemAgeAdvancesWithoutQueueMutation(t *testing.T) {
@@ -429,7 +556,7 @@ func TestCentralQueueRetriesDoNotGrowOldestEnqueuedHeap(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, lease)
 		require.NoError(t, lease.requeue(now))
-		now = now.Add(centralQueueMaxRetryDelay)
+		now = now.Add(centralQueueMaxRetryDelay + centralQueueMaxRetryJitter)
 	}
 
 	q.mu.Lock()
@@ -509,5 +636,26 @@ func requireCentralQueueFirstRetryDelay(t *testing.T, q *centralQueue) {
 	}, time.Second, time.Millisecond)
 
 	retryAfterEnqueue := time.Unix(0, item.nextAttemptUnixNano).Sub(time.Unix(0, item.enqueuedAtUnixNano))
-	require.LessOrEqual(t, retryAfterEnqueue, centralQueueInitialRetryDelay+50*time.Millisecond)
+	require.GreaterOrEqual(t, retryAfterEnqueue, centralQueueRetryDelay(0))
+	require.LessOrEqual(t, retryAfterEnqueue, centralQueueRetryDelayUpperBound(0)+50*time.Millisecond)
+}
+
+func requireNextAttemptWithinRetryDelay(t *testing.T, now time.Time, attempt int, nextAttemptUnixNano int64) {
+	t.Helper()
+	nextAttempt := time.Unix(0, nextAttemptUnixNano)
+	require.GreaterOrEqual(t, nextAttempt.Sub(now), centralQueueRetryDelay(attempt))
+	require.LessOrEqual(t, nextAttempt.Sub(now), centralQueueRetryDelayUpperBound(attempt))
+}
+
+func centralQueueRetryDelayUpperBound(attempt int) time.Duration {
+	delay := centralQueueRetryDelay(attempt)
+	return delay + centralQueueRetryJitterLimit(delay)
+}
+
+func requireCentralQueueReadyWindows(t *testing.T, q *centralQueue, expected int) {
+	t.Helper()
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	require.Len(t, q.ready, expected)
 }

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -88,6 +88,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 			maxUncompressedBatchBytes:    centralCfg.MaxUncompressedBatchBytes,
 			targetCompressedBytes:        centralCfg.TargetCompressedBytes,
 			maxBatchDelay:                centralCfg.MaxBatchDelay,
+			maxReadyWindows:              centralQueueReadyWindowLimit(centralCfg.NumConsumers),
 			telemetry:                    centralTelemetry,
 		})
 		logExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression)

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -88,6 +88,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 			maxUncompressedBatchBytes:    centralCfg.MaxUncompressedBatchBytes,
 			targetCompressedBytes:        centralCfg.TargetCompressedBytes,
 			maxBatchDelay:                centralCfg.MaxBatchDelay,
+			maxReadyWindows:              centralQueueReadyWindowLimit(centralCfg.NumConsumers),
 			telemetry:                    centralTelemetry,
 		})
 		metricExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression)


### PR DESCRIPTION
#### Description
Adds bounded ready-window scheduling for the compressed central queue so request windows are built toward `target_compressed_bytes` before drain workers send them. Ready windows are capped by `central_queue.num_consumers`, reserve the in-flight uncompressed budget, and expose scheduler/ready-window metrics.

Also adds deterministic retry jitter, regression coverage for interleaved lanes, fairness, ready-window bounds, and target-sized windows across multiple consumers.

#### Link to tracking issue
Fixes

#### Testing
- `go test ./... -count=1` from `exporter/loadbalancingexporter`
- `go test ./... -run 'TestCentralQueueReadyWindows|TestLogsCentralQueueConsumersSendWindowsConcurrently|TestMetricsCentralQueueConsumersSendWindowsConcurrently' -race -count=1` from `exporter/loadbalancingexporter`\n\n#### Documentation\nUpdated `exporter/loadbalancingexporter/README.md` and added a changelog entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central queue dispatch semantics by introducing a bounded ready-window scheduler and reserving in-flight uncompressed budget earlier, which can affect throughput/latency and backpressure behavior under load. Also tweaks retry timing via deterministic jitter, so timing-sensitive scenarios may behave differently.
> 
> **Overview**
> Adds **bounded “ready window” scheduling** to the load-balancing exporter’s compressed `central_queue`, prebuilding request windows (toward `target_compressed_bytes`) before workers lease them and capping the ready backlog by `central_queue.num_consumers`.
> 
> Updates in-flight accounting so `inflight_uncompressed_bytes` includes *ready + leased* windows, introduces deterministic per-item retry jitter, and adds new scheduler/ready-window gauges (`..._ready_windows`, `..._ready_window_limit`, `..._ready_uncompressed_bytes`, `..._scheduler_state`). Documentation, changelog, and unit tests are updated to cover fairness across routing keys and bounded ready-window behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe6d6698cf54ddbece245d7a5ebe8f21e1f1900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded ready-window scheduling to the central queue in `exporter/loadbalancingexporter`, so workers lease pre-built, target-sized windows. Improves fairness and backpressure by reserving in-flight bytes for ready + leased and capping the ready backlog to `central_queue.num_consumers`.

- **New Features**
  - Keep a limited set of ready windows; coalesce by routing key and prefer target-sized windows.
  - Schedule one candidate per routing key each cycle to avoid hot-lane monopolies.
  - New gauges: `otelcol_loadbalancer_central_queue_ready_windows`, `..._ready_window_limit`, `..._ready_uncompressed_bytes`, `..._scheduler_state`; add deterministic retry jitter (≤10%, max 100ms).
  - README and changelog updated.

- **Bug Fixes**
  - Refresh fallback candidates after building target windows to prevent starvation.
  - Avoid copying window-candidate structs in scheduler loops.
  - Only register scheduler metrics callback when all instruments are created.
  - Remove a dead scheduler branch to simplify state handling.

<sup>Written for commit 2fe6d6698cf54ddbece245d7a5ebe8f21e1f1900. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduler-state metrics and gauges to the load‑balancing exporter for visibility into ready windows, ready-window limits, and reserved in‑flight bytes.
  * Introduced bounded "ready request window" scheduling to keep consumer windows target-sized and cap ready backlog.

* **Documentation**
  * Updated load‑balancing exporter docs to describe the refined request window handling and new observability metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/65)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->