### PR TITLE
[exporter/loadbalancing] reroute ResourceExhausted backend failures

### DIFF
--- a/.chloggen/saw-7500-loadbalancing-resource-exhausted-reroute.yaml
+++ b/.chloggen/saw-7500-loadbalancing-resource-exhausted-reroute.yaml
@@ -1,0 +1,6 @@
+change_type: bug_fix
+component: exporter/loadbalancing
+note: Reroute backend `ResourceExhausted` overload responses to another eligible endpoint when endpoint health rerouting is enabled.
+issues: [7500]
+subtext: |-
+  Permanent bad-data errors remain non-rerouteable.

--- a/exporter/loadbalancingexporter/endpoint_health.go
+++ b/exporter/loadbalancingexporter/endpoint_health.go
@@ -24,6 +24,7 @@ type endpointFailureReason string
 const (
 	endpointFailureTimeout           endpointFailureReason = "timeout"
 	endpointFailureUnavailable       endpointFailureReason = "unavailable"
+	endpointFailureResourceExhausted endpointFailureReason = "resource_exhausted"
 	endpointFailureConnectionRefused endpointFailureReason = "connection_refused"
 	endpointFailureConnectionReset   endpointFailureReason = "connection_reset"
 	endpointFailureNoRoute           endpointFailureReason = "no_route"
@@ -524,6 +525,8 @@ func classifyEndpointFailure(err error) (endpointFailureReason, bool) {
 		return endpointFailureTimeout, true
 	case codes.Unavailable:
 		return endpointFailureUnavailable, true
+	case codes.ResourceExhausted:
+		return endpointFailureResourceExhausted, true
 	}
 
 	var netErr net.Error

--- a/exporter/loadbalancingexporter/endpoint_health_test.go
+++ b/exporter/loadbalancingexporter/endpoint_health_test.go
@@ -378,6 +378,12 @@ func TestEndpointFailureClassification(t *testing.T) {
 			ok:     true,
 		},
 		{
+			name:   "grpc resource exhausted",
+			err:    status.Error(codes.ResourceExhausted, "backend overloaded"),
+			reason: endpointFailureReason("resource_exhausted"),
+			ok:     true,
+		},
+		{
 			name:   "grpc unavailable dns lookup",
 			err:    status.Error(codes.Unavailable, "transport: error while dialing: dial tcp: lookup backend.default.svc: no such host"),
 			reason: endpointFailureDNS,

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -869,6 +869,84 @@ func TestConsumeLogsReroutesEndpointLocalFailure(t *testing.T) {
 	}, metricdatatest.IgnoreTimestamp())
 }
 
+func TestConsumeLogsReroutesBackendResourceExhausted(t *testing.T) {
+	ts, tb, telemetry := getTelemetryAssetsWithReader(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+
+	calls := map[string]int{}
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(context.Context, plog.Logs) error {
+			calls[endpoint]++
+			if endpoint == "endpoint-1:4317" {
+				return status.Error(codes.ResourceExhausted, "backend overloaded")
+			}
+			return nil
+		}), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.endpointHealth.reconcile([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.ring = newHashRing([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1:4317", "endpoint-2:4317"})
+
+	p, err := newLogsExporter(ts, cfg)
+	require.NoError(t, err)
+	p.loadBalancer = lb
+	p.started.Store(true)
+
+	traceIDForEndpoint1 := findTraceIDForEndpoint(t, lb.ring, "endpoint-1:4317")
+	err = p.ConsumeLogs(t.Context(), simpleLogWithID(traceIDForEndpoint1))
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls["endpoint-1:4317"])
+	assert.Equal(t, 1, calls["endpoint-2:4317"])
+	assert.NotContains(t, lb.exporters, "endpoint-1:4317")
+	metadatatest.AssertEqualLoadbalancerBackendRerouteTotal(t, telemetry, []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(attribute.String("signal", "logs"), attribute.String("result", "success"), attribute.String("reason", "resource_exhausted")),
+			Value:      1,
+		},
+	}, metricdatatest.IgnoreTimestamp())
+}
+
+func TestConsumeLogsDoesNotReroutePermanentFailure(t *testing.T) {
+	ts, tb, telemetry := getTelemetryAssetsWithReader(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+
+	calls := map[string]int{}
+	componentFactory := func(_ context.Context, endpoint string) (component.Component, error) {
+		return newMockLogsExporter(func(context.Context, plog.Logs) error {
+			calls[endpoint]++
+			if endpoint == "endpoint-1:4317" {
+				return consumererror.NewPermanent(errors.New("bad data"))
+			}
+			return nil
+		}), nil
+	}
+	lb, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	lb.endpointHealth.reconcile([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.ring = newHashRing([]string{"endpoint-1:4317", "endpoint-2:4317"})
+	lb.addMissingExporters(t.Context(), []string{"endpoint-1:4317", "endpoint-2:4317"})
+
+	p, err := newLogsExporter(ts, cfg)
+	require.NoError(t, err)
+	p.loadBalancer = lb
+	p.started.Store(true)
+
+	traceIDForEndpoint1 := findTraceIDForEndpoint(t, lb.ring, "endpoint-1:4317")
+	err = p.ConsumeLogs(t.Context(), simpleLogWithID(traceIDForEndpoint1))
+	require.Error(t, err)
+
+	assert.Equal(t, 1, calls["endpoint-1:4317"])
+	assert.Zero(t, calls["endpoint-2:4317"])
+	assert.Contains(t, lb.exporters, "endpoint-1:4317")
+	_, metricErr := telemetry.GetMetric("otelcol_loadbalancer_backend_reroute_total")
+	require.Error(t, metricErr)
+}
+
 func TestConsumeLogsReroutePreservesPayloadAfterExporterMutation(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := simpleConfig()

--- a/exporter/loadbalancingexporter/payload_codec_benchmark_test.go
+++ b/exporter/loadbalancingexporter/payload_codec_benchmark_test.go
@@ -150,7 +150,6 @@ func newInitializedBenchmarkQueuePayloadCodec(
 	}
 	encodedBytes := len(encoded)
 	queuePayloadCodecBenchmarkSink = nil
-	encoded = nil
 
 	debug.FreeOSMemory()
 	var after runtime.MemStats


### PR DESCRIPTION
Sanitized Sawmills fork metadata.

Summary: treats backend ResourceExhausted responses as endpoint-local failures so endpoint health can reroute batches to another eligible backend.

Verification: covered by loadbalancing exporter regression tests and PR checks.