### PR TITLE
fix(awss3exporter): honor s3_prefix in legacy template mode (SAW-7554)

### DIFF
--- a/.chloggen/saw-7554-awss3-prefix-invariant.yaml
+++ b/.chloggen/saw-7554-awss3-prefix-invariant.yaml
@@ -7,12 +7,13 @@ note: honor s3_prefix as an invariant in legacy template mode
 issues: [74]
 
 subtext: |
-  The legacy-template key builder previously treated `s3_prefix` as advisory:
-  it was only honored if the template referenced `{{.Prefix}}`. Default mode
-  (no template) already honored it unconditionally via `bucketKeyPrefix`. That
-  asymmetry let any hardcoded template silently drop the configured prefix
-  and write to bucket root. The exporter now auto-prepends the prefix when
-  the parsed template does not reference `.Prefix`; templates that already
-  reference `.Prefix` render exactly as before (no double-prepend).
+  Tracks SAW-7554. The legacy-template key builder previously treated
+  `s3_prefix` as advisory: it was only honored if the template referenced
+  `{{.Prefix}}`. Default mode (no template) already honored it
+  unconditionally via `bucketKeyPrefix`. That asymmetry let any hardcoded
+  template silently drop the configured prefix and write to bucket root.
+  The exporter now auto-prepends the prefix when the parsed template does
+  not reference `.Prefix`; templates that already reference `.Prefix`
+  render exactly as before (no double-prepend).
 
 change_logs: [user]

--- a/.chloggen/saw-7554-awss3-prefix-invariant.yaml
+++ b/.chloggen/saw-7554-awss3-prefix-invariant.yaml
@@ -1,0 +1,18 @@
+change_type: bug_fix
+
+component: exporter/awss3exporter
+
+note: honor s3_prefix as an invariant in legacy template mode
+
+issues: [SAW-7554]
+
+subtext: |
+  The legacy-template key builder previously treated `s3_prefix` as advisory:
+  it was only honored if the template referenced `{{.Prefix}}`. Default mode
+  (no template) already honored it unconditionally via `bucketKeyPrefix`. That
+  asymmetry let any hardcoded template silently drop the configured prefix
+  and write to bucket root. The exporter now auto-prepends the prefix when
+  the parsed template does not reference `.Prefix`; templates that already
+  reference `.Prefix` render exactly as before (no double-prepend).
+
+change_logs: [user]

--- a/.chloggen/saw-7554-awss3-prefix-invariant.yaml
+++ b/.chloggen/saw-7554-awss3-prefix-invariant.yaml
@@ -4,7 +4,7 @@ component: exporter/awss3exporter
 
 note: honor s3_prefix as an invariant in legacy template mode
 
-issues: [SAW-7554]
+issues: [74]
 
 subtext: |
   The legacy-template key builder previously treated `s3_prefix` as advisory:

--- a/.chloggen/saw-7554-awss3-prefix-invariant.yaml
+++ b/.chloggen/saw-7554-awss3-prefix-invariant.yaml
@@ -1,6 +1,6 @@
 change_type: bug_fix
 
-component: exporter/awss3exporter
+component: exporter/awss3
 
 note: honor s3_prefix as an invariant in legacy template mode
 

--- a/exporter/awss3exporter/internal/upload/partition.go
+++ b/exporter/awss3exporter/internal/upload/partition.go
@@ -149,11 +149,23 @@ func parseLegacyTemplate(templateText string) (*template.Template, error) {
 // templateReferencesPrefix reports whether tmpl reads the .Prefix field of
 // legacyTemplateData anywhere in its body. Used by buildLegacyTemplateKey
 // to decide whether to auto-prepend the configured prefix (SAW-7554).
+//
+// Walks every associated parse tree (`tmpl.Templates()`), not just the root,
+// so a reference defined in a `{{define}}/{{template}}` subtemplate still
+// counts.
 func templateReferencesPrefix(tmpl *template.Template) bool {
-	if tmpl == nil || tmpl.Tree == nil {
+	if tmpl == nil {
 		return false
 	}
-	return walkForPrefix(tmpl.Root)
+	for _, t := range tmpl.Templates() {
+		if t == nil || t.Tree == nil {
+			continue
+		}
+		if walkForPrefix(t.Root) {
+			return true
+		}
+	}
+	return false
 }
 
 func walkForPrefix(n parse.Node) bool {
@@ -164,11 +176,7 @@ func walkForPrefix(n parse.Node) bool {
 		if node == nil {
 			return false
 		}
-		for _, child := range node.Nodes {
-			if walkForPrefix(child) {
-				return true
-			}
-		}
+		return slices.ContainsFunc(node.Nodes, walkForPrefix)
 	case *parse.ActionNode:
 		return walkForPrefix(node.Pipe)
 	case *parse.IfNode:
@@ -187,16 +195,12 @@ func walkForPrefix(n parse.Node) bool {
 		if node == nil {
 			return false
 		}
-		for _, cmd := range node.Cmds {
+		return slices.ContainsFunc(node.Cmds, func(cmd *parse.CommandNode) bool {
 			if cmd == nil {
-				continue
+				return false
 			}
-			for _, arg := range cmd.Args {
-				if walkForPrefix(arg) {
-					return true
-				}
-			}
-		}
+			return slices.ContainsFunc(cmd.Args, walkForPrefix)
+		})
 	case *parse.FieldNode:
 		// `{{.Prefix}}` parses as FieldNode with Ident=["Prefix"].
 		return slices.Contains(node.Ident, "Prefix")

--- a/exporter/awss3exporter/internal/upload/partition.go
+++ b/exporter/awss3exporter/internal/upload/partition.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -152,7 +153,7 @@ func templateReferencesPrefix(tmpl *template.Template) bool {
 	if tmpl == nil || tmpl.Tree == nil {
 		return false
 	}
-	return walkForPrefix(tmpl.Tree.Root)
+	return walkForPrefix(tmpl.Root)
 }
 
 func walkForPrefix(n parse.Node) bool {
@@ -198,19 +199,11 @@ func walkForPrefix(n parse.Node) bool {
 		}
 	case *parse.FieldNode:
 		// `{{.Prefix}}` parses as FieldNode with Ident=["Prefix"].
-		for _, ident := range node.Ident {
-			if ident == "Prefix" {
-				return true
-			}
-		}
+		return slices.Contains(node.Ident, "Prefix")
 	case *parse.ChainNode:
 		// e.g. `{{$x.Prefix}}` would land here, though our schema doesn't
 		// use it. Cover defensively.
-		for _, ident := range node.Field {
-			if ident == "Prefix" {
-				return true
-			}
-		}
+		return slices.Contains(node.Field, "Prefix")
 	}
 	return false
 }

--- a/exporter/awss3exporter/internal/upload/partition.go
+++ b/exporter/awss3exporter/internal/upload/partition.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"text/template/parse"
 	"time"
 
 	"github.com/google/uuid"
@@ -125,11 +126,93 @@ func buildLegacyTemplateKey(prefix string, tmpl *template.Template, ts time.Time
 		return ""
 	}
 
-	return rendered.String()
+	key := rendered.String()
+
+	// SAW-7554: legacy-template mode must honor s3_prefix as an invariant,
+	// symmetric with default mode (which always joins the prefix via
+	// bucketKeyPrefix). When the template author forgot to reference
+	// {{.Prefix}}, the configured prefix would otherwise be silently
+	// dropped. Auto-prepend it; templates that already reference .Prefix
+	// stay unchanged (no double-prepend).
+	if prefix != "" && !templateReferencesPrefix(tmpl) {
+		return path.Join(prefix, key)
+	}
+
+	return key
 }
 
 func parseLegacyTemplate(templateText string) (*template.Template, error) {
 	return template.New("legacy-s3-key").Funcs(legacyTemplateFuncs).Option("missingkey=error").Parse(templateText)
+}
+
+// templateReferencesPrefix reports whether tmpl reads the .Prefix field of
+// legacyTemplateData anywhere in its body. Used by buildLegacyTemplateKey
+// to decide whether to auto-prepend the configured prefix (SAW-7554).
+func templateReferencesPrefix(tmpl *template.Template) bool {
+	if tmpl == nil || tmpl.Tree == nil {
+		return false
+	}
+	return walkForPrefix(tmpl.Tree.Root)
+}
+
+func walkForPrefix(n parse.Node) bool {
+	switch node := n.(type) {
+	case nil:
+		return false
+	case *parse.ListNode:
+		if node == nil {
+			return false
+		}
+		for _, child := range node.Nodes {
+			if walkForPrefix(child) {
+				return true
+			}
+		}
+	case *parse.ActionNode:
+		return walkForPrefix(node.Pipe)
+	case *parse.IfNode:
+		return walkForPrefix(node.Pipe) ||
+			walkForPrefix(node.List) ||
+			walkForPrefix(node.ElseList)
+	case *parse.RangeNode:
+		return walkForPrefix(node.Pipe) ||
+			walkForPrefix(node.List) ||
+			walkForPrefix(node.ElseList)
+	case *parse.WithNode:
+		return walkForPrefix(node.Pipe) ||
+			walkForPrefix(node.List) ||
+			walkForPrefix(node.ElseList)
+	case *parse.PipeNode:
+		if node == nil {
+			return false
+		}
+		for _, cmd := range node.Cmds {
+			if cmd == nil {
+				continue
+			}
+			for _, arg := range cmd.Args {
+				if walkForPrefix(arg) {
+					return true
+				}
+			}
+		}
+	case *parse.FieldNode:
+		// `{{.Prefix}}` parses as FieldNode with Ident=["Prefix"].
+		for _, ident := range node.Ident {
+			if ident == "Prefix" {
+				return true
+			}
+		}
+	case *parse.ChainNode:
+		// e.g. `{{$x.Prefix}}` would land here, though our schema doesn't
+		// use it. Cover defensively.
+		for _, ident := range node.Field {
+			if ident == "Prefix" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func ParseLegacyTemplateForValidation(templateText string) (*template.Template, error) {

--- a/exporter/awss3exporter/internal/upload/partition.go
+++ b/exporter/awss3exporter/internal/upload/partition.go
@@ -147,28 +147,23 @@ func parseLegacyTemplate(templateText string) (*template.Template, error) {
 }
 
 // templateReferencesPrefix reports whether tmpl reads the .Prefix field of
-// legacyTemplateData anywhere in its body. Used by buildLegacyTemplateKey
-// to decide whether to auto-prepend the configured prefix (SAW-7554).
+// legacyTemplateData anywhere in its REACHABLE parse trees. Used by
+// buildLegacyTemplateKey to decide whether to auto-prepend the configured
+// prefix (SAW-7554).
 //
-// Walks every associated parse tree (`tmpl.Templates()`), not just the root,
-// so a reference defined in a `{{define}}/{{template}}` subtemplate still
-// counts.
+// Walks from the root tree and follows {{template "name"}} call sites to
+// associated subtemplates. Unused {{define}} blocks (those with no
+// {{template}} call site reachable from root) are intentionally NOT scanned
+// — a reference that the rendered output never emits would otherwise
+// incorrectly suppress the auto-prepend.
 func templateReferencesPrefix(tmpl *template.Template) bool {
-	if tmpl == nil {
+	if tmpl == nil || tmpl.Tree == nil {
 		return false
 	}
-	for _, t := range tmpl.Templates() {
-		if t == nil || t.Tree == nil {
-			continue
-		}
-		if walkForPrefix(t.Root) {
-			return true
-		}
-	}
-	return false
+	return walkForPrefix(tmpl, tmpl.Root, map[string]struct{}{})
 }
 
-func walkForPrefix(n parse.Node) bool {
+func walkForPrefix(root *template.Template, n parse.Node, visited map[string]struct{}) bool {
 	switch node := n.(type) {
 	case nil:
 		return false
@@ -176,21 +171,23 @@ func walkForPrefix(n parse.Node) bool {
 		if node == nil {
 			return false
 		}
-		return slices.ContainsFunc(node.Nodes, walkForPrefix)
+		return slices.ContainsFunc(node.Nodes, func(c parse.Node) bool {
+			return walkForPrefix(root, c, visited)
+		})
 	case *parse.ActionNode:
-		return walkForPrefix(node.Pipe)
+		return walkForPrefix(root, node.Pipe, visited)
 	case *parse.IfNode:
-		return walkForPrefix(node.Pipe) ||
-			walkForPrefix(node.List) ||
-			walkForPrefix(node.ElseList)
+		return walkForPrefix(root, node.Pipe, visited) ||
+			walkForPrefix(root, node.List, visited) ||
+			walkForPrefix(root, node.ElseList, visited)
 	case *parse.RangeNode:
-		return walkForPrefix(node.Pipe) ||
-			walkForPrefix(node.List) ||
-			walkForPrefix(node.ElseList)
+		return walkForPrefix(root, node.Pipe, visited) ||
+			walkForPrefix(root, node.List, visited) ||
+			walkForPrefix(root, node.ElseList, visited)
 	case *parse.WithNode:
-		return walkForPrefix(node.Pipe) ||
-			walkForPrefix(node.List) ||
-			walkForPrefix(node.ElseList)
+		return walkForPrefix(root, node.Pipe, visited) ||
+			walkForPrefix(root, node.List, visited) ||
+			walkForPrefix(root, node.ElseList, visited)
 	case *parse.PipeNode:
 		if node == nil {
 			return false
@@ -199,8 +196,25 @@ func walkForPrefix(n parse.Node) bool {
 			if cmd == nil {
 				return false
 			}
-			return slices.ContainsFunc(cmd.Args, walkForPrefix)
+			return slices.ContainsFunc(cmd.Args, func(arg parse.Node) bool {
+				return walkForPrefix(root, arg, visited)
+			})
 		})
+	case *parse.TemplateNode:
+		// {{template "name" .pipe}}: the pipe argument may itself reference
+		// .Prefix; the named subtemplate is reachable iff actually invoked
+		// here, so descend (once per name to avoid mutual-recursion loops).
+		if walkForPrefix(root, node.Pipe, visited) {
+			return true
+		}
+		if _, seen := visited[node.Name]; seen {
+			return false
+		}
+		visited[node.Name] = struct{}{}
+		if sub := root.Lookup(node.Name); sub != nil && sub.Tree != nil {
+			return walkForPrefix(root, sub.Root, visited)
+		}
+		return false
 	case *parse.FieldNode:
 		// `{{.Prefix}}` parses as FieldNode with Ident=["Prefix"].
 		return slices.Contains(node.Ident, "Prefix")

--- a/exporter/awss3exporter/internal/upload/partition_test.go
+++ b/exporter/awss3exporter/internal/upload/partition_test.go
@@ -492,19 +492,54 @@ func TestTemplateReferencesPrefix(t *testing.T) {
 // Regression for the architect's review concern (SAW-7554 PR #74): a template
 // that defines .Prefix references in associated subtemplates would have been
 // missed by a root-only AST walk. Validates the detector descends through
-// every parse tree the template carries.
-func TestTemplateReferencesPrefix_AssociatedSubtemplates(t *testing.T) {
+// every parse tree REACHABLE from the root via {{template "name"}}.
+func TestTemplateReferencesPrefix_ReachableSubtemplates(t *testing.T) {
 	t.Parallel()
 
 	// .Prefix lives in a {{define}} block, not the root, and is reached via
-	// {{template "tail"}}. A root-only walker reports false; the correct
-	// answer is true (the rendered output DOES include the prefix).
+	// {{template "tail"}}. The rendered output DOES include the prefix, so
+	// the detector must return true.
 	const tmpl = `{{define "tail"}}{{.Prefix}}/dt={{.Date}}{{end}}{{template "tail" .}}`
 
 	parsed, err := parseLegacyTemplate(tmpl)
 	assert.NoError(t, err)
 	assert.True(t, templateReferencesPrefix(parsed),
-		"detector must descend into associated templates created with {{define}}")
+		"detector must descend into associated templates invoked via {{template}}")
+}
+
+// Regression for the architect's second review concern (SAW-7554 PR #74):
+// an UNUSED {{define}} block must NOT count as a Prefix reference, otherwise
+// the auto-prepend gets suppressed for a template whose rendered key never
+// actually emits the prefix. The detector should only follow reachable
+// {{template "name"}} call sites.
+func TestTemplateReferencesPrefix_IgnoresUnusedDefines(t *testing.T) {
+	t.Parallel()
+
+	// "unused" mentions .Prefix but is never invoked. The rendered key is
+	// just "foo" — the prefix is missing, so the detector must return false
+	// to let buildLegacyTemplateKey auto-prepend it.
+	const tmpl = `{{define "unused"}}{{.Prefix}}{{end}}foo`
+
+	parsed, err := parseLegacyTemplate(tmpl)
+	assert.NoError(t, err)
+	assert.False(t, templateReferencesPrefix(parsed),
+		"detector must ignore {{define}} blocks that are unreachable from root")
+}
+
+// Regression: mutual recursion between named templates must not loop
+// forever. The detector tracks visited template names.
+func TestTemplateReferencesPrefix_MutualRecursionIsBounded(t *testing.T) {
+	t.Parallel()
+
+	// "a" calls "b", "b" calls "a". Neither references .Prefix, so the
+	// detector should return false and, more importantly, terminate.
+	const tmpl = `{{define "a"}}A{{template "b" .}}{{end}}` +
+		`{{define "b"}}B{{template "a" .}}{{end}}` +
+		`{{template "a" .}}`
+
+	parsed, err := parseLegacyTemplate(tmpl)
+	assert.NoError(t, err)
+	assert.False(t, templateReferencesPrefix(parsed))
 }
 
 func TestPartitionKeyInputsUniqueKey(t *testing.T) {

--- a/exporter/awss3exporter/internal/upload/partition_test.go
+++ b/exporter/awss3exporter/internal/upload/partition_test.go
@@ -489,6 +489,24 @@ func TestTemplateReferencesPrefix(t *testing.T) {
 	}
 }
 
+// Regression for the architect's review concern (SAW-7554 PR #74): a template
+// that defines .Prefix references in associated subtemplates would have been
+// missed by a root-only AST walk. Validates the detector descends through
+// every parse tree the template carries.
+func TestTemplateReferencesPrefix_AssociatedSubtemplates(t *testing.T) {
+	t.Parallel()
+
+	// .Prefix lives in a {{define}} block, not the root, and is reached via
+	// {{template "tail"}}. A root-only walker reports false; the correct
+	// answer is true (the rendered output DOES include the prefix).
+	const tmpl = `{{define "tail"}}{{.Prefix}}/dt={{.Date}}{{end}}{{template "tail" .}}`
+
+	parsed, err := parseLegacyTemplate(tmpl)
+	assert.NoError(t, err)
+	assert.True(t, templateReferencesPrefix(parsed),
+		"detector must descend into associated templates created with {{define}}")
+}
+
 func TestPartitionKeyInputsUniqueKey(t *testing.T) {
 	t.Parallel()
 

--- a/exporter/awss3exporter/internal/upload/partition_test.go
+++ b/exporter/awss3exporter/internal/upload/partition_test.go
@@ -397,6 +397,98 @@ func TestValidateLegacyTemplate_DatadogKeyTemplate(t *testing.T) {
 	assert.NoError(t, ValidateLegacyTemplateForValidation(tmpl))
 }
 
+// SAW-7554: the legacy-template mode must honor the configured s3_prefix as
+// a runtime invariant, symmetric with default mode (which always joins the
+// prefix via bucketKeyPrefix). Before this fix, a template that omitted
+// {{.Prefix}} would silently drop the prefix on the floor, causing every
+// caller (e.g. the collectors-service generator) to bear responsibility for
+// remembering to reference .Prefix — see the bug report for the production
+// impact (~486 active collectors writing to bucket root).
+
+func TestBuildKey_LegacyTemplate_AutoPrependsPrefix_WhenTemplateOmitsPrefix(t *testing.T) {
+	t.Parallel()
+
+	// The exact "datadog archive" template emitted by collectors-service:
+	// authored before {{.Prefix}} was a thing, never referenced it.
+	const tmpl = `dt={{ dateInZone "20060102" (now) "UTC" }}/hour={{ dateInZone "15" (now) "UTC" }}/archive_{{ dateInZone "150405.0000" (now) "UTC" }}.{{ randAlpha 22 }}.json.gz`
+
+	parsed, err := parseLegacyTemplate(tmpl)
+	assert.NoError(t, err)
+
+	key := buildLegacyTemplateKey(
+		"/datadog/hosted/logs",
+		parsed,
+		time.Date(2026, 5, 14, 12, 30, 0, 0, time.UTC),
+	)
+
+	// Prefix must be present at the start. The template uses `(now)`, not
+	// the ts arg, so the date/hour/seconds reflect wall-clock — assert
+	// only the invariant pieces.
+	assert.Regexp(t, `^/datadog/hosted/logs/dt=\d{8}/hour=\d{2}/archive_\d+\.\d+\.[A-Za-z]{22}\.json\.gz$`, key)
+}
+
+func TestBuildKey_LegacyTemplate_PreservesExistingPrefixReference(t *testing.T) {
+	t.Parallel()
+
+	// A template that already references {{.Prefix}} must NOT have the
+	// prefix prepended a second time — back-compat for callers that
+	// learned the original rule.
+	parsed, err := parseLegacyTemplate(`{{.Prefix}}/{{.Date}}/{{.UUID}}.json.gz`)
+	assert.NoError(t, err)
+
+	key := buildLegacyTemplateKey(
+		"/datadog/hosted/logs",
+		parsed,
+		time.Date(2026, 5, 14, 12, 30, 0, 0, time.UTC),
+	)
+
+	assert.Regexp(t, `^/datadog/hosted/logs/2026/05/14/.+\.json\.gz$`, key)
+}
+
+func TestBuildKey_LegacyTemplate_EmptyPrefix_NoLeadingSlash(t *testing.T) {
+	t.Parallel()
+
+	// With no prefix configured, the rendered key must NOT gain a leading
+	// slash — preserves today's behavior for prefix-less destinations
+	// (which currently render starting with "dt=...").
+	parsed, err := parseLegacyTemplate(`dt=20260514/archive.json.gz`)
+	assert.NoError(t, err)
+
+	key := buildLegacyTemplateKey("", parsed, time.Date(2026, 5, 14, 12, 30, 0, 0, time.UTC))
+	assert.Equal(t, "dt=20260514/archive.json.gz", key)
+}
+
+func TestTemplateReferencesPrefix(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		tmpl string
+		want bool
+	}{
+		{"plain prefix ref", `{{.Prefix}}/foo`, true},
+		{"spaced prefix ref", `{{ .Prefix }}/foo`, true},
+		{"prefix inside if", `{{if .Prefix}}{{.Prefix}}/{{end}}foo`, true},
+		{"prefix inside with", `{{with .Prefix}}{{.}}/{{end}}foo`, true},
+		{"no prefix ref", `dt=20260514/archive.gz`, false},
+		{"date ref but no prefix ref", `{{.Date}}/{{.UUID}}.gz`, false},
+		{
+			"datadog template (the buggy one)",
+			`dt={{ dateInZone "20060102" (now) "UTC" }}/hour={{ dateInZone "15" (now) "UTC" }}/archive_{{ dateInZone "150405.0000" (now) "UTC" }}.{{ randAlpha 22 }}.json.gz`,
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			parsed, err := parseLegacyTemplate(tc.tmpl)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, templateReferencesPrefix(parsed))
+		})
+	}
+}
+
 func TestPartitionKeyInputsUniqueKey(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

The exporter accepts `s3_prefix` (`S3Uploader.S3Prefix` → `PartitionPrefix`) and passes it to the legacy-template engine as `legacyTemplateData.Prefix`, but treats the field as **advisory** — honored only if the template references `{{.Prefix}}`. Default mode (no template) joins the prefix unconditionally via `bucketKeyPrefix`. That asymmetry is the SAW-7554 defect: any generated template that omits `{{.Prefix}}` silently drops the configured `s3_prefix`, sending logs to bucket root.

## Production impact

Caught via the SAW-7554 blast-radius audit in collectors-service.

| Customer | Active collectors | Buckets | Configured `s3_prefix` | Actual write path |
|---|---|---|---|---|
| **BigID** (`org_2scjXGiUUgkr7yIc3Lb1dyWPHMm`) | ~355 across 19 clusters | `bigid-datadog-us-logs` | `/datadog/hosted/logs` | bucket root |
| **HiBob** (`org_2rapVHF5g98Wx9yTVHkOlKPWnae`) | 131 across `hibob-{dev,prod,sandbox,stage}` | `hibob-{env}-eu-west-1-s3-sawmills-datadog-logs-{stream,archive}` | `/datadog/logs` | bucket root |

~486 active collector instances writing telemetry that's invisible to the customers' configured Datadog Archive Search paths.

## Fix

In `buildLegacyTemplateKey`, auto-prepend the prefix via `path.Join` when:
1. The prefix is non-empty, AND
2. The parsed template does not reference `.Prefix`

The new `templateReferencesPrefix` helper walks the parsed AST once per `Build()` call. Templates that already reference `.Prefix` render exactly as before (no double-prepend).

```go
key := rendered.String()
if prefix != "" && !templateReferencesPrefix(tmpl) {
    return path.Join(prefix, key)
}
return key
```

## Behavior matrix

| Template | Prefix | Before | After |
|---|---|---|---|
| `dt={{...}}/archive.gz` (no `.Prefix`) | `/datadog/hosted/logs` | `dt=.../archive.gz` ❌ | `/datadog/hosted/logs/dt=.../archive.gz` ✓ |
| `{{.Prefix}}/dt=.../archive.gz` | `/datadog/hosted/logs` | `/datadog/hosted/logs/dt=.../archive.gz` ✓ | unchanged ✓ |
| `{{if .Prefix}}{{.Prefix}}/{{end}}dt=...` | `/datadog/hosted/logs` | `/datadog/hosted/logs/dt=...` ✓ | unchanged ✓ |
| `dt=.../archive.gz` | _empty_ | `dt=.../archive.gz` ✓ | unchanged ✓ |
| Default mode (no template) | any | already honored via `bucketKeyPrefix` | unchanged ✓ |

**Strictly back-compat for every template that already worked.** Asymmetry between default and legacy-template modes is eliminated.

## Why fix here (and not at the caller)

[Sawmills/collectors-service#876](https://github.com/Sawmills/collectors-service/pull/876) patched the symptom at the generator boundary (emit a template that references `{{.Prefix}}`). That patch has been reverted in [Sawmills/collectors-service#877](https://github.com/Sawmills/collectors-service/pull/877) in favor of this fix because:
- The defect is internal to the exporter — it accepts the config field and silently drops it.
- Putting prefix-honoring in the exporter prevents any future hardcoded template (in our generator or any other caller) from re-introducing this class of bug.
- Symmetric with default mode, which already treats `s3_prefix` as an invariant.

## Test plan

- New tests:
  - `TestBuildKey_LegacyTemplate_AutoPrependsPrefix_WhenTemplateOmitsPrefix` — uses the exact "datadog archive" template emitted by collectors-service
  - `TestBuildKey_LegacyTemplate_PreservesExistingPrefixReference` — no double-prepend
  - `TestBuildKey_LegacyTemplate_EmptyPrefix_NoLeadingSlash` — guards no surprise `/` prefix
  - `TestTemplateReferencesPrefix` — table-driven AST walker over: plain ref, spaced, `if`, `with`, no-ref, other-fields, historical datadog template
- Full `./exporter/awss3exporter/...` suite passes locally.
- TDD: red (stubbed helper returns false → assertions fail), then green (real AST walker + auto-prepend).

## Follow-up

Once tagged, bump in `collectors-service` `go.mod`. After that, every regenerated customer config — including the buggy datadog/ndjson destinations for BigID + HiBob — will honor `s3_prefix` at runtime with no caller changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the `awss3exporter` always honors `s3_prefix` in legacy template mode by auto-prepending it when templates (including reachable subtemplates) omit `.Prefix`, matching default mode behavior. Fixes SAW-7554 so data writes under the configured path instead of the bucket root.

- **Bug Fixes**
  - In `buildLegacyTemplateKey`, prepend the prefix when non-empty and the template doesn’t reference `.Prefix`; otherwise unchanged.
  - `templateReferencesPrefix` follows only subtemplates reachable from the root via `{{template}}`, ignores unused `{{define}}` blocks, and bounds mutual recursion; tests cover auto-prepend, no double-prepend, empty-prefix, detection cases, reachable subtemplates, unused defines, and recursion.

- **Refactors**
  - Modernized AST traversal using `slices.ContainsFunc` and addressed staticcheck cleanups; no behavior change.
  - Updated `.chloggen` entry: canonical component `exporter/awss3`; `issues` set to `[74]`.

<sup>Written for commit 04fbe86898c3c8d81b9fc4cb3f4cc07a2804b37e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AWS S3 exporter to properly handle `s3_prefix` configuration in legacy template mode. The prefix is now treated as an invariant, automatically prepended to S3 keys when the template does not reference it, preventing double-prepending.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/74)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->