### PR TITLE
fix(elasticsearchexporter): preserve bulk error reasons

### DIFF
--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -386,7 +386,7 @@ In the exporter, the equivalent configuration is also named `include_source_on_e
 - `include_source_on_error`:
   - `true`: Enables bulk index responses to include source document on error. Requires Elasticsearch 8.18+. WARNING: the exporter may log error responses containing request payload, causing potential sensitive data to be exposed in logs.
   - `false`: Disables including source document on bulk index error responses.  Requires Elasticsearch 8.18+.
-  - `null` (default): Backward-compatible option for older Elasticsearch versions. By default, the error reason is discarded from bulk index responses entirely, i.e. only error type is returned.
+  - `null` (default): Does not request source documents on bulk index errors. With `telemetry.preserve_error_reason` enabled, the exporter keeps backend-provided `error.reason` while stripping the `include_source_on_error` request parameter for OpenSearch compatibility.
 
 ### Elasticsearch node discovery
 
@@ -408,6 +408,7 @@ The Elasticsearch Exporter's own telemetry settings for testing and debugging pu
 ⚠️ This is experimental and may change at any time.
 
 - `telemetry`:
+  - `preserve_error_reason` (default=true): Preserves backend-provided bulk item `error.reason` in failed document logs without asking Elasticsearch/OpenSearch to include source snippets. This keeps mapper parsing details visible for debugging while avoiding the `include_source_on_error` bulk request parameter that some OpenSearch versions reject. WARNING: backend error reasons may still include field names, rejected values, or other sensitive details.
   - `log_request_body` (default=false): Logs Elasticsearch client request body as a field in a log line at DEBUG level. It requires `service::telemetry::logs::level` to be set to `debug`. WARNING: Enabling this config may expose sensitive data.
   - `log_response_body` (default=false): Logs Elasticsearch client response body as a field in a log line at DEBUG level. It requires `service::telemetry::logs::level` to be set to `debug`. WARNING: Enabling this config may expose sensitive data.
   - `log_failed_docs_input` (default=false): Include the input (action line and document line) causing indexing error under `input` field in a log line at DEBUG level. It requires `service::telemetry::logs::level` to be set to `debug`. WARNING: Enabling this config may expose sensitive data.

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -94,16 +94,34 @@ func bulkIndexerConfig(client elastictransport.Interface, config *Config, requir
 		compressionLevel = int(config.CompressionParams.Level)
 	}
 	return docappender.BulkIndexerConfig{
-		Client:                  client,
+		Client:                  bulkIndexerClient(client, config),
 		MaxDocumentRetries:      maxDocRetries,
 		Pipeline:                config.Pipeline,
 		RetryOnDocumentStatus:   config.Retry.RetryOnStatus,
 		RequireDataStream:       requireDataStream,
 		CompressionLevel:        compressionLevel,
 		PopulateFailedDocsInput: config.LogFailedDocsInput,
-		IncludeSourceOnError:    bulkIndexerIncludeSourceOnError(config.IncludeSourceOnError),
+		IncludeSourceOnError:    bulkIndexerIncludeSourceOnError(config),
 		QueryParams:             getQueryParamsFromEndpoint(config, logger),
 	}
+}
+
+type stripIncludeSourceOnErrorTransport struct {
+	next elastictransport.Interface
+}
+
+func (t stripIncludeSourceOnErrorTransport) Perform(req *http.Request) (*http.Response, error) {
+	q := req.URL.Query()
+	q.Del("include_source_on_error")
+	req.URL.RawQuery = q.Encode()
+	return t.next.Perform(req)
+}
+
+func bulkIndexerClient(client elastictransport.Interface, config *Config) elastictransport.Interface {
+	if shouldPreserveErrorReasonWithoutSourceParam(config) {
+		return stripIncludeSourceOnErrorTransport{next: client}
+	}
+	return client
 }
 
 func getQueryParamsFromEndpoint(config *Config, logger *zap.Logger) (queryParams map[string][]string) {
@@ -127,14 +145,25 @@ func getQueryParamsFromEndpoint(config *Config, logger *zap.Logger) (queryParams
 	return nil
 }
 
-func bulkIndexerIncludeSourceOnError(includeSourceOnError *bool) docappender.Value {
-	if includeSourceOnError == nil {
+func bulkIndexerIncludeSourceOnError(config *Config) docappender.Value {
+	if config.IncludeSourceOnError == nil {
+		// go-docappender currently preserves bulk item error.reason only when
+		// IncludeSourceOnError is explicitly set. OpenSearch rejects the matching
+		// request parameter, so the transport wrapper strips it before the request
+		// leaves the exporter.
+		if config.PreserveErrorReason {
+			return docappender.False
+		}
 		return docappender.Unset
 	}
-	if *includeSourceOnError {
+	if *config.IncludeSourceOnError {
 		return docappender.True
 	}
 	return docappender.False
+}
+
+func shouldPreserveErrorReasonWithoutSourceParam(config *Config) bool {
+	return config.IncludeSourceOnError == nil && config.PreserveErrorReason
 }
 
 func newSyncBulkIndexer(

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync/atomic"
@@ -47,6 +48,18 @@ func (t *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return defaultRoundTripFunc(req)
 	}
 	return t.RoundTripFunc(req)
+}
+
+type fakeElasticTransport struct {
+	request *http.Request
+}
+
+func (t *fakeElasticTransport) Perform(req *http.Request) (*http.Response, error) {
+	t.request = req
+	return &http.Response{
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		StatusCode: http.StatusOK,
+	}, nil
 }
 
 const successResp = `{
@@ -377,6 +390,86 @@ func TestQueryParamsParsedFromEndpoints(t *testing.T) {
 		"pretty":              {"false"},
 		"require_data_stream": {"true"},
 	}, bi.QueryParams)
+}
+
+func TestBulkIndexerIncludeSourceOnError(t *testing.T) {
+	falsePtr := func() *bool {
+		v := false
+		return &v
+	}
+	truePtr := func() *bool {
+		v := true
+		return &v
+	}
+
+	tests := []struct {
+		name       string
+		cfg        func(*Config)
+		wantValue  docappender.Value
+		wantStrip  bool
+		wantClient any
+	}{
+		{
+			name:       "default preserves reason for opensearch compatibility",
+			wantValue:  docappender.False,
+			wantStrip:  true,
+			wantClient: stripIncludeSourceOnErrorTransport{},
+		},
+		{
+			name: "disabled leaves docappender default behavior",
+			cfg: func(cfg *Config) {
+				cfg.PreserveErrorReason = false
+			},
+			wantValue: docappender.Unset,
+		},
+		{
+			name: "explicit include source false keeps upstream request parameter",
+			cfg: func(cfg *Config) {
+				cfg.IncludeSourceOnError = falsePtr()
+			},
+			wantValue: docappender.False,
+		},
+		{
+			name: "explicit include source true keeps upstream request parameter",
+			cfg: func(cfg *Config) {
+				cfg.IncludeSourceOnError = truePtr()
+			},
+			wantValue: docappender.True,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			if tt.cfg != nil {
+				tt.cfg(cfg)
+			}
+
+			assert.Equal(t, tt.wantValue, bulkIndexerIncludeSourceOnError(cfg))
+			client := bulkIndexerClient(&fakeElasticTransport{}, cfg)
+			if tt.wantStrip {
+				assert.IsType(t, tt.wantClient, client)
+			} else {
+				assert.IsType(t, &fakeElasticTransport{}, client)
+			}
+		})
+	}
+}
+
+func TestStripIncludeSourceOnErrorTransport(t *testing.T) {
+	next := &fakeElasticTransport{}
+	transport := stripIncludeSourceOnErrorTransport{next: next}
+	req := httptest.NewRequest(http.MethodPost, "http://localhost:9200/_bulk?include_source_on_error=false&filter_path=items.*.error&pipeline=test", nil)
+
+	resp, err := transport.Perform(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	q := next.request.URL.Query()
+	_, ok := q["include_source_on_error"]
+	assert.False(t, ok)
+	assert.Equal(t, []string{"items.*.error"}, q["filter_path"])
+	assert.Equal(t, []string{"test"}, q["pipeline"])
 }
 
 func TestNewBulkIndexer(t *testing.T) {

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -101,7 +101,9 @@ type Config struct {
 	// have no effect.
 	//
 	// NOTE: The default behavior if this configuration is not set, is to
-	// discard the error reason entirely, i.e. only the error type is returned.
+	// preserve error.reason without requesting source snippets. To restore the
+	// upstream docappender behavior that discards error.reason, set
+	// telemetry::preserve_error_reason to false.
 	//
 	// WARNING: If set to true, the exporter may log error responses containing
 	// request payload, causing potential sensitive data to be exposed in logs.
@@ -127,6 +129,7 @@ type TelemetrySettings struct {
 
 	LogFailedDocsInput          bool          `mapstructure:"log_failed_docs_input"`
 	LogFailedDocsInputRateLimit time.Duration `mapstructure:"log_failed_docs_input_rate_limit"`
+	PreserveErrorReason         bool          `mapstructure:"preserve_error_reason"`
 
 	// prevent unkeyed literal initialization
 	_ struct{}

--- a/exporter/elasticsearchexporter/config.schema.yaml
+++ b/exporter/elasticsearchexporter/config.schema.yaml
@@ -112,6 +112,8 @@ $defs:
         type: boolean
       log_response_body:
         type: boolean
+      preserve_error_reason:
+        type: boolean
 description: Config defines configuration for Elastic exporter.
 type: object
 properties:
@@ -129,7 +131,7 @@ properties:
     description: 'Deprecated: [v0.136.0] This config is now deprecated. Use `sending_queue::batch` instead. If this config is defined then it will be used to configure sending queue''s batch provided sending queue''s config are not explicitly defined.'
     $ref: flush_settings
   include_source_on_error:
-    description: 'IncludeSourceOnError configures whether the bulk index responses include a part of the source document on error. Defaults to nil. This setting requires Elasticsearch 8.18+. Using it in prior versions have no effect. NOTE: The default behavior if this configuration is not set, is to discard the error reason entirely, i.e. only the error type is returned. WARNING: If set to true, the exporter may log error responses containing request payload, causing potential sensitive data to be exposed in logs. Users are expected to sanitize the responses themselves.'
+    description: 'IncludeSourceOnError configures whether the bulk index responses include a part of the source document on error. Defaults to nil. This setting requires Elasticsearch 8.18+. Using it in prior versions have no effect. NOTE: The default behavior if this configuration is not set, is to preserve error.reason without requesting source snippets. To restore the upstream docappender behavior that discards error.reason, set telemetry::preserve_error_reason to false. WARNING: If set to true, the exporter may log error responses containing request payload, causing potential sensitive data to be exposed in logs. Users are expected to sanitize the responses themselves.'
     x-pointer: true
     type: boolean
   logs_dynamic_id:

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -138,6 +138,7 @@ func TestConfig(t *testing.T) {
 				},
 				TelemetrySettings: TelemetrySettings{
 					LogFailedDocsInputRateLimit: time.Second,
+					PreserveErrorReason:         true,
 				},
 			},
 		},
@@ -214,6 +215,7 @@ func TestConfig(t *testing.T) {
 				},
 				TelemetrySettings: TelemetrySettings{
 					LogFailedDocsInputRateLimit: time.Second,
+					PreserveErrorReason:         true,
 				},
 			},
 		},
@@ -290,6 +292,7 @@ func TestConfig(t *testing.T) {
 				},
 				TelemetrySettings: TelemetrySettings{
 					LogFailedDocsInputRateLimit: time.Second,
+					PreserveErrorReason:         true,
 				},
 			},
 		},
@@ -351,6 +354,14 @@ func TestConfig(t *testing.T) {
 				cfg.Endpoint = "https://elastic.example.com:9200"
 				includeSource := true
 				cfg.IncludeSourceOnError = &includeSource
+			}),
+		},
+		{
+			id:         component.NewIDWithName(metadata.Type, "preserve_error_reason_disabled"),
+			configFile: "config.yaml",
+			expected: withDefaultConfig(func(cfg *Config) {
+				cfg.Endpoint = "https://elastic.example.com:9200"
+				cfg.PreserveErrorReason = false
 			}),
 		},
 		{

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -85,6 +85,7 @@ func createDefaultConfig() component.Config {
 			LogResponseBody:             false,
 			LogFailedDocsInput:          false,
 			LogFailedDocsInputRateLimit: time.Second,
+			PreserveErrorReason:         true,
 		},
 		IncludeSourceOnError: nil,
 	}

--- a/exporter/elasticsearchexporter/testdata/config.yaml
+++ b/exporter/elasticsearchexporter/testdata/config.yaml
@@ -100,6 +100,10 @@ elasticsearch/compression_gzip:
 elasticsearch/include_source_on_error:
   endpoint: https://elastic.example.com:9200
   include_source_on_error: true
+elasticsearch/preserve_error_reason_disabled:
+  endpoint: https://elastic.example.com:9200
+  telemetry:
+    preserve_error_reason: false
 elasticsearch/metadata_keys:
   endpoint: https://elastic.example.com:9200
   metadata_keys:


### PR DESCRIPTION
Preserve backend-provided bulk item error.reason by default while stripping the include_source_on_error query parameter for OpenSearch compatibility. Explicit include_source_on_error config still keeps upstream behavior.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves backend-provided bulk item error.reason by default and strips the include_source_on_error query parameter for OpenSearch compatibility. Explicit include_source_on_error keeps upstream `docappender` behavior.

- **Bug Fixes**
  - Default: preserve error.reason without requesting source snippets (`telemetry.preserve_error_reason: true`).
  - Strip `include_source_on_error` from bulk requests via a transport wrapper when not explicitly configured.
  - Respect explicit `include_source_on_error` to keep upstream `docappender` behavior.
  - Added unit tests for default behavior and parameter stripping; updated defaults, docs, and sample config.

- **Migration**
  - To restore the old behavior (discard error.reason), set `telemetry.preserve_error_reason` to `false`.

<sup>Written for commit 2732690836a3711b15348f3225f48914c6d5bf9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `preserve_error_reason` configuration option to the Elasticsearch exporter's telemetry settings, allowing control over whether error details are preserved in telemetry data. Enabled by default.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/71)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->