### PR TITLE
feat(elasticsearchexporter): make RequireDataStream togglable

### DIFF
--- a/.chloggen/sawmills-elasticsearch-require-data-stream-override.yaml
+++ b/.chloggen/sawmills-elasticsearch-require-data-stream-override.yaml
@@ -1,7 +1,7 @@
 change_type: bug_fix
 component: exporter/elasticsearch
 note: Allow overriding Elasticsearch bulk action require_data_stream metadata.
-issues: []
+issues: [7506]
 subtext: |-
   Adds mapping::require_data_stream so Sawmills can use ECS or OTel mapping
   with plain indices on Elasticsearch-compatible backends that reject the

--- a/.chloggen/sawmills-elasticsearch-require-data-stream-override.yaml
+++ b/.chloggen/sawmills-elasticsearch-require-data-stream-override.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+component: exporter/elasticsearch
+note: Allow overriding Elasticsearch bulk action require_data_stream metadata.
+issues: []
+subtext: |-
+  Adds mapping::require_data_stream so Sawmills can use ECS or OTel mapping
+  with plain indices on Elasticsearch-compatible backends that reject the
+  require_data_stream bulk action parameter.
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -171,6 +171,18 @@ behaviours, which may be configured through the following settings:
 - `mapping`:
   - `mode` (DEPRECATED): The mapping mode if supplied via config file is ignored. Use the `X-Elastic-Mapping-Mode` client metadata key or the `elastic.mapping.mode` scope attribute instead. If not specified via these methods, the default mapping mode is `otel`.
   - `allowed_modes` (defaults to all mapping modes): A list of allowed mapping modes.
+  - `require_data_stream` (optional): Overrides whether `require_data_stream` is added to logs, metrics, and traces bulk action metadata. When unset, the exporter preserves the default behaviour: `otel` and `ecs` mapping modes set `require_data_stream: true`, while `none`, `raw`, and `bodymap` do not. Set this to `false` when using ECS/OTel mapping modes with plain indices on backends that reject `require_data_stream`, including AWS Elasticsearch 7.10.2 OSS. This setting does not change the transport format and does not select the mapping mode; use the `elastic.mapping.mode` scope attribute or `X-Elastic-Mapping-Mode` for that. Profiles keep their existing data-stream behaviour.
+
+Example for targeting a plain index with a backend that rejects `require_data_stream`:
+
+```yaml
+exporters:
+  elasticsearch:
+    endpoints: [https://elasticsearch:9200]
+    logs_index: sawmills_qa
+    mapping:
+      require_data_stream: false
+```
 
 The mapping mode can be controlled via the client metadata key `X-Elastic-Mapping-Mode`,
 e.g. via HTTP headers, gRPC metadata.

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -548,7 +548,7 @@ func (b *bulkIndexers) start(
 	}
 
 	for _, mode := range allowedMappingModes {
-		requireDataStream := mode == MappingOTel || mode == MappingECS
+		requireDataStream := requireDataStreamForSignalMappingMode(cfg, mode)
 		modeSpecificErrorHintFunc := func(index, errorType string) string {
 			return getErrorHint(mode, index, errorType)
 		}
@@ -572,6 +572,13 @@ func (b *bulkIndexers) start(
 	profilingExecutables := newBulkIndexer(esClient, cfg, false, b.telemetryBuilder, set.Logger, mappingModeNoneErrorHintFunc)
 	b.profilingExecutables = &wgTrackingBulkIndexer{bulkIndexer: profilingExecutables, wg: &b.wg}
 	return nil
+}
+
+func requireDataStreamForSignalMappingMode(cfg *Config, mode MappingMode) bool {
+	if cfg.Mapping.RequireDataStream != nil {
+		return *cfg.Mapping.RequireDataStream
+	}
+	return mode == MappingOTel || mode == MappingECS
 }
 
 func (b *bulkIndexers) shutdown(ctx context.Context) error {

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -390,6 +390,68 @@ func TestNewBulkIndexer(t *testing.T) {
 	t.Cleanup(func() { bi.Close(t.Context()) })
 }
 
+func TestRequireDataStreamForSignalMappingMode(t *testing.T) {
+	boolPtr := func(v bool) *bool {
+		return &v
+	}
+
+	tests := []struct {
+		name string
+		cfg  func(*Config)
+		want map[MappingMode]bool
+	}{
+		{
+			name: "default",
+			want: map[MappingMode]bool{
+				MappingNone:    false,
+				MappingECS:     true,
+				MappingOTel:    true,
+				MappingRaw:     false,
+				MappingBodyMap: false,
+			},
+		},
+		{
+			name: "explicit false",
+			cfg: func(cfg *Config) {
+				cfg.Mapping.RequireDataStream = boolPtr(false)
+			},
+			want: map[MappingMode]bool{
+				MappingNone:    false,
+				MappingECS:     false,
+				MappingOTel:    false,
+				MappingRaw:     false,
+				MappingBodyMap: false,
+			},
+		},
+		{
+			name: "explicit true",
+			cfg: func(cfg *Config) {
+				cfg.Mapping.RequireDataStream = boolPtr(true)
+			},
+			want: map[MappingMode]bool{
+				MappingNone:    true,
+				MappingECS:     true,
+				MappingOTel:    true,
+				MappingRaw:     true,
+				MappingBodyMap: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			if tt.cfg != nil {
+				tt.cfg(cfg)
+			}
+
+			for mode, want := range tt.want {
+				assert.Equal(t, want, requireDataStreamForSignalMappingMode(cfg, mode), mode.String())
+			}
+		})
+	}
+}
+
 func TestGetErrorHint(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -272,6 +272,11 @@ type MappingsSettings struct {
 	// If unspecified, all mapping modes are allowed.
 	AllowedModes []string `mapstructure:"allowed_modes"`
 
+	// RequireDataStream overrides whether the exporter adds require_data_stream
+	// to bulk action metadata. If unset, the exporter keeps its mapping-mode
+	// default: true for otel/ecs, false for none/raw/bodymap.
+	RequireDataStream *bool `mapstructure:"require_data_stream"`
+
 	// prevent unkeyed literal initialization
 	_ struct{}
 }

--- a/exporter/elasticsearchexporter/config.schema.yaml
+++ b/exporter/elasticsearchexporter/config.schema.yaml
@@ -70,6 +70,10 @@ $defs:
       mode:
         description: 'Deprecated: [v0.145.0] Mode is ignored. The default mapping mode is "otel". The mode may be overridden in two ways: - by the client metadata key X-Elastic-Mapping-Mode, if specified - by the scope attribute elastic.mapping.mode, if specified The order of precedence is: scope attribute > client metadata > default mode.'
         type: string
+      require_data_stream:
+        description: 'RequireDataStream overrides whether the exporter adds require_data_stream to bulk action metadata. If unset, the exporter keeps its mapping-mode default: true for otel/ecs, false for none/raw/bodymap.'
+        x-pointer: true
+        type: boolean
   retry_settings:
     description: RetrySettings defines settings for the HTTP request retries in the Elasticsearch exporter. Failed sends are retried with exponential backoff.
     type: object

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -304,6 +304,15 @@ func TestConfig(t *testing.T) {
 			expected:   defaultRawCfg,
 		},
 		{
+			id:         component.NewIDWithName(metadata.Type, "require_data_stream_false"),
+			configFile: "config.yaml",
+			expected: withDefaultConfig(func(cfg *Config) {
+				cfg.Endpoints = []string{"http://localhost:9200"}
+				requireDataStream := false
+				cfg.Mapping.RequireDataStream = &requireDataStream
+			}),
+		},
+		{
 			id:         component.NewIDWithName(metadata.Type, "cloudid"),
 			configFile: "config.yaml",
 			expected: withDefaultConfig(func(cfg *Config) {

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -336,6 +336,65 @@ func TestExporterLogs(t *testing.T) {
 		assert.JSONEq(t, `{"create":{"_index":"logs-generic-default","require_data_stream":true}}`, string(docs[0].Action))
 	})
 
+	t.Run("publish with mapping require_data_stream override", func(t *testing.T) {
+		boolPtr := func(v bool) *bool {
+			return &v
+		}
+
+		tests := []struct {
+			name                     string
+			mappingMode              string
+			requireDataStream        *bool
+			wantRequireDataStreamSet bool
+		}{
+			{
+				name:                     "ecs default",
+				mappingMode:              "ecs",
+				wantRequireDataStreamSet: true,
+			},
+			{
+				name:              "ecs explicit false",
+				mappingMode:       "ecs",
+				requireDataStream: boolPtr(false),
+			},
+			{
+				name:              "otel explicit false",
+				mappingMode:       "otel",
+				requireDataStream: boolPtr(false),
+			},
+			{
+				name:                     "none explicit true",
+				mappingMode:              "none",
+				requireDataStream:        boolPtr(true),
+				wantRequireDataStreamSet: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				rec := newBulkRecorder()
+				server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+					rec.Record(docs)
+					return itemsAllOK(docs)
+				})
+
+				exporter := newTestLogsExporter(t, server.URL, func(cfg *Config) {
+					cfg.Mapping.RequireDataStream = tt.requireDataStream
+				})
+				logs := plog.NewLogs()
+				logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("hello world")
+				ctx := client.NewContext(
+					t.Context(),
+					client.Info{Metadata: client.NewMetadata(map[string][]string{"X-Elastic-Mapping-Mode": {tt.mappingMode}})},
+				)
+				mustSendLogsWithCtx(ctx, t, exporter, logs)
+
+				docs := rec.WaitItems(1)
+				assert.Equal(t, tt.wantRequireDataStreamSet, gjson.GetBytes(docs[0].Action, "create.require_data_stream").Exists())
+			})
+		}
+	})
+
 	t.Run("publish with elasticsearch.index", func(t *testing.T) {
 		rec := newBulkRecorder()
 		index := "someindex"

--- a/exporter/elasticsearchexporter/testdata/config.yaml
+++ b/exporter/elasticsearchexporter/testdata/config.yaml
@@ -83,6 +83,10 @@ elasticsearch/raw:
   endpoints: [http://localhost:9200]
   mapping:
     mode: raw
+elasticsearch/require_data_stream_false:
+  endpoints: [http://localhost:9200]
+  mapping:
+    require_data_stream: false
 elasticsearch/cloudid:
   cloudid: foo:YmFyLmNsb3VkLmVzLmlvJGFiYzEyMyRkZWY0NTY=
 elasticsearch/confighttp_endpoint:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `mapping.require_data_stream` toggle to the `elasticsearchexporter` to control the `require_data_stream` bulk metadata. Enables ECS/OTel mapping to work with plain indices on backends that reject this flag (e.g., AWS Elasticsearch 7.10.2 OSS), addressing SAW-7506.

- **New Features**
  - New `mapping.require_data_stream` override; defaults stay the same (true for `otel`/`ecs`, false for `none`/`raw`/`bodymap`).
  - Applies to logs, metrics, and traces; docs, schema, and tests updated.

- **Migration**
  - If using `otel` or `ecs` mapping with plain indices, set `mapping.require_data_stream: false`.

<sup>Written for commit c304ef0376e68304d032fa43f48593abb75e612c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mapping.require_data_stream` configuration option to override the default behavior for whether Elasticsearch bulk action metadata includes `require_data_stream`.

* **Documentation**
  * Updated README with documentation and examples for the new `mapping.require_data_stream` configuration option, including guidance on when to use it.

* **Tests**
  * Added comprehensive test coverage for the new configuration option across different mapping modes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/68)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->