### PR TITLE
loadbalancingexporter: Bound zstd payload codec memory

### DIFF
--- a/.chloggen/loadbalancingexporter-zstd-payload-codec-options.yaml
+++ b/.chloggen/loadbalancingexporter-zstd-payload-codec-options.yaml
@@ -1,0 +1,10 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Add configurable zstd encoder memory controls for load balancing exporter queue payload codecs.
+issues: [70]
+subtext: |-
+  Adds optional `payload_codec.zstd` settings for encoder concurrency, window size,
+  and lower-memory encoding so operators can bound retained zstd working memory
+  while keeping queue, log batcher, metric batcher, and central queue payload
+  compression on zstd.
+change_logs: [user]

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -151,6 +151,10 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `payload_compression` compresses log batcher chunks while they are pending in memory. Supported values: `none`, `snappy`, `zstd`. Default: `none`.
 * The `metric_batcher` property enables post-routing metric batching per backend. It is `disabled` by default for backward compatibility.
   * `payload_compression` compresses metric batcher chunks while they are pending in memory. Supported values: `none`, `snappy`, `zstd`. Default: `none`.
+* The `payload_codec` property controls shared payload codec options used by `sending_queue.payload_compression`, `log_batcher.payload_compression`, `metric_batcher.payload_compression`, and `central_queue.payload_compression`.
+  * `zstd.encoder_concurrency` optionally limits zstd encoder workers. Leave unset or `0` for the library default.
+  * `zstd.window_size` optionally sets the zstd encoder window size. It must be a power of two between `1024` and `536870912`.
+  * `zstd.lower_encoder_mem` enables zstd lower-memory encoder mode. Default: `false`.
 * The `central_queue` property enables a single load-balancer queue per exporter instance for logs and metrics. It is `disabled` by default for backward compatibility.
   * `enabled` turns the central compressed queue on or off.
   * `max_compressed_bytes` sets the central queue capacity in compressed OTLP payload bytes and must be greater than zero when enabled.
@@ -198,6 +202,11 @@ exporters:
       max_bytes: 1048576
       flush_interval: 100ms
       payload_compression: zstd
+    payload_codec:
+      zstd:
+        encoder_concurrency: 1
+        window_size: 1048576
+        lower_encoder_mem: false
     central_queue:
       enabled: false
       max_compressed_bytes: 4294967296

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
+	"github.com/klauspost/compress/zstd"
 	"go.opentelemetry.io/collector/config/configoptional"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/confmap"
@@ -48,6 +49,7 @@ type Config struct {
 	LogBatcher                LogBatcherConfig     `mapstructure:"log_batcher"`
 	LogRouting                LogRoutingConfig     `mapstructure:"log_routing"`
 	MetricBatcher             MetricBatcherConfig  `mapstructure:"metric_batcher"`
+	PayloadCodec              PayloadCodecConfig   `mapstructure:"payload_codec"`
 	EndpointHealth            EndpointHealthConfig `mapstructure:"endpoint_health"`
 
 	Protocol Protocol         `mapstructure:"protocol"`
@@ -128,6 +130,16 @@ type MetricBatcherConfig struct {
 	FlushInterval            time.Duration           `mapstructure:"flush_interval"`
 	MaxRetryBufferMultiplier int                     `mapstructure:"max_retry_buffer_multiplier"`
 	PayloadCompression       QueuePayloadCompression `mapstructure:"payload_compression"`
+}
+
+type PayloadCodecConfig struct {
+	Zstd ZstdPayloadCodecConfig `mapstructure:"zstd"`
+}
+
+type ZstdPayloadCodecConfig struct {
+	EncoderConcurrency int  `mapstructure:"encoder_concurrency"`
+	WindowSize         int  `mapstructure:"window_size"`
+	LowerEncoderMem    bool `mapstructure:"lower_encoder_mem"`
 }
 
 const defaultEndpointHealthQuarantineDuration = 30 * time.Second
@@ -298,6 +310,9 @@ func (cfg *Config) centralQueueByteBatchingEnabled() bool {
 }
 
 func (cfg *Config) Validate() error {
+	if err := cfg.PayloadCodec.Validate(); err != nil {
+		return err
+	}
 	if err := cfg.QueueSettings.Validate(); err != nil {
 		return err
 	}
@@ -323,6 +338,26 @@ func (cfg *Config) Validate() error {
 		return err
 	}
 	return cfg.EndpointHealth.Validate()
+}
+
+func (c PayloadCodecConfig) Validate() error {
+	return c.Zstd.Validate()
+}
+
+func (c ZstdPayloadCodecConfig) Validate() error {
+	if c.EncoderConcurrency < 0 {
+		return errors.New("payload_codec.zstd.encoder_concurrency must be greater than or equal to 0")
+	}
+	if c.WindowSize == 0 {
+		return nil
+	}
+	if c.WindowSize < zstd.MinWindowSize || c.WindowSize > zstd.MaxWindowSize {
+		return fmt.Errorf("payload_codec.zstd.window_size must be a power of two between %d and %d", zstd.MinWindowSize, zstd.MaxWindowSize)
+	}
+	if c.WindowSize&(c.WindowSize-1) != 0 {
+		return fmt.Errorf("payload_codec.zstd.window_size must be a power of two between %d and %d", zstd.MinWindowSize, zstd.MaxWindowSize)
+	}
+	return nil
 }
 
 func (c CentralQueueConfig) Validate() error {

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -134,12 +134,16 @@ type MetricBatcherConfig struct {
 
 type PayloadCodecConfig struct {
 	Zstd ZstdPayloadCodecConfig `mapstructure:"zstd"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 type ZstdPayloadCodecConfig struct {
 	EncoderConcurrency int  `mapstructure:"encoder_concurrency"`
 	WindowSize         int  `mapstructure:"window_size"`
 	LowerEncoderMem    bool `mapstructure:"lower_encoder_mem"`
+	// prevent unkeyed literal initialization
+	_ struct{}
 }
 
 const defaultEndpointHealthQuarantineDuration = 30 * time.Second

--- a/exporter/loadbalancingexporter/config.schema.yaml
+++ b/exporter/loadbalancingexporter/config.schema.yaml
@@ -160,6 +160,26 @@ $defs:
           - none
           - snappy
           - zstd
+  payload_codec_config:
+    type: object
+    properties:
+      zstd:
+        $ref: zstd_payload_codec_config
+  zstd_payload_codec_config:
+    type: object
+    properties:
+      encoder_concurrency:
+        type: integer
+        minimum: 0
+        description: Optional zstd encoder worker limit. Leave unset or 0 for the library default.
+      window_size:
+        type: integer
+        minimum: 1024
+        maximum: 536870912
+        description: Optional zstd encoder window size. Must be a power of two between 1024 and 536870912.
+      lower_encoder_mem:
+        type: boolean
+        description: Enables the zstd lower-memory encoder mode.
   protocol:
     description: Protocol holds the individual protocol-specific settings. Only OTLP is supported at the moment.
     type: object
@@ -201,6 +221,8 @@ properties:
     $ref: log_routing_config
   metric_batcher:
     $ref: metric_batcher_config
+  payload_codec:
+    $ref: payload_codec_config
   protocol:
     $ref: protocol
   resolver:

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -46,6 +46,86 @@ func TestConfigValidatePayloadCompression(t *testing.T) {
 	require.Error(t, cfg.Validate())
 }
 
+func TestLoadConfigWithZstdPayloadCodecOptions(t *testing.T) {
+	cfg := createDefaultConfig().(*Config)
+	conf := confmap.NewFromStringMap(map[string]any{
+		"protocol": map[string]any{
+			"otlp": map[string]any{
+				"endpoint": "localhost:4317",
+				"tls": map[string]any{
+					"insecure": true,
+				},
+			},
+		},
+		"resolver": map[string]any{
+			"static": map[string]any{
+				"hostnames": []string{"localhost:4317"},
+			},
+		},
+		"payload_codec": map[string]any{
+			"zstd": map[string]any{
+				"encoder_concurrency": 2,
+				"window_size":         2 << 20,
+				"lower_encoder_mem":   true,
+			},
+		},
+	})
+
+	require.NoError(t, conf.Unmarshal(cfg))
+	require.Equal(t, 2, cfg.PayloadCodec.Zstd.EncoderConcurrency)
+	require.Equal(t, 2<<20, cfg.PayloadCodec.Zstd.WindowSize)
+	require.True(t, cfg.PayloadCodec.Zstd.LowerEncoderMem)
+	require.NoError(t, cfg.Validate())
+}
+
+func TestConfigValidateZstdPayloadCodecOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		zstd        ZstdPayloadCodecConfig
+		expectedErr string
+	}{
+		{
+			name:        "negative concurrency",
+			zstd:        ZstdPayloadCodecConfig{EncoderConcurrency: -1},
+			expectedErr: "payload_codec.zstd.encoder_concurrency",
+		},
+		{
+			name:        "too small window",
+			zstd:        ZstdPayloadCodecConfig{WindowSize: 512},
+			expectedErr: "payload_codec.zstd.window_size",
+		},
+		{
+			name:        "non power of two window",
+			zstd:        ZstdPayloadCodecConfig{WindowSize: 3 << 20},
+			expectedErr: "payload_codec.zstd.window_size",
+		},
+		{
+			name:        "too large window",
+			zstd:        ZstdPayloadCodecConfig{WindowSize: 1 << 30},
+			expectedErr: "payload_codec.zstd.window_size",
+		},
+		{
+			name:        "valid bounded options",
+			zstd:        ZstdPayloadCodecConfig{EncoderConcurrency: 1, WindowSize: 2 << 20, LowerEncoderMem: true},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			cfg.PayloadCodec.Zstd = tt.zstd
+
+			err := cfg.Validate()
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.expectedErr)
+		})
+	}
+}
+
 func TestConfigValidateCompressInMemory(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.QueueSettings.CompressInMemory = true

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -228,7 +228,7 @@ func newQueuePayloadCodecIfEnabled(cfg *Config) *queuePayloadCodec {
 		return nil
 	}
 
-	return newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression)
+	return newQueuePayloadCodec(cfg.QueueSettings.PayloadCompression, cfg.PayloadCodec.Zstd)
 }
 
 func shutdownWithCodec(shutdown component.ShutdownFunc, codec *queuePayloadCodec) component.ShutdownFunc {

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -371,6 +371,19 @@ func TestNewQueuePayloadCodecIfEnabled(t *testing.T) {
 		cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionNone
 		assert.NotNil(t, newQueuePayloadCodecIfEnabled(cfg))
 	})
+
+	t.Run("zstd options are passed to codec", func(t *testing.T) {
+		cfg.QueueSettings.PayloadCompression = QueuePayloadCompressionZstd
+		cfg.PayloadCodec.Zstd = ZstdPayloadCodecConfig{
+			EncoderConcurrency: 1,
+			WindowSize:         2 << 20,
+			LowerEncoderMem:    true,
+		}
+
+		codec := newQueuePayloadCodecIfEnabled(cfg)
+		require.NotNil(t, codec)
+		assert.Equal(t, cfg.PayloadCodec.Zstd, codec.zstd)
+	})
 }
 
 func TestQueueConfigForExportKeepsMemoryQueueWhenRequested(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_batcher.go
+++ b/exporter/loadbalancingexporter/log_batcher.go
@@ -39,6 +39,7 @@ type logBatcherSettings struct {
 	maxBytes           int
 	flushInterval      time.Duration
 	payloadCompression QueuePayloadCompression
+	zstd               ZstdPayloadCodecConfig
 }
 
 type (
@@ -331,18 +332,18 @@ func newBackendLogBatcher(
 		telemetry:    telemetry,
 		requests:     make(chan logBatcherRequest, 16),
 		done:         make(chan struct{}),
-		payloadCodec: newLogBatcherPayloadCodec(settings.payloadCompression),
+		payloadCodec: newLogBatcherPayloadCodec(settings.payloadCompression, settings.zstd),
 	}
 
 	go backend.run()
 	return backend
 }
 
-func newLogBatcherPayloadCodec(compression QueuePayloadCompression) *queuePayloadCodec {
+func newLogBatcherPayloadCodec(compression QueuePayloadCompression, zstdConfig ...ZstdPayloadCodecConfig) *queuePayloadCodec {
 	if compression == "" || compression == QueuePayloadCompressionNone {
 		return nil
 	}
-	return newQueuePayloadCodec(compression)
+	return newQueuePayloadCodec(compression, zstdConfig...)
 }
 
 func (b *backendLogBatcher) stopAndFlush(ctx context.Context, reason string) error {

--- a/exporter/loadbalancingexporter/log_batcher_test.go
+++ b/exporter/loadbalancingexporter/log_batcher_test.go
@@ -416,6 +416,18 @@ func TestCompressedLogBatcherChunkDoesNotRetainUncompressedPayload(t *testing.T)
 	require.Equal(t, logs.LogRecordCount(), decoded.LogRecordCount())
 }
 
+func TestLogBatcherPayloadCodecUsesZstdOptions(t *testing.T) {
+	zstd := ZstdPayloadCodecConfig{
+		EncoderConcurrency: 1,
+		WindowSize:         2 << 20,
+		LowerEncoderMem:    true,
+	}
+
+	codec := newLogBatcherPayloadCodec(QueuePayloadCompressionZstd, zstd)
+	require.NotNil(t, codec)
+	require.Equal(t, zstd, codec.zstd)
+}
+
 func TestCompressedLogBatcherFlushPreservesLogsAndSplitsByMaxRecords(t *testing.T) {
 	ts, _ := getTelemetryAssets(t)
 	var mu sync.Mutex

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -91,7 +91,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 			maxReadyWindows:              centralQueueReadyWindowLimit(centralCfg.NumConsumers),
 			telemetry:                    centralTelemetry,
 		})
-		logExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression)
+		logExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression, cfg.(*Config).PayloadCodec.Zstd)
 	}
 	if cfg.(*Config).LogBatcher.Enabled {
 		logBatcherCfg := cfg.(*Config).LogBatcher
@@ -103,6 +103,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 				maxBytes:           logBatcherCfg.MaxBytes,
 				flushInterval:      logBatcherCfg.FlushInterval,
 				payloadCompression: logBatcherCfg.PayloadCompression,
+				zstd:               cfg.(*Config).PayloadCodec.Zstd,
 			},
 			logExporter.consumeBatcherFlush,
 			logExporter.rerouteDrainBatch,

--- a/exporter/loadbalancingexporter/metric_batcher.go
+++ b/exporter/loadbalancingexporter/metric_batcher.go
@@ -45,6 +45,7 @@ type metricBatcherSettings struct {
 	flushInterval            time.Duration
 	maxRetryBufferMultiplier int
 	payloadCompression       QueuePayloadCompression
+	zstd                     ZstdPayloadCodecConfig
 }
 
 type (
@@ -359,18 +360,18 @@ func newBackendMetricBatcher(
 		drainErr:     drainErr,
 		requests:     make(chan metricBatcherRequest, 16),
 		done:         make(chan struct{}),
-		payloadCodec: newMetricBatcherPayloadCodec(settings.payloadCompression),
+		payloadCodec: newMetricBatcherPayloadCodec(settings.payloadCompression, settings.zstd),
 	}
 
 	go backend.run()
 	return backend
 }
 
-func newMetricBatcherPayloadCodec(compression QueuePayloadCompression) *queuePayloadCodec {
+func newMetricBatcherPayloadCodec(compression QueuePayloadCompression, zstdConfig ...ZstdPayloadCodecConfig) *queuePayloadCodec {
 	if compression == "" || compression == QueuePayloadCompressionNone {
 		return nil
 	}
-	return newQueuePayloadCodec(compression)
+	return newQueuePayloadCodec(compression, zstdConfig...)
 }
 
 func (b *backendMetricBatcher) stopAndFlush(ctx context.Context, reason string) error {

--- a/exporter/loadbalancingexporter/metric_batcher_test.go
+++ b/exporter/loadbalancingexporter/metric_batcher_test.go
@@ -28,6 +28,18 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadatatest"
 )
 
+func TestMetricBatcherPayloadCodecUsesZstdOptions(t *testing.T) {
+	zstd := ZstdPayloadCodecConfig{
+		EncoderConcurrency: 1,
+		WindowSize:         2 << 20,
+		LowerEncoderMem:    true,
+	}
+
+	codec := newMetricBatcherPayloadCodec(QueuePayloadCompressionZstd, zstd)
+	require.NotNil(t, codec)
+	require.Equal(t, zstd, codec.zstd)
+}
+
 func TestMetricBatcherReroutesEndpointLocalFlushFailure(t *testing.T) {
 	ts, tb, telemetry := getTelemetryAssetsWithReader(t)
 	cfg := endpoint2Config()

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -91,7 +91,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 			maxReadyWindows:              centralQueueReadyWindowLimit(centralCfg.NumConsumers),
 			telemetry:                    centralTelemetry,
 		})
-		metricExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression)
+		metricExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression, cfg.(*Config).PayloadCodec.Zstd)
 	}
 
 	switch cfg.(*Config).RoutingKey {
@@ -118,6 +118,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 				flushInterval:            cfg.(*Config).MetricBatcher.FlushInterval,
 				maxRetryBufferMultiplier: cfg.(*Config).MetricBatcher.MaxRetryBufferMultiplier,
 				payloadCompression:       cfg.(*Config).MetricBatcher.PayloadCompression,
+				zstd:                     cfg.(*Config).PayloadCodec.Zstd,
 			},
 			metricExporter.consumeBatch,
 			metricExporter.rerouteDrainBatch,

--- a/exporter/loadbalancingexporter/payload_codec.go
+++ b/exporter/loadbalancingexporter/payload_codec.go
@@ -29,6 +29,7 @@ const (
 
 type queuePayloadCodec struct {
 	compression QueuePayloadCompression
+	zstd        ZstdPayloadCodecConfig
 	zstdOnce    sync.Once
 	closeOnce   sync.Once
 	zstdEnc     *zstd.Encoder
@@ -36,8 +37,12 @@ type queuePayloadCodec struct {
 	zstdErr     error
 }
 
-func newQueuePayloadCodec(compression QueuePayloadCompression) *queuePayloadCodec {
-	return &queuePayloadCodec{compression: compression}
+func newQueuePayloadCodec(compression QueuePayloadCompression, zstdConfig ...ZstdPayloadCodecConfig) *queuePayloadCodec {
+	codec := &queuePayloadCodec{compression: compression}
+	if len(zstdConfig) > 0 {
+		codec.zstd = zstdConfig[0]
+	}
+	return codec
 }
 
 func (c *queuePayloadCodec) Encode(payload []byte) ([]byte, error) {
@@ -112,7 +117,7 @@ func (c *queuePayloadCodec) decompress(codecID byte, payload []byte) ([]byte, er
 
 func (c *queuePayloadCodec) initZstd() error {
 	c.zstdOnce.Do(func() {
-		c.zstdEnc, c.zstdErr = zstd.NewWriter(nil)
+		c.zstdEnc, c.zstdErr = zstd.NewWriter(nil, c.zstd.encoderOptions()...)
 		if c.zstdErr != nil {
 			return
 		}
@@ -125,6 +130,20 @@ func (c *queuePayloadCodec) initZstd() error {
 		}
 	})
 	return c.zstdErr
+}
+
+func (c ZstdPayloadCodecConfig) encoderOptions() []zstd.EOption {
+	opts := make([]zstd.EOption, 0, 3)
+	if c.EncoderConcurrency > 0 {
+		opts = append(opts, zstd.WithEncoderConcurrency(c.EncoderConcurrency))
+	}
+	if c.WindowSize > 0 {
+		opts = append(opts, zstd.WithWindowSize(c.WindowSize))
+	}
+	if c.LowerEncoderMem {
+		opts = append(opts, zstd.WithLowerEncoderMem(true))
+	}
+	return opts
 }
 
 func (c *queuePayloadCodec) Close() error {

--- a/exporter/loadbalancingexporter/payload_codec_benchmark_test.go
+++ b/exporter/loadbalancingexporter/payload_codec_benchmark_test.go
@@ -13,6 +13,8 @@ import (
 
 var queuePayloadCodecBenchmarkSink []byte
 
+const benchmarkBytesPerMiB = 1024 * 1024
+
 func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 	payload, err := (&plog.ProtoMarshaler{}).MarshalLogs(compressibleLogs(16000, 1024))
 	if err != nil {
@@ -20,8 +22,9 @@ func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 	}
 
 	tests := []struct {
-		name string
-		zstd ZstdPayloadCodecConfig
+		name                string
+		zstd                ZstdPayloadCodecConfig
+		maxLiveHeapAllocMiB float64
 	}{
 		{name: "default"},
 		{
@@ -30,6 +33,7 @@ func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 				EncoderConcurrency: 1,
 				WindowSize:         2 << 20,
 			},
+			maxLiveHeapAllocMiB: 12,
 		},
 		{
 			name: "concurrency_2_window_2MiB",
@@ -37,6 +41,7 @@ func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 				EncoderConcurrency: 2,
 				WindowSize:         2 << 20,
 			},
+			maxLiveHeapAllocMiB: 14,
 		},
 		{
 			name: "concurrency_1_window_2MiB_lowmem",
@@ -45,6 +50,7 @@ func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 				WindowSize:         2 << 20,
 				LowerEncoderMem:    true,
 			},
+			maxLiveHeapAllocMiB: 8,
 		},
 		{
 			name: "concurrency_2_window_2MiB_lowmem",
@@ -53,6 +59,7 @@ func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 				WindowSize:         2 << 20,
 				LowerEncoderMem:    true,
 			},
+			maxLiveHeapAllocMiB: 10,
 		},
 		{
 			name: "concurrency_1_window_1MiB",
@@ -60,6 +67,7 @@ func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 				EncoderConcurrency: 1,
 				WindowSize:         1 << 20,
 			},
+			maxLiveHeapAllocMiB: 8,
 		},
 		{
 			name: "concurrency_2_window_1MiB",
@@ -67,6 +75,7 @@ func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 				EncoderConcurrency: 2,
 				WindowSize:         1 << 20,
 			},
+			maxLiveHeapAllocMiB: 10,
 		},
 		{
 			name: "concurrency_1_window_1MiB_lowmem",
@@ -75,6 +84,7 @@ func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 				WindowSize:         1 << 20,
 				LowerEncoderMem:    true,
 			},
+			maxLiveHeapAllocMiB: 6,
 		},
 	}
 
@@ -98,9 +108,17 @@ func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
 				queuePayloadCodecBenchmarkSink = encoded
 			}
 			b.StopTimer()
-			b.ReportMetric(float64(stats.firstEncodeAllocBytes)/(1024*1024), "init_alloc_MiB/op")
-			b.ReportMetric(float64(stats.liveHeapAllocBytes)/(1024*1024), "live_heap_alloc_MiB")
-			b.ReportMetric(float64(stats.liveHeapInuseBytes)/(1024*1024), "live_heap_inuse_MiB")
+			liveHeapAllocMiB := float64(stats.liveHeapAllocBytes) / benchmarkBytesPerMiB
+			if tt.maxLiveHeapAllocMiB > 0 && liveHeapAllocMiB > tt.maxLiveHeapAllocMiB {
+				b.Fatalf(
+					"bounded zstd codec retained heap = %.2f MiB, want <= %.2f MiB",
+					liveHeapAllocMiB,
+					tt.maxLiveHeapAllocMiB,
+				)
+			}
+			b.ReportMetric(float64(stats.firstEncodeAllocBytes)/benchmarkBytesPerMiB, "init_alloc_MiB/op")
+			b.ReportMetric(liveHeapAllocMiB, "live_heap_alloc_MiB")
+			b.ReportMetric(float64(stats.liveHeapInuseBytes)/benchmarkBytesPerMiB, "live_heap_inuse_MiB")
 			b.ReportMetric(float64(stats.encodedBytes)/1024, "encoded_KiB")
 		})
 	}

--- a/exporter/loadbalancingexporter/payload_codec_benchmark_test.go
+++ b/exporter/loadbalancingexporter/payload_codec_benchmark_test.go
@@ -1,0 +1,155 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+var queuePayloadCodecBenchmarkSink []byte
+
+func BenchmarkQueuePayloadCodecZstdOptions(b *testing.B) {
+	payload, err := (&plog.ProtoMarshaler{}).MarshalLogs(compressibleLogs(16000, 1024))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		zstd ZstdPayloadCodecConfig
+	}{
+		{name: "default"},
+		{
+			name: "concurrency_1_window_2MiB",
+			zstd: ZstdPayloadCodecConfig{
+				EncoderConcurrency: 1,
+				WindowSize:         2 << 20,
+			},
+		},
+		{
+			name: "concurrency_2_window_2MiB",
+			zstd: ZstdPayloadCodecConfig{
+				EncoderConcurrency: 2,
+				WindowSize:         2 << 20,
+			},
+		},
+		{
+			name: "concurrency_1_window_2MiB_lowmem",
+			zstd: ZstdPayloadCodecConfig{
+				EncoderConcurrency: 1,
+				WindowSize:         2 << 20,
+				LowerEncoderMem:    true,
+			},
+		},
+		{
+			name: "concurrency_2_window_2MiB_lowmem",
+			zstd: ZstdPayloadCodecConfig{
+				EncoderConcurrency: 2,
+				WindowSize:         2 << 20,
+				LowerEncoderMem:    true,
+			},
+		},
+		{
+			name: "concurrency_1_window_1MiB",
+			zstd: ZstdPayloadCodecConfig{
+				EncoderConcurrency: 1,
+				WindowSize:         1 << 20,
+			},
+		},
+		{
+			name: "concurrency_2_window_1MiB",
+			zstd: ZstdPayloadCodecConfig{
+				EncoderConcurrency: 2,
+				WindowSize:         1 << 20,
+			},
+		},
+		{
+			name: "concurrency_1_window_1MiB_lowmem",
+			zstd: ZstdPayloadCodecConfig{
+				EncoderConcurrency: 1,
+				WindowSize:         1 << 20,
+				LowerEncoderMem:    true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			codec, stats := newInitializedBenchmarkQueuePayloadCodec(b, tt.zstd, payload)
+			b.Cleanup(func() {
+				if err := codec.Close(); err != nil {
+					b.Fatal(err)
+				}
+			})
+			b.ReportAllocs()
+			b.SetBytes(int64(len(payload)))
+			b.ResetTimer()
+
+			for range b.N {
+				encoded, err := codec.Encode(payload)
+				if err != nil {
+					b.Fatal(err)
+				}
+				queuePayloadCodecBenchmarkSink = encoded
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(stats.firstEncodeAllocBytes)/(1024*1024), "init_alloc_MiB/op")
+			b.ReportMetric(float64(stats.liveHeapAllocBytes)/(1024*1024), "live_heap_alloc_MiB")
+			b.ReportMetric(float64(stats.liveHeapInuseBytes)/(1024*1024), "live_heap_inuse_MiB")
+			b.ReportMetric(float64(stats.encodedBytes)/1024, "encoded_KiB")
+		})
+	}
+}
+
+type benchmarkQueuePayloadCodecStats struct {
+	firstEncodeAllocBytes uint64
+	liveHeapAllocBytes    uint64
+	liveHeapInuseBytes    uint64
+	encodedBytes          int
+}
+
+func newInitializedBenchmarkQueuePayloadCodec(
+	b *testing.B,
+	zstd ZstdPayloadCodecConfig,
+	payload []byte,
+) (*queuePayloadCodec, benchmarkQueuePayloadCodecStats) {
+	b.Helper()
+
+	queuePayloadCodecBenchmarkSink = nil
+	debug.FreeOSMemory()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd, zstd)
+	encoded, err := codec.Encode(payload)
+	if err != nil {
+		b.Fatal(err)
+	}
+	encodedBytes := len(encoded)
+	queuePayloadCodecBenchmarkSink = nil
+	encoded = nil
+
+	debug.FreeOSMemory()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	runtime.KeepAlive(codec)
+
+	stats := benchmarkQueuePayloadCodecStats{
+		encodedBytes: encodedBytes,
+	}
+	if after.TotalAlloc > before.TotalAlloc {
+		stats.firstEncodeAllocBytes = after.TotalAlloc - before.TotalAlloc
+	}
+	if after.HeapAlloc > before.HeapAlloc {
+		stats.liveHeapAllocBytes = after.HeapAlloc - before.HeapAlloc
+	}
+	if after.HeapInuse > before.HeapInuse {
+		stats.liveHeapInuseBytes = after.HeapInuse - before.HeapInuse
+	}
+	return codec, stats
+}


### PR DESCRIPTION
TL;DR: Adds configurable zstd encoder bounds for LB payload compression and proves the memory/throughput tradeoff with a focused benchmark. This supports SAW-7527 staging validation via explicit LaunchDarkly-rendered payload codec settings.

Description:
- Adds `payload_codec.zstd.{encoder_concurrency,window_size,lower_encoder_mem}` to loadbalancingexporter config/schema/docs.
- Wires the shared zstd options into sending queue, central queue, log batcher, and metric batcher payload codecs.
- Adds red/green tests plus `BenchmarkQueuePayloadCodecZstdOptions` showing default ~28.9 MiB retained codec heap vs ~3.6 MiB with c=1/window=1 MiB.

Verification:
- `go test . -count=1` in `exporter/loadbalancingexporter`
- `go test . -run '^$' -bench '^BenchmarkQueuePayloadCodecZstdOptions$' -benchmem -benchtime=10x -count=3`\n\nRefs SAW-7527

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core payload compression used by queues/batchers and changes zstd encoder initialization options, which could impact memory/throughput and interoperability if misconfigured, though defaults preserve existing behavior.
> 
> **Overview**
> Adds a new `payload_codec.zstd` config block to bound zstd encoder working memory (encoder concurrency, window size, and lower-memory mode), including schema/docs updates and validation.
> 
> Wires these shared zstd options into all places the exporter compresses queued/batched payloads (`sending_queue`, `central_queue`, `log_batcher`, `metric_batcher`) by passing the config into `newQueuePayloadCodec`, and adds unit tests plus a focused benchmark to quantify memory/alloc tradeoffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3151694fb8532a36cbf54e0da8a354a413e74407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable zstd encoder bounds to the `loadbalancingexporter` payload codec to make memory use predictable and cut retained heap. Applies to all zstd-compressed queues and batchers with defaults unchanged; addresses SAW-7527.

- **New Features**
  - Adds `payload_codec.zstd` options: `encoder_concurrency`, `window_size` (power of two, 1 KiB–512 MiB), and `lower_encoder_mem` with schema and runtime validation.
  - Wires options into zstd codecs used by `sending_queue`, `central_queue`, `log_batcher`, and `metric_batcher`; payload compatibility preserved.
  - Adds `BenchmarkQueuePayloadCodecZstdOptions` to enforce bounded live-heap for selected settings and document memory/throughput tradeoffs.
  - Updates README with config examples and adds changelog entry.

- **Refactors**
  - Prevent unkeyed payload codec struct literals to avoid accidental field omissions.

<sup>Written for commit 3151694fb8532a36cbf54e0da8a354a413e74407. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `payload_codec` configuration section enabling fine-grained control over Zstd compression settings, including encoder concurrency, window size, and lower-memory encoding mode, applied across sending queue, log batcher, metric batcher, and central queue components.

* **Documentation**
  * Updated configuration documentation with `payload_codec` block examples and detailed Zstd option specifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->