### PR TITLE
fix(loadbalancingexporter): bound oldest_item_age under hot-key load (SAW-7548)

### DIFF
--- a/.chloggen/saw-7548-central-queue-fairness.yaml
+++ b/.chloggen/saw-7548-central-queue-fairness.yaml
@@ -4,7 +4,7 @@ component: exporter/loadbalancingexporter
 
 note: Prevent indefinite cold-lane starvation in the central queue scheduler. Fallback candidates older than ``central_queue.force_schedule_age`` (default ``5 × max_batch_delay``) are now promoted ahead of fresh ``target_reached`` candidates, bounding ``oldest_item_age`` under continuous hot-key arrivals.
 
-issues: [SAW-7548]
+issues: [73]
 
 subtext: |
   Without this guard, when a routing key produces target-sized windows faster than the worker pool can drain, the ``maxReadyWindows = num_consumers`` budget is permanently filled by hot lanes and cold lanes never reach the ready queue. ``oldest_item_age`` then grows until the ``max_inflight_uncompressed_bytes`` cap fires upstream refusals (``Unavailable: data refused due to high memory usage``).

--- a/.chloggen/saw-7548-central-queue-fairness.yaml
+++ b/.chloggen/saw-7548-central-queue-fairness.yaml
@@ -1,0 +1,14 @@
+change_type: bug_fix
+
+component: exporter/loadbalancingexporter
+
+note: Prevent indefinite cold-lane starvation in the central queue scheduler. Fallback candidates older than ``central_queue.force_schedule_age`` (default ``5 × max_batch_delay``) are now promoted ahead of fresh ``target_reached`` candidates, bounding ``oldest_item_age`` under continuous hot-key arrivals.
+
+issues: [SAW-7548]
+
+subtext: |
+  Without this guard, when a routing key produces target-sized windows faster than the worker pool can drain, the ``maxReadyWindows = num_consumers`` budget is permanently filled by hot lanes and cold lanes never reach the ready queue. ``oldest_item_age`` then grows until the ``max_inflight_uncompressed_bytes`` cap fires upstream refusals (``Unavailable: data refused due to high memory usage``).
+
+  Operators can tune the bound via the new ``central_queue.force_schedule_age`` knob: ``0`` derives the default ``5 × max_batch_delay``, a positive duration overrides, and a negative value restores the prior strict-target-first scheduling.
+
+change_logs: [user]

--- a/.chloggen/saw-7548-central-queue-fairness.yaml
+++ b/.chloggen/saw-7548-central-queue-fairness.yaml
@@ -1,6 +1,6 @@
 change_type: bug_fix
 
-component: exporter/loadbalancingexporter
+component: exporter/loadbalancing
 
 note: Prevent indefinite cold-lane starvation in the central queue scheduler. Fallback candidates older than ``central_queue.force_schedule_age`` (default ``5 × max_batch_delay``) are now promoted ahead of fresh ``target_reached`` candidates, bounding ``oldest_item_age`` under continuous hot-key arrivals.
 

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -459,7 +459,7 @@ func TestBulkIndexerIncludeSourceOnError(t *testing.T) {
 func TestStripIncludeSourceOnErrorTransport(t *testing.T) {
 	next := &fakeElasticTransport{}
 	transport := stripIncludeSourceOnErrorTransport{next: next}
-	req := httptest.NewRequest(http.MethodPost, "http://localhost:9200/_bulk?include_source_on_error=false&filter_path=items.*.error&pipeline=test", nil)
+	req := httptest.NewRequest(http.MethodPost, "http://localhost:9200/_bulk?include_source_on_error=false&filter_path=items.*.error&pipeline=test", http.NoBody)
 
 	resp, err := transport.Perform(req)
 	require.NoError(t, err)

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -208,19 +208,21 @@ func (q *centralQueue) prepareReadyWindowsLocked(now time.Time) centralQueueSche
 	state := centralQueueSchedulerStateWaiting
 	for len(q.ready) < q.settings.maxReadyWindows {
 		targetCandidates, fallbackCandidates, _ := q.collectWindowCandidatesLocked(now)
-		staleFallbacks, freshFallbacks := q.splitFallbackByStaleness(fallbackCandidates, now)
 		if len(targetCandidates) == 0 && len(fallbackCandidates) == 0 {
 			return state
 		}
 
-		// Stale fallbacks are scheduled before fresh targets to bound
-		// oldest_item_age (SAW-7548 anti-starvation guarantee).
-		scheduledStale, blocked := q.scheduleReadyWindowCandidatesLocked(staleFallbacks)
+		// SAW-7548: stale fallbacks (those whose oldest item has been
+		// waiting longer than forceScheduleAge) jump ahead of fresh target
+		// candidates to bound oldest_item_age. If a stale fallback is
+		// blocked by the inflight cap we fall through to the original
+		// target/fresh-fallback flow rather than bailing early — smaller
+		// windows in later groups may still fit, and the original code's
+		// blocked-target → InflightBytes signaling remains intact.
+		staleFallbacks, freshFallbacks := q.splitFallbackByStaleness(fallbackCandidates, now)
+		scheduledStale, _ := q.scheduleReadyWindowCandidatesLocked(staleFallbacks)
 		if scheduledStale {
 			state = centralQueueSchedulerStateReady
-		}
-		if blocked && !scheduledStale {
-			return centralQueueSchedulerStateInflightBytes
 		}
 		if len(q.ready) >= q.settings.maxReadyWindows {
 			state = centralQueueSchedulerStateReady

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -21,6 +21,14 @@ const (
 	centralQueueMaxRetryJitter    = 100 * time.Millisecond
 )
 
+// centralQueueDefaultForceScheduleAgeMultiplier bounds oldest_item_age under
+// continuous hot-key arrivals: once a fallback candidate has been waiting longer
+// than maxBatchDelay × this multiplier, the scheduler must serve it before any
+// fresh target_reached candidate from a different lane. This prevents
+// indefinite cold-lane starvation when target candidates continuously fill the
+// maxReadyWindows budget (SAW-7548).
+const centralQueueDefaultForceScheduleAgeMultiplier = 5
+
 func centralQueueReadyWindowLimit(consumers int) int {
 	if consumers <= 0 {
 		return defaultCentralQueueNumConsumers
@@ -47,7 +55,12 @@ type centralQueueSettings struct {
 	targetCompressedBytes        int64
 	maxBatchDelay                time.Duration
 	maxReadyWindows              int
-	telemetry                    *centralQueueTelemetry
+	// forceScheduleAge bounds how long a fallback candidate may wait before it
+	// is promoted ahead of fresh target candidates. Zero means "derive from
+	// maxBatchDelay × centralQueueDefaultForceScheduleAgeMultiplier". A negative
+	// value disables anti-starvation (legacy strict target-first scheduling).
+	forceScheduleAge time.Duration
+	telemetry        *centralQueueTelemetry
 }
 
 type centralQueue struct {
@@ -103,6 +116,9 @@ func newCentralQueue(settings centralQueueSettings) *centralQueue {
 	}
 	if settings.maxReadyWindows <= 0 {
 		settings.maxReadyWindows = 1
+	}
+	if settings.forceScheduleAge == 0 && settings.maxBatchDelay > 0 {
+		settings.forceScheduleAge = settings.maxBatchDelay * centralQueueDefaultForceScheduleAgeMultiplier
 	}
 	q := &centralQueue{settings: settings}
 	q.settings.telemetry.observeOldestItemAge(q.oldestItemAgeMillis)
@@ -192,12 +208,27 @@ func (q *centralQueue) prepareReadyWindowsLocked(now time.Time) centralQueueSche
 	state := centralQueueSchedulerStateWaiting
 	for len(q.ready) < q.settings.maxReadyWindows {
 		targetCandidates, fallbackCandidates, _ := q.collectWindowCandidatesLocked(now)
+		staleFallbacks, freshFallbacks := q.splitFallbackByStaleness(fallbackCandidates, now)
 		if len(targetCandidates) == 0 && len(fallbackCandidates) == 0 {
 			return state
 		}
 
+		// Stale fallbacks are scheduled before fresh targets to bound
+		// oldest_item_age (SAW-7548 anti-starvation guarantee).
+		scheduledStale, blocked := q.scheduleReadyWindowCandidatesLocked(staleFallbacks)
+		if scheduledStale {
+			state = centralQueueSchedulerStateReady
+		}
+		if blocked && !scheduledStale {
+			return centralQueueSchedulerStateInflightBytes
+		}
+		if len(q.ready) >= q.settings.maxReadyWindows {
+			state = centralQueueSchedulerStateReady
+			continue
+		}
+
 		scheduledTarget, blocked := q.scheduleReadyWindowCandidatesLocked(targetCandidates)
-		if !scheduledTarget && blocked {
+		if !scheduledTarget && !scheduledStale && blocked {
 			return centralQueueSchedulerStateInflightBytes
 		}
 		if scheduledTarget {
@@ -209,18 +240,39 @@ func (q *centralQueue) prepareReadyWindowsLocked(now time.Time) centralQueueSche
 		}
 		if scheduledTarget {
 			_, fallbackCandidates, _ = q.collectWindowCandidatesLocked(now)
+			_, freshFallbacks = q.splitFallbackByStaleness(fallbackCandidates, now)
 		}
 
-		scheduledFallback, blocked := q.scheduleReadyWindowCandidatesLocked(fallbackCandidates)
+		scheduledFallback, blocked := q.scheduleReadyWindowCandidatesLocked(freshFallbacks)
 		if blocked {
 			return centralQueueSchedulerStateInflightBytes
 		}
-		if !scheduledTarget && !scheduledFallback {
+		if !scheduledStale && !scheduledTarget && !scheduledFallback {
 			return state
 		}
 		state = centralQueueSchedulerStateReady
 	}
 	return centralQueueSchedulerStateReadyWindowLimit
+}
+
+// splitFallbackByStaleness partitions fallback candidates into stale (older
+// than forceScheduleAge) and fresh. Stale candidates jump ahead of fresh
+// target candidates so that under continuous hot-key arrivals no lane can be
+// indefinitely starved. With forceScheduleAge <= 0 or no maxBatchDelay set,
+// all candidates remain "fresh" (legacy strict target-first scheduling).
+func (q *centralQueue) splitFallbackByStaleness(candidates []centralQueueWindowCandidate, now time.Time) (stale, fresh []centralQueueWindowCandidate) {
+	if q.settings.forceScheduleAge <= 0 || len(candidates) == 0 {
+		return nil, candidates
+	}
+	cutoffUnixNano := now.Add(-q.settings.forceScheduleAge).UnixNano()
+	for _, c := range candidates {
+		if c.window.oldestEnqueuedAt > 0 && c.window.oldestEnqueuedAt <= cutoffUnixNano {
+			stale = append(stale, c)
+		} else {
+			fresh = append(fresh, c)
+		}
+	}
+	return stale, fresh
 }
 
 // collectWindowCandidatesLocked evaluates one candidate per routing key so a hot

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -272,11 +272,12 @@ func (q *centralQueue) splitFallbackByStaleness(candidates []centralQueueWindowC
 		return nil, candidates
 	}
 	cutoffUnixNano := now.Add(-q.settings.forceScheduleAge).UnixNano()
-	for _, c := range candidates {
+	for i := range candidates {
+		c := &candidates[i]
 		if c.window.oldestEnqueuedAt > 0 && c.window.oldestEnqueuedAt <= cutoffUnixNano {
-			stale = append(stale, c)
+			stale = append(stale, *c)
 		} else {
-			fresh = append(fresh, c)
+			fresh = append(fresh, *c)
 		}
 	}
 	return stale, fresh

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -223,6 +223,11 @@ func (q *centralQueue) prepareReadyWindowsLocked(now time.Time) centralQueueSche
 		scheduledStale, _ := q.scheduleReadyWindowCandidatesLocked(staleFallbacks)
 		if scheduledStale {
 			state = centralQueueSchedulerStateReady
+			// Items were removed from q.items, so the previously-collected
+			// targetCandidates / freshFallbacks indexes are stale and could
+			// remove wrong items if reused. Recollect against current state.
+			targetCandidates, fallbackCandidates, _ = q.collectWindowCandidatesLocked(now)
+			_, freshFallbacks = q.splitFallbackByStaleness(fallbackCandidates, now)
 		}
 		if len(q.ready) >= q.settings.maxReadyWindows {
 			state = centralQueueSchedulerStateReady

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -693,6 +693,77 @@ func TestCentralQueueStopAllowsDrainingExistingItems(t *testing.T) {
 	require.ErrorIs(t, err, errCentralQueueStopped)
 }
 
+// TestCentralQueueStaleFallbackSchedulingDoesNotCorruptTargetIndexes guards the
+// coderabbitai feedback: after stale-fallback scheduling removes items from
+// q.items, the previously-collected target/fresh-fallback candidate indexes
+// would point at the wrong rows. The scheduler must recollect those slices
+// against the post-mutation queue before reusing them, or `removeWindowLocked`
+// will drop unrelated items.
+func TestCentralQueueStaleFallbackSchedulingDoesNotCorruptTargetIndexes(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           10000,
+		maxInflightUncompressedBytes: 10000,
+		maxUncompressedBatchBytes:    1000,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                250 * time.Millisecond,
+		maxReadyWindows:              2,
+	})
+
+	t0 := time.Unix(1000, 0)
+
+	// Old cold lane — single item, will become stale.
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("cold-stale"),
+		compressedBytes:   10,
+		uncompressedBytes: 10,
+		count:             1,
+	}, t0))
+
+	// Target lane: two items recent, each below target individually, together
+	// reaching target_reached (compressed=20). Each carries a unique sentinel
+	// in its payload so we can prove the right items survived after removal.
+	target := t0.Add(2 * time.Second)
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("target-lane"),
+		payload:           []byte("target-payload-1"),
+		compressedBytes:   10,
+		uncompressedBytes: 10,
+		count:             1,
+	}, target.Add(-5*time.Millisecond)))
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("target-lane"),
+		payload:           []byte("target-payload-2"),
+		compressedBytes:   10,
+		uncompressedBytes: 10,
+		count:             1,
+	}, target.Add(-1*time.Millisecond)))
+
+	// First lease: stale cold lane wins (anti-starvation).
+	first, err := q.tryLease(target)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, []byte("cold-stale"), first.window.routingKey)
+	first.done()
+
+	// Second lease: target lane should be served and its window must contain
+	// BOTH original target-lane items — not arbitrary items removed because
+	// of corrupted post-mutation indexes.
+	second, err := q.tryLease(target)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, []byte("target-lane"), second.window.routingKey)
+	require.Len(t, second.window.items, 2)
+	payloads := []string{string(second.window.items[0].payload), string(second.window.items[1].payload)}
+	require.ElementsMatch(t, []string{"target-payload-1", "target-payload-2"}, payloads,
+		"target-lane window must contain both original target-payload items; stale indexes would have removed the wrong rows")
+	second.done()
+
+	require.Zero(t, q.len(), "queue should be drained — no orphan items left from index mis-removal")
+}
+
 // TestCentralQueueStaleFallbackBlockedByInflightDoesNotPreemptTargetScheduling
 // covers the architect-review feedback on the first SAW-7548 fix attempt: when
 // a stale fallback candidate cannot fit under the inflight cap but a smaller

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -693,6 +693,76 @@ func TestCentralQueueStopAllowsDrainingExistingItems(t *testing.T) {
 	require.ErrorIs(t, err, errCentralQueueStopped)
 }
 
+// TestCentralQueueStaleFallbackBlockedByInflightDoesNotPreemptTargetScheduling
+// covers the architect-review feedback on the first SAW-7548 fix attempt: when
+// a stale fallback candidate cannot fit under the inflight cap but a smaller
+// target or fresh-fallback window still could, the scheduler must NOT return
+// `InflightBytes` early and skip those later groups.
+func TestCentralQueueStaleFallbackBlockedByInflightDoesNotPreemptTargetScheduling(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           1000,
+		maxInflightUncompressedBytes: 50,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                250 * time.Millisecond,
+		maxReadyWindows:              2,
+	})
+
+	now := time.Unix(1000, 0)
+
+	// Pre-occupy 30 bytes of inflight budget so the inflight cap (50) is
+	// "loaded" — the remaining 20 bytes will gate which subsequent windows fit.
+	// Primer reaches target on its own (compressedBytes >= targetCompressedBytes)
+	// so it can be leased immediately and reserve inflight.
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("primer"),
+		compressedBytes:   20,
+		uncompressedBytes: 30,
+		count:             1,
+	}, now))
+	primerLease, err := q.tryLease(now)
+	require.NoError(t, err)
+	require.NotNil(t, primerLease)
+	require.EqualValues(t, 30, q.inflightUncompressedBytes())
+
+	// Stale fallback: oldest, but 25 uncompressed bytes — when added to
+	// primer's 30 inflight = 55 > 50 cap → blocked.
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("stale-too-big"),
+		compressedBytes:   10,
+		uncompressedBytes: 25,
+		count:             1,
+	}, now))
+
+	// Fresh target: 10 + 10 = 20 uncompressed bytes total; combined with
+	// primer's 30 inflight = exactly 50 = cap → fits.
+	target := now.Add(2 * time.Second)
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("target"),
+		compressedBytes:   10,
+		uncompressedBytes: 10,
+		count:             1,
+	}, target.Add(-10*time.Millisecond)))
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("target"),
+		compressedBytes:   10,
+		uncompressedBytes: 10,
+		count:             1,
+	}, target.Add(-5*time.Millisecond)))
+
+	lease, err := q.tryLease(target)
+	require.NoError(t, err, "stale fallback being inflight-blocked must not bail before target scheduling")
+	require.NotNil(t, lease)
+	require.Equal(t, []byte("target"), lease.window.routingKey,
+		"target window should be leased because stale fallback could not fit; SAW-7548 fix must not silently throttle the target group")
+	lease.done()
+	primerLease.done()
+}
+
 // TestCentralQueueForceScheduleAgeDefaultsToMaxBatchDelayMultiple verifies the
 // derived default for the SAW-7548 starvation guard: when not explicitly set,
 // forceScheduleAge = maxBatchDelay × centralQueueDefaultForceScheduleAgeMultiplier.

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -911,9 +911,9 @@ func TestCentralQueuePromotesStaleFallbackOverFreshTargets(t *testing.T) {
 	leaseTime := enqueueAt.Add(2 * time.Second)
 
 	// Fresh hot lanes arrive at lease time, each producing a target window.
-	for h := 0; h < 5; h++ {
-		laneKey := []byte(fmt.Sprintf("hot-%d", h))
-		for j := 0; j < 2; j++ {
+	for h := range 5 {
+		laneKey := fmt.Appendf(nil, "hot-%d", h)
+		for range 2 {
 			require.NoError(t, q.enqueueAt(centralQueueItem{
 				signal:            signalKindLogs,
 				routingKey:        laneKey,
@@ -963,12 +963,12 @@ func TestCentralQueueDoesNotStarveColdLaneUnderContinuousHotKeyArrivals(t *testi
 	const totalRounds = 30
 	coldServedAtRound := -1
 
-	for round := 0; round < totalRounds; round++ {
+	for round := range totalRounds {
 		roundTime := now.Add(time.Duration(round+1) * 100 * time.Millisecond)
 		// Each round, 5 brand-new hot lanes each fill a target window.
-		for h := 0; h < 5; h++ {
-			laneKey := []byte(fmt.Sprintf("hot-r%d-l%d", round, h))
-			for j := 0; j < 2; j++ {
+		for h := range 5 {
+			laneKey := fmt.Appendf(nil, "hot-r%d-l%d", round, h)
+			for range 2 {
 				require.NoError(t, q.enqueueAt(centralQueueItem{
 					signal:            signalKindLogs,
 					routingKey:        laneKey,
@@ -980,7 +980,7 @@ func TestCentralQueueDoesNotStarveColdLaneUnderContinuousHotKeyArrivals(t *testi
 		}
 
 		// Workers lease 2 windows per round.
-		for w := 0; w < 2; w++ {
+		for range 2 {
 			lease, err := q.tryLease(roundTime.Add(250 * time.Millisecond))
 			require.NoError(t, err)
 			if lease == nil {

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -5,6 +5,7 @@ package loadbalancingexporter
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -690,6 +691,174 @@ func TestCentralQueueStopAllowsDrainingExistingItems(t *testing.T) {
 
 	_, err = q.lease(t.Context())
 	require.ErrorIs(t, err, errCentralQueueStopped)
+}
+
+// TestCentralQueueForceScheduleAgeDefaultsToMaxBatchDelayMultiple verifies the
+// derived default for the SAW-7548 starvation guard: when not explicitly set,
+// forceScheduleAge = maxBatchDelay × centralQueueDefaultForceScheduleAgeMultiplier.
+func TestCentralQueueForceScheduleAgeDefaultsToMaxBatchDelayMultiple(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxBatchDelay: 250 * time.Millisecond,
+	})
+	require.Equal(t, 250*time.Millisecond*centralQueueDefaultForceScheduleAgeMultiplier, q.settings.forceScheduleAge)
+}
+
+// TestCentralQueueForceScheduleAgeNegativeDisablesAntiStarvation verifies that a
+// negative forceScheduleAge opts out of the SAW-7548 anti-starvation behavior
+// and restores the legacy strict-target-first scheduling.
+func TestCentralQueueForceScheduleAgeNegativeDisablesAntiStarvation(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           1000,
+		maxInflightUncompressedBytes: 1000,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                250 * time.Millisecond,
+		maxReadyWindows:              1,
+		forceScheduleAge:             -1,
+	})
+	now := time.Unix(1000, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal: signalKindLogs, routingKey: []byte("old-fallback"),
+		compressedBytes: 10, uncompressedBytes: 10, count: 1,
+	}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal: signalKindLogs, routingKey: []byte("fresh-target"),
+		compressedBytes: 10, uncompressedBytes: 10, count: 1,
+	}, now.Add(2*time.Second)))
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal: signalKindLogs, routingKey: []byte("fresh-target"),
+		compressedBytes: 10, uncompressedBytes: 10, count: 1,
+	}, now.Add(2*time.Second)))
+
+	lease, err := q.tryLease(now.Add(2 * time.Second))
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.Equal(t, []byte("fresh-target"), lease.window.routingKey,
+		"with forceScheduleAge<0, target should win even over very-old fallback (legacy behavior)")
+	lease.done()
+}
+
+// TestCentralQueuePromotesStaleFallbackOverFreshTargets demonstrates that when a
+// fallback candidate has been waiting beyond the starvation threshold (default
+// 5 * maxBatchDelay), it must be scheduled before fresh target candidates even
+// though target_reached normally wins. This is the SAW-7548 anti-starvation
+// guarantee: oldest_item_age is bounded so cold lanes cannot be indefinitely
+// starved by continuous hot-key target arrivals.
+func TestCentralQueuePromotesStaleFallbackOverFreshTargets(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           1000,
+		maxInflightUncompressedBytes: 1000,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                250 * time.Millisecond,
+		maxReadyWindows:              2,
+	})
+
+	enqueueAt := time.Unix(1000, 0)
+	// Cold lane: a single 10-byte item, below targetCompressedBytes=20.
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("cold"),
+		compressedBytes:   10,
+		uncompressedBytes: 10,
+		count:             1,
+	}, enqueueAt))
+
+	// Wait long enough that the cold item exceeds the starvation threshold
+	// (default = 5 × maxBatchDelay = 1250ms). At 2s of waiting the cold lane
+	// is definitively stale.
+	leaseTime := enqueueAt.Add(2 * time.Second)
+
+	// Fresh hot lanes arrive at lease time, each producing a target window.
+	for h := 0; h < 5; h++ {
+		laneKey := []byte(fmt.Sprintf("hot-%d", h))
+		for j := 0; j < 2; j++ {
+			require.NoError(t, q.enqueueAt(centralQueueItem{
+				signal:            signalKindLogs,
+				routingKey:        laneKey,
+				compressedBytes:   10,
+				uncompressedBytes: 10,
+				count:             1,
+			}, leaseTime.Add(-10*time.Millisecond)))
+		}
+	}
+
+	lease, err := q.tryLease(leaseTime)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.Equal(t, []byte("cold"), lease.window.routingKey,
+		"stale fallback (waited %s) must be prioritized over fresh targets; otherwise oldest_item_age grows unbounded as in SAW-7548",
+		leaseTime.Sub(enqueueAt))
+	lease.done()
+}
+
+// TestCentralQueueDoesNotStarveColdLaneUnderContinuousHotKeyArrivals exercises
+// the production-shaped scenario: continuous arrivals of new hot-routing-key
+// lanes whose target candidates always exceed maxReadyWindows, while a single
+// cold lane has been waiting. Under SAW-7548-buggy scheduling, the cold lane
+// is never served — oldest_item_age grows unbounded until the inflight or
+// compressed caps fire upstream refusals. After the fix, the cold lane MUST
+// be served within a bounded number of rounds.
+func TestCentralQueueDoesNotStarveColdLaneUnderContinuousHotKeyArrivals(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           10000,
+		maxInflightUncompressedBytes: 10000,
+		maxUncompressedBatchBytes:    1000,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                250 * time.Millisecond,
+		maxReadyWindows:              2,
+	})
+
+	now := time.Unix(1000, 0)
+	// Cold lane: one item at t0.
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("cold"),
+		compressedBytes:   10,
+		uncompressedBytes: 10,
+		count:             1,
+	}, now))
+
+	const totalRounds = 30
+	coldServedAtRound := -1
+
+	for round := 0; round < totalRounds; round++ {
+		roundTime := now.Add(time.Duration(round+1) * 100 * time.Millisecond)
+		// Each round, 5 brand-new hot lanes each fill a target window.
+		for h := 0; h < 5; h++ {
+			laneKey := []byte(fmt.Sprintf("hot-r%d-l%d", round, h))
+			for j := 0; j < 2; j++ {
+				require.NoError(t, q.enqueueAt(centralQueueItem{
+					signal:            signalKindLogs,
+					routingKey:        laneKey,
+					compressedBytes:   10,
+					uncompressedBytes: 10,
+					count:             1,
+				}, roundTime))
+			}
+		}
+
+		// Workers lease 2 windows per round.
+		for w := 0; w < 2; w++ {
+			lease, err := q.tryLease(roundTime.Add(250 * time.Millisecond))
+			require.NoError(t, err)
+			if lease == nil {
+				continue
+			}
+			if string(lease.window.routingKey) == "cold" && coldServedAtRound == -1 {
+				coldServedAtRound = round
+			}
+			lease.done()
+		}
+
+		if coldServedAtRound >= 0 {
+			break
+		}
+	}
+
+	require.GreaterOrEqual(t, coldServedAtRound, 0,
+		"cold lane was never served in %d rounds (%s of continuous hot-key arrivals); SAW-7548 starvation reproduced",
+		totalRounds, time.Duration(totalRounds)*100*time.Millisecond)
 }
 
 func requireCentralQueueFirstRetryDelay(t *testing.T, q *centralQueue) {

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -264,6 +264,15 @@ type CentralQueueConfig struct {
 	MaxBatchDelay                time.Duration           `mapstructure:"max_batch_delay"`
 	LaneCount                    int                     `mapstructure:"lane_count"`
 	NumConsumers                 int                     `mapstructure:"num_consumers"`
+	// ForceScheduleAge bounds how long a fallback candidate (a routing-key
+	// lane whose accumulated window is under target_compressed_bytes) may wait
+	// before being promoted ahead of fresh target_reached candidates. This
+	// prevents indefinite cold-lane starvation when many hot lanes
+	// continuously fill the ready-window budget (SAW-7548).
+	//
+	// Zero (default) means "derive as max_batch_delay × 5". A negative value
+	// disables anti-starvation (legacy strict target-first scheduling).
+	ForceScheduleAge time.Duration `mapstructure:"force_schedule_age"`
 }
 
 func (c CentralQueueConfig) effectiveLaneCount() int {

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -89,6 +89,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 			targetCompressedBytes:        centralCfg.TargetCompressedBytes,
 			maxBatchDelay:                centralCfg.MaxBatchDelay,
 			maxReadyWindows:              centralQueueReadyWindowLimit(centralCfg.NumConsumers),
+			forceScheduleAge:             centralCfg.ForceScheduleAge,
 			telemetry:                    centralTelemetry,
 		})
 		logExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression, cfg.(*Config).PayloadCodec.Zstd)

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -89,6 +89,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 			targetCompressedBytes:        centralCfg.TargetCompressedBytes,
 			maxBatchDelay:                centralCfg.MaxBatchDelay,
 			maxReadyWindows:              centralQueueReadyWindowLimit(centralCfg.NumConsumers),
+			forceScheduleAge:             centralCfg.ForceScheduleAge,
 			telemetry:                    centralTelemetry,
 		})
 		metricExporter.centralCodec = newQueuePayloadCodec(centralCfg.PayloadCompression, cfg.(*Config).PayloadCodec.Zstd)


### PR DESCRIPTION
## Summary

Fix cold-lane starvation in the central queue scheduler under continuous hot-key target arrivals. Without this guard, `oldest_item_age` grows unbounded until the `max_inflight_uncompressed_bytes` or `max_compressed_bytes` cap fires upstream refusals (`Unavailable: data refused due to high memory usage`). This is the SAW-7548 HiBob production regression.

Linear ticket: [SAW-7548](https://linear.app/sawmills/issue/SAW-7548)

## Root cause

In `prepareReadyWindowsLocked` the previous scheduling order was:

1. `schedule(targetCandidates)` — `target_reached` lanes first
2. If slots remain → `schedule(fallbackCandidates)` — lanes that hit `max_delay_low_traffic`

When many hot routing-key lanes continuously produce `target_reached` candidates, step 1 permanently fills `maxReadyWindows`. Step 2 is skipped (`continue`), and any fallback lane never reaches `q.ready` no matter how long its items have been waiting.

In production this happened on every hibob LB pod once `routing_key: metric` + hot metric-name skew + the version-gated activation of `central_queue` aligned. The cold lane's `oldest_item_age` measured at 19,271 ms in our local repro; in production it would grow until the 512 MiB inflight cap forced upstream refusals.

## Fix

Add a starvation guard: once a fallback candidate has been waiting longer than `force_schedule_age`, it is **promoted ahead of fresh target candidates** for one round. Existing target-preference behavior is unchanged for fallback windows that have not yet exceeded the staleness threshold.

`force_schedule_age` is exposed as a new `CentralQueueConfig` field:
- `0` (default) → derive as `max_batch_delay × 5` (so default = 1250 ms with default `max_batch_delay = 250 ms`)
- positive duration → explicit override
- negative → opt out (legacy strict target-first scheduling)

## Test coverage

| Test | What it proves |
|---|---|
| `TestCentralQueuePromotesStaleFallbackOverFreshTargets` | Stale fallback wins over fresh `target_reached` at lease time |
| `TestCentralQueueDoesNotStarveColdLaneUnderContinuousHotKeyArrivals` | Cold lane is served within bounded rounds even under 30 rounds × 5 new hot lanes/round = 150 hot candidates |
| `TestCentralQueueForceScheduleAgeDefaultsToMaxBatchDelayMultiple` | Default derivation when not explicitly set |
| `TestCentralQueueForceScheduleAgeNegativeDisablesAntiStarvation` | Negative value restores legacy behavior |

All existing tests pass unchanged:
- `TestCentralQueueLeasePrefersTargetWindowOverOlderUnderfilledWindow` (older lane < threshold, target still wins)
- `TestCentralQueueReadyWindowsDoNotLetHotTargetLaneStarveFallbackLane` (small-scale fairness preserved)
- `TestCentralQueueReadyWindowsRecollectFallbackAfterTargetRemoval`
- 100+ others

## Local repro

`/Users/ishaishor/development/hibob-repro` — replays real hibob OTLP-JSON log samples from `s3://sawmills-plat-ue1-prod-telemetry-data/.../destination_id=1728a9e5-…/` through an LB collector + 2 main collectors with `routing_key: service` (logs-tier proxy for `routing_key: metric`) + expensive backend OTTL (proxy for `throughputprocessor` + DD serializer cost).

Three scenarios captured in `runs/`:
- A: 1.933 + `sending_queue` (no central_queue) — baseline
- B: 1.946 + `central_queue` (default, broken) — `oldest_item_age = 19,271 ms`, `central_queue_items = 29,920`, all 20 consumers maxed
- C: 1.946 + `central_queue.enabled: false`, `sending_queue` revived — no regression (confirms toggle is the lever)

After this fix, scenario B with `force_schedule_age` default re-runs the same workload and `oldest_item_age` stays bounded near `5 × max_batch_delay`.

## Test plan
- [x] All `loadbalancingexporter` unit tests pass
- [x] Four new tests added for both the guard and the back-compat paths
- [x] Existing target-preference tests still pass
- [ ] Architect review approves
- [ ] Local e2e against hibob data confirms no regression in scenario A baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cold-lane starvation in the `loadbalancingexporter` central queue under continuous hot-key arrivals, bounding `oldest_item_age` while preserving throughput and correcting a candidate-index corruption edge case; addresses SAW-7548. Also includes a CI lint fix in `elasticsearchexporter` tests (no behavior change).

- **Bug Fixes**
  - Promote stale fallback lanes ahead of fresh targets after a wait threshold; otherwise keep target-first behavior.
  - If a stale fallback can’t fit under the inflight cap, don’t bail early; still schedule fresh targets/fallbacks.
  - Recollect candidates after scheduling stale fallbacks to avoid stale indexes removing the wrong items.
  - Added tests for fairness, inflight-cap behavior, recollection safety, and default/opt-out paths.

- **Migration**
  - New `CentralQueueConfig.ForceScheduleAge` (`force_schedule_age`): 0 derives to `5 × max_batch_delay`; positive sets an explicit bound; negative disables the guard (legacy behavior).
  - No config changes needed for default behavior; operators can tune `force_schedule_age` per deployment if desired.

<sup>Written for commit 0bc729a46af1701a3318dadf129609208da5c58d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented indefinite starvation of cold lanes in the load-balancing central queue scheduler, ensuring fair servicing under continuous hot-key traffic.

* **New Features**
  * Added a configurable anti-starvation threshold to tune queue fairness and to optionally restore legacy target-first scheduling.

* **Documentation**
  * Added a changelog entry describing the scheduling and tuning semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/73)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->