### PR TITLE
perf(loadbalancingexporter): reduce central queue backlog scans

### DIFF
--- a/.chloggen/loadbalancingexporter-central-queue-drain-performance.yaml
+++ b/.chloggen/loadbalancingexporter-central-queue-drain-performance.yaml
@@ -1,7 +1,9 @@
 change_type: enhancement
 component: exporter/loadbalancing
 note: Reduce central queue scheduling and drain CPU for load-balanced logs and metrics.
+issues: [76]
 
 subtext: |-
   Reworks central queue candidate collection and window removal to avoid repeated full-backlog scans
   and per-item slice compaction under large queued backlogs.
+change_logs: [user]

--- a/.chloggen/loadbalancingexporter-central-queue-drain-performance.yaml
+++ b/.chloggen/loadbalancingexporter-central-queue-drain-performance.yaml
@@ -1,0 +1,7 @@
+change_type: enhancement
+component: exporter/loadbalancing
+note: Reduce central queue scheduling and drain CPU for load-balanced logs and metrics.
+
+subtext: |-
+  Reworks central queue candidate collection and window removal to avoid repeated full-backlog scans
+  and per-item slice compaction under large queued backlogs.

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -299,7 +299,8 @@ func (q *centralQueue) collectWindowCandidatesLocked(now time.Time) ([]centralQu
 	targetCandidates := make([]centralQueueWindowCandidate, 0)
 	fallbackCandidates := make([]centralQueueWindowCandidate, 0)
 	hasReady := false
-	for i, item := range q.items {
+	for i := range q.items {
+		item := &q.items[i]
 		if item.nextAttemptUnixNano > nowUnixNano {
 			continue
 		}
@@ -420,7 +421,7 @@ func (q *centralQueue) scheduleReadyWindowCandidatesLocked(candidates []centralQ
 	return true, blocked
 }
 
-func appendCentralQueueWindowCandidateIndex(candidate *centralQueueWindowCandidate, item centralQueueItem, index int) {
+func appendCentralQueueWindowCandidateIndex(candidate *centralQueueWindowCandidate, item *centralQueueItem, index int) {
 	candidate.indexes = append(candidate.indexes, index)
 	candidate.window.compressedBytes += item.compressedBytes
 	candidate.window.uncompressedBytes += item.uncompressedBytes
@@ -440,7 +441,7 @@ func (q *centralQueue) materializeWindowCandidateItemsLocked(candidate *centralQ
 	}
 }
 
-func (q *centralQueue) windowWouldExceedLimit(window centralQueueWindow, item centralQueueItem) bool {
+func (q *centralQueue) windowWouldExceedLimit(window centralQueueWindow, item *centralQueueItem) bool {
 	return q.settings.maxUncompressedBatchBytes > 0 &&
 		window.uncompressedBytes+item.uncompressedBytes > q.settings.maxUncompressedBatchBytes
 }
@@ -463,8 +464,8 @@ func (q *centralQueue) leaseReadyWindowLocked() *centralQueueLease {
 	copy(q.ready, q.ready[1:])
 	q.ready[len(q.ready)-1] = centralQueueWindow{}
 	q.ready = q.ready[:len(q.ready)-1]
-	for _, item := range window.items {
-		q.untrackOldestEnqueuedAtLocked(item)
+	for i := range window.items {
+		q.untrackOldestEnqueuedAtLocked(window.items[i])
 	}
 	snapshot := q.snapshotLocked()
 	q.settings.telemetry.record(context.Background(), snapshot)
@@ -525,7 +526,8 @@ func (l *centralQueueLease) requeue(now time.Time) error {
 			l.queue.currentCompressedBytes -= int64(l.window.compressedBytes)
 			err = errCentralQueueStopped
 		} else {
-			for _, item := range l.window.items {
+			for i := range l.window.items {
+				item := l.window.items[i]
 				nextAttempt := now.Add(centralQueueRetryDelayWithJitter(item))
 				item.attempt++
 				item.nextAttemptUnixNano = nextAttempt.UnixNano()

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -4,7 +4,6 @@
 package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 
 import (
-	"bytes"
 	"container/heap"
 	"context"
 	"encoding/binary"
@@ -110,6 +109,11 @@ type centralQueueWindowCandidate struct {
 	indexes []int
 }
 
+type centralQueueWindowCandidateBuilder struct {
+	candidate centralQueueWindowCandidate
+	finalized bool
+}
+
 func newCentralQueue(settings centralQueueSettings) *centralQueue {
 	if settings.targetCompressedBytes <= 0 {
 		settings.targetCompressedBytes = 1
@@ -152,6 +156,9 @@ func (q *centralQueue) enqueueAt(item centralQueueItem, now time.Time) error {
 	}
 	if item.enqueuedAtUnixNano == 0 {
 		item.enqueuedAtUnixNano = now.UnixNano()
+	}
+	if item.routingKeyID == "" && len(item.routingKey) > 0 {
+		item.routingKeyID = string(item.routingKey)
 	}
 	q.items = append(q.items, item)
 	q.currentCompressedBytes += int64(item.compressedBytes)
@@ -287,24 +294,79 @@ func (q *centralQueue) splitFallbackByStaleness(candidates []centralQueueWindowC
 // lane cannot fill the bounded ready backlog before other ready lanes get a turn.
 func (q *centralQueue) collectWindowCandidatesLocked(now time.Time) ([]centralQueueWindowCandidate, []centralQueueWindowCandidate, bool) {
 	nowUnixNano := now.UnixNano()
-	evaluatedRoutingKeys := make(map[string]struct{})
+	candidateIndexesByRoutingKey := make(map[string]int)
+	candidates := make([]centralQueueWindowCandidateBuilder, 0)
 	targetCandidates := make([]centralQueueWindowCandidate, 0)
 	fallbackCandidates := make([]centralQueueWindowCandidate, 0)
 	hasReady := false
-	for _, item := range q.items {
+	for i, item := range q.items {
 		if item.nextAttemptUnixNano > nowUnixNano {
 			continue
 		}
 		hasReady = true
-		routingKey := string(item.routingKey)
-		if _, ok := evaluatedRoutingKeys[routingKey]; ok {
-			continue
+
+		routingKeyID := item.routingKeyID
+		if routingKeyID == "" && len(item.routingKey) > 0 {
+			routingKeyID = string(item.routingKey)
 		}
-		evaluatedRoutingKeys[routingKey] = struct{}{}
-		candidate, ok := q.buildWindowCandidateLocked(item.routingKey, now)
+		candidateIndex, ok := candidateIndexesByRoutingKey[routingKeyID]
 		if !ok {
+			candidateIndexesByRoutingKey[routingKeyID] = len(candidates)
+			candidates = append(candidates, centralQueueWindowCandidateBuilder{
+				candidate: centralQueueWindowCandidate{
+					window: centralQueueWindow{
+						routingKey: append([]byte(nil), item.routingKey...),
+					},
+					indexes: make([]int, 0, 1),
+				},
+			})
+			candidateIndex = len(candidates) - 1
+		}
+
+		candidate := &candidates[candidateIndex]
+		if candidate.finalized {
 			continue
 		}
+		if len(candidate.candidate.indexes) > 0 && q.windowWouldExceedLimit(candidate.candidate.window, item) {
+			candidate.candidate.window.flushReason = centralQueueFlushReasonHardCap
+			candidate.finalized = true
+			continue
+		}
+
+		appendCentralQueueWindowCandidateIndex(&candidate.candidate, item, i)
+		if int64(candidate.candidate.window.compressedBytes) >= q.settings.targetCompressedBytes {
+			candidate.candidate.window.flushReason = centralQueueFlushReasonTargetReached
+			candidate.finalized = true
+		}
+	}
+
+	for i := range candidates {
+		candidate := candidates[i].candidate
+		if len(candidate.indexes) == 0 {
+			continue
+		}
+		switch candidate.window.flushReason {
+		case centralQueueFlushReasonTargetReached:
+		case "":
+			switch {
+			case q.stopped:
+				candidate.window.flushReason = centralQueueFlushReasonShutdown
+			case q.settings.maxBatchDelay <= 0:
+				candidate.window.flushReason = centralQueueFlushReasonMaxDelayLowTraffic
+			default:
+				oldest := time.Unix(0, candidate.window.oldestEnqueuedAt)
+				if oldest.IsZero() || now.Sub(oldest) < q.settings.maxBatchDelay {
+					continue
+				}
+				candidate.window.flushReason = centralQueueFlushReasonMaxDelayLowTraffic
+			}
+		default:
+			if q.stopped {
+				candidate.window.flushReason = centralQueueFlushReasonShutdown
+			}
+		}
+		q.materializeWindowCandidateItemsLocked(&candidate)
+
 		if candidate.window.flushReason != centralQueueFlushReasonTargetReached {
 			fallbackCandidates = append(fallbackCandidates, candidate)
 			continue
@@ -358,63 +420,24 @@ func (q *centralQueue) scheduleReadyWindowCandidatesLocked(candidates []centralQ
 	return true, blocked
 }
 
-func (q *centralQueue) buildWindowCandidateLocked(routingKey []byte, now time.Time) (centralQueueWindowCandidate, bool) {
-	nowUnixNano := now.UnixNano()
-	candidate := centralQueueWindowCandidate{
-		window: centralQueueWindow{
-			routingKey: append([]byte(nil), routingKey...),
-			items:      make([]centralQueueItem, 0, 1),
-		},
-		indexes: make([]int, 0, 1),
+func appendCentralQueueWindowCandidateIndex(candidate *centralQueueWindowCandidate, item centralQueueItem, index int) {
+	candidate.indexes = append(candidate.indexes, index)
+	candidate.window.compressedBytes += item.compressedBytes
+	candidate.window.uncompressedBytes += item.uncompressedBytes
+	candidate.window.count += item.count
+	if item.attempt > candidate.window.maxAttempt {
+		candidate.window.maxAttempt = item.attempt
 	}
+	if candidate.window.oldestEnqueuedAt == 0 || item.enqueuedAtUnixNano < candidate.window.oldestEnqueuedAt {
+		candidate.window.oldestEnqueuedAt = item.enqueuedAtUnixNano
+	}
+}
 
-	blockedByHardLimit := false
-	for i, item := range q.items {
-		if !bytes.Equal(item.routingKey, routingKey) || item.nextAttemptUnixNano > nowUnixNano {
-			continue
-		}
-		if len(candidate.window.items) > 0 && q.windowWouldExceedLimit(candidate.window, item) {
-			blockedByHardLimit = true
-			break
-		}
-		candidate.window.items = append(candidate.window.items, item)
-		candidate.indexes = append(candidate.indexes, i)
-		candidate.window.compressedBytes += item.compressedBytes
-		candidate.window.uncompressedBytes += item.uncompressedBytes
-		candidate.window.count += item.count
-		if item.attempt > candidate.window.maxAttempt {
-			candidate.window.maxAttempt = item.attempt
-		}
-		if candidate.window.oldestEnqueuedAt == 0 || item.enqueuedAtUnixNano < candidate.window.oldestEnqueuedAt {
-			candidate.window.oldestEnqueuedAt = item.enqueuedAtUnixNano
-		}
-		if int64(candidate.window.compressedBytes) >= q.settings.targetCompressedBytes {
-			candidate.window.flushReason = centralQueueFlushReasonTargetReached
-			return candidate, true
-		}
+func (q *centralQueue) materializeWindowCandidateItemsLocked(candidate *centralQueueWindowCandidate) {
+	candidate.window.items = make([]centralQueueItem, 0, len(candidate.indexes))
+	for _, index := range candidate.indexes {
+		candidate.window.items = append(candidate.window.items, q.items[index])
 	}
-
-	if len(candidate.window.items) == 0 {
-		return centralQueueWindowCandidate{}, false
-	}
-	if q.stopped {
-		candidate.window.flushReason = centralQueueFlushReasonShutdown
-		return candidate, true
-	}
-	if blockedByHardLimit {
-		candidate.window.flushReason = centralQueueFlushReasonHardCap
-		return candidate, true
-	}
-	if q.settings.maxBatchDelay <= 0 {
-		candidate.window.flushReason = centralQueueFlushReasonMaxDelayLowTraffic
-		return candidate, true
-	}
-	oldest := time.Unix(0, candidate.window.oldestEnqueuedAt)
-	if !oldest.IsZero() && now.Sub(oldest) >= q.settings.maxBatchDelay {
-		candidate.window.flushReason = centralQueueFlushReasonMaxDelayLowTraffic
-		return candidate, true
-	}
-	return centralQueueWindowCandidate{}, false
 }
 
 func (q *centralQueue) windowWouldExceedLimit(window centralQueueWindow, item centralQueueItem) bool {
@@ -456,26 +479,28 @@ func (q *centralQueue) leaseReadyWindowLocked() *centralQueueLease {
 	return lease
 }
 
-func (q *centralQueue) removeItemLocked(index int) {
-	removed := q.items[index]
-	q.items = removeCentralQueueItem(q.items, index)
-	q.untrackOldestEnqueuedAtLocked(removed)
-}
-
 func (q *centralQueue) removeWindowLocked(indexes []int, untrack bool) {
-	for i := len(indexes) - 1; i >= 0; i-- {
-		if untrack {
-			q.removeItemLocked(indexes[i])
+	if len(indexes) == 0 {
+		return
+	}
+
+	writeIndex := indexes[0]
+	removeIndex := 0
+	for readIndex := indexes[0]; readIndex < len(q.items); readIndex++ {
+		if removeIndex < len(indexes) && indexes[removeIndex] == readIndex {
+			if untrack {
+				q.untrackOldestEnqueuedAtLocked(q.items[readIndex])
+			}
+			for removeIndex < len(indexes) && indexes[removeIndex] == readIndex {
+				removeIndex++
+			}
 			continue
 		}
-		q.items = removeCentralQueueItem(q.items, indexes[i])
+		q.items[writeIndex] = q.items[readIndex]
+		writeIndex++
 	}
-}
-
-func removeCentralQueueItem(items []centralQueueItem, index int) []centralQueueItem {
-	copy(items[index:], items[index+1:])
-	items[len(items)-1] = centralQueueItem{}
-	return items[:len(items)-1]
+	clear(q.items[writeIndex:])
+	q.items = q.items[:writeIndex]
 }
 
 func (l *centralQueueLease) done() {

--- a/exporter/loadbalancingexporter/central_queue_item.go
+++ b/exporter/loadbalancingexporter/central_queue_item.go
@@ -22,6 +22,7 @@ var (
 type centralQueueItem struct {
 	signal              signalKind
 	routingKey          []byte
+	routingKeyID        string
 	payload             []byte
 	compressedBytes     int
 	uncompressedBytes   int

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -195,6 +195,138 @@ func TestCentralQueueReadyWindowsHandleInterleavedLaneItems(t *testing.T) {
 	require.Zero(t, q.compressedBytes())
 }
 
+func TestCentralQueueCollectWindowCandidatesGroupsInterleavedKeys(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        20,
+		maxBatchDelay:                time.Hour,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), payload: []byte("a-1"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-b"), payload: []byte("b-1"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), payload: []byte("a-2"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-b"), payload: []byte("b-2"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+
+	q.mu.Lock()
+	targetCandidates, fallbackCandidates, hasReady := q.collectWindowCandidatesLocked(now)
+	q.mu.Unlock()
+
+	require.True(t, hasReady)
+	require.Empty(t, fallbackCandidates)
+	require.Len(t, targetCandidates, 2)
+	require.Equal(t, []byte("lane-a"), targetCandidates[0].window.routingKey)
+	require.Equal(t, []int{0, 2}, targetCandidates[0].indexes)
+	require.Equal(t, []string{"a-1", "a-2"}, centralQueuePayloadStrings(targetCandidates[0].window.items))
+	require.Equal(t, centralQueueFlushReasonTargetReached, targetCandidates[0].window.flushReason)
+	require.Equal(t, []byte("lane-b"), targetCandidates[1].window.routingKey)
+	require.Equal(t, []int{1, 3}, targetCandidates[1].indexes)
+	require.Equal(t, []string{"b-1", "b-2"}, centralQueuePayloadStrings(targetCandidates[1].window.items))
+	require.Equal(t, centralQueueFlushReasonTargetReached, targetCandidates[1].window.flushReason)
+}
+
+func TestCentralQueueCollectWindowCandidatesMarksHardCapBeforeTarget(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    30,
+		targetCompressedBytes:        100,
+		maxBatchDelay:                time.Hour,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), payload: []byte("first"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), payload: []byte("second"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+
+	q.mu.Lock()
+	targetCandidates, fallbackCandidates, hasReady := q.collectWindowCandidatesLocked(now)
+	q.mu.Unlock()
+
+	require.True(t, hasReady)
+	require.Empty(t, targetCandidates)
+	require.Len(t, fallbackCandidates, 1)
+	require.Equal(t, centralQueueFlushReasonHardCap, fallbackCandidates[0].window.flushReason)
+	require.Equal(t, []int{0}, fallbackCandidates[0].indexes)
+	require.Equal(t, []string{"first"}, centralQueuePayloadStrings(fallbackCandidates[0].window.items))
+}
+
+func TestCentralQueueCollectWindowCandidatesUsesMaxDelayForLowTraffic(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        100,
+		maxBatchDelay:                250 * time.Millisecond,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), compressedBytes: 10, uncompressedBytes: 10, count: 1}, now))
+
+	q.mu.Lock()
+	targetCandidates, fallbackCandidates, hasReady := q.collectWindowCandidatesLocked(now.Add(249 * time.Millisecond))
+	q.mu.Unlock()
+	require.True(t, hasReady)
+	require.Empty(t, targetCandidates)
+	require.Empty(t, fallbackCandidates)
+
+	q.mu.Lock()
+	targetCandidates, fallbackCandidates, hasReady = q.collectWindowCandidatesLocked(now.Add(250 * time.Millisecond))
+	q.mu.Unlock()
+	require.True(t, hasReady)
+	require.Empty(t, targetCandidates)
+	require.Len(t, fallbackCandidates, 1)
+	require.Equal(t, centralQueueFlushReasonMaxDelayLowTraffic, fallbackCandidates[0].window.flushReason)
+}
+
+func TestCentralQueueCollectWindowCandidatesShutdownOverridesWaitingAndHardCap(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    30,
+		targetCompressedBytes:        100,
+		maxBatchDelay:                time.Hour,
+	})
+	now := time.Unix(10, 0)
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), payload: []byte("first"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+	require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte("lane-a"), payload: []byte("second"), compressedBytes: 10, uncompressedBytes: 20, count: 1}, now))
+	q.stop()
+
+	q.mu.Lock()
+	targetCandidates, fallbackCandidates, hasReady := q.collectWindowCandidatesLocked(now)
+	q.mu.Unlock()
+
+	require.True(t, hasReady)
+	require.Empty(t, targetCandidates)
+	require.Len(t, fallbackCandidates, 1)
+	require.Equal(t, centralQueueFlushReasonShutdown, fallbackCandidates[0].window.flushReason)
+	require.Equal(t, []int{0}, fallbackCandidates[0].indexes)
+	require.Equal(t, []string{"first"}, centralQueuePayloadStrings(fallbackCandidates[0].window.items))
+}
+
+func TestCentralQueueMaterializeAndRemoveWindowKeepsSparseIndexSurvivors(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        100,
+	})
+	now := time.Unix(10, 0)
+	for _, payload := range []string{"keep-0", "drop-1", "keep-2", "drop-3", "keep-4"} {
+		require.NoError(t, q.enqueueAt(centralQueueItem{signal: signalKindLogs, routingKey: []byte(payload), payload: []byte(payload), compressedBytes: 1, uncompressedBytes: 1, count: 1}, now))
+	}
+
+	candidate := centralQueueWindowCandidate{
+		indexes: []int{1, 3},
+	}
+	q.mu.Lock()
+	q.materializeWindowCandidateItemsLocked(&candidate)
+	q.removeWindowLocked(candidate.indexes, false)
+	remainingItems := append([]centralQueueItem(nil), q.items...)
+	q.mu.Unlock()
+
+	require.Equal(t, []string{"drop-1", "drop-3"}, centralQueuePayloadStrings(candidate.window.items))
+	require.Equal(t, []string{"keep-0", "keep-2", "keep-4"}, centralQueuePayloadStrings(remainingItems))
+}
+
 func TestCentralQueueReadyWindowsRecollectFallbackAfterTargetRemoval(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:           100,
@@ -1116,6 +1248,14 @@ func requireCentralQueueFirstRetryDelay(t *testing.T, q *centralQueue) {
 	retryAfterEnqueue := time.Unix(0, item.nextAttemptUnixNano).Sub(time.Unix(0, item.enqueuedAtUnixNano))
 	require.GreaterOrEqual(t, retryAfterEnqueue, centralQueueRetryDelay(0))
 	require.LessOrEqual(t, retryAfterEnqueue, centralQueueRetryDelayUpperBound(0)+50*time.Millisecond)
+}
+
+func centralQueuePayloadStrings(items []centralQueueItem) []string {
+	payloads := make([]string, 0, len(items))
+	for _, item := range items {
+		payloads = append(payloads, string(item.payload))
+	}
+	return payloads
 }
 
 func requireNextAttemptWithinRetryDelay(t *testing.T, now time.Time, attempt int, nextAttemptUnixNano int64) {

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -1252,8 +1252,8 @@ func requireCentralQueueFirstRetryDelay(t *testing.T, q *centralQueue) {
 
 func centralQueuePayloadStrings(items []centralQueueItem) []string {
 	payloads := make([]string, 0, len(items))
-	for _, item := range items {
-		payloads = append(payloads, string(item.payload))
+	for i := range items {
+		payloads = append(payloads, string(items[i].payload))
 	}
 	return payloads
 }

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -1002,6 +1002,103 @@ func TestCentralQueueDoesNotStarveColdLaneUnderContinuousHotKeyArrivals(t *testi
 		totalRounds, time.Duration(totalRounds)*100*time.Millisecond)
 }
 
+func BenchmarkCentralQueueDrainInterleavedBacklog(b *testing.B) {
+	const (
+		laneCount             = 64
+		itemsPerLane          = 512
+		itemCompressedBytes   = 4 * 1024
+		itemUncompressedBytes = 16 * 1024
+		targetCompressedBytes = 256 * 1024
+	)
+
+	laneKeys := make([][]byte, laneCount)
+	for lane := range laneCount {
+		laneKeys[lane] = fmt.Appendf(nil, "lane-%02d", lane)
+	}
+	now := time.Unix(1000, 0)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		q := newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           int64(laneCount * itemsPerLane * itemCompressedBytes),
+			maxInflightUncompressedBytes: int64(laneCount * targetCompressedBytes * 16),
+			maxUncompressedBatchBytes:    laneCount * targetCompressedBytes,
+			targetCompressedBytes:        targetCompressedBytes,
+			maxBatchDelay:                time.Second,
+			maxReadyWindows:              laneCount,
+		})
+
+		b.StopTimer()
+		for itemIndex := range itemsPerLane {
+			for lane := range laneCount {
+				require.NoError(b, q.enqueueAt(centralQueueItem{
+					signal:            signalKindLogs,
+					routingKey:        laneKeys[lane],
+					compressedBytes:   itemCompressedBytes,
+					uncompressedBytes: itemUncompressedBytes,
+					count:             1,
+				}, now.Add(time.Duration(itemIndex)*time.Nanosecond)))
+			}
+		}
+		b.StartTimer()
+
+		for q.len() > 0 {
+			lease, err := q.tryLease(now.Add(time.Second))
+			require.NoError(b, err)
+			if lease == nil {
+				b.Fatalf("queue stalled with %d items remaining", q.len())
+			}
+			lease.done()
+		}
+	}
+}
+
+func BenchmarkCentralQueueCollectInterleavedUnderfilledBacklog(b *testing.B) {
+	const (
+		laneCount             = 64
+		itemsPerLane          = 512
+		itemCompressedBytes   = 1
+		itemUncompressedBytes = 16 * 1024
+	)
+
+	laneKeys := make([][]byte, laneCount)
+	for lane := range laneCount {
+		laneKeys[lane] = fmt.Appendf(nil, "lane-%02d", lane)
+	}
+	now := time.Unix(1000, 0)
+
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           int64(laneCount * itemsPerLane * itemCompressedBytes),
+		maxInflightUncompressedBytes: int64(laneCount * itemsPerLane * itemUncompressedBytes),
+		maxUncompressedBatchBytes:    laneCount * itemsPerLane * itemUncompressedBytes,
+		targetCompressedBytes:        itemsPerLane + 1,
+		maxBatchDelay:                time.Hour,
+		maxReadyWindows:              laneCount,
+	})
+	for itemIndex := range itemsPerLane {
+		for lane := range laneCount {
+			require.NoError(b, q.enqueueAt(centralQueueItem{
+				signal:            signalKindLogs,
+				routingKey:        laneKeys[lane],
+				compressedBytes:   itemCompressedBytes,
+				uncompressedBytes: itemUncompressedBytes,
+				count:             1,
+			}, now.Add(time.Duration(itemIndex)*time.Nanosecond)))
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		q.mu.Lock()
+		targetCandidates, fallbackCandidates, hasReady := q.collectWindowCandidatesLocked(now)
+		q.mu.Unlock()
+		require.True(b, hasReady)
+		require.Empty(b, targetCandidates)
+		require.Empty(b, fallbackCandidates)
+	}
+}
+
 func requireCentralQueueFirstRetryDelay(t *testing.T, q *centralQueue) {
 	t.Helper()
 

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -307,7 +307,8 @@ func (e *logExporterImp) consumeCentralQueueLogWindowAttempt(ctx context.Context
 	corruptPayloads := 0
 	droppedItems := 0
 	var firstDecodeErr error
-	for _, item := range window.items {
+	for i := range window.items {
+		item := window.items[i]
 		itemLogs, err := decodeCentralQueueLogsItem(item, e.centralCodec)
 		if err != nil {
 			corruptPayloads++

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -299,7 +299,8 @@ func (e *metricExporterImp) consumeCentralQueueMetricWindowAttempt(ctx context.C
 	corruptPayloads := 0
 	droppedItems := 0
 	var firstDecodeErr error
-	for _, item := range window.items {
+	for i := range window.items {
+		item := window.items[i]
 		itemMetrics, err := decodeCentralQueueMetricsItem(item, e.centralCodec)
 		if err != nil {
 			corruptPayloads++


### PR DESCRIPTION
Sanitized Sawmills fork metadata.

Summary: reduces central queue CPU spent on repeated backlog scans and slice compaction by building candidates in one pass and compacting removals in bulk.

Verification: covered by queue-drain benchmarks, exporter tests, and PR checks.