### PR TITLE
perf(ottl): fast-path string transforms

### DIFF
--- a/.chloggen/saw-7310-bigid-ottl-fastpaths.yaml
+++ b/.chloggen/saw-7310-bigid-ottl-fastpaths.yaml
@@ -1,0 +1,6 @@
+change_type: enhancement
+component: pkg/ottl
+note: Improve performance of BigID-heavy OTTL string transforms by fast-pathing leading escape removal and ASCII case-insensitive prefix/suffix checks.
+issues: [79]
+subtext:
+change_logs: [user]

--- a/pkg/ottl/ottlfuncs/func_replace_pattern.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern.go
@@ -100,6 +100,9 @@ func applyOptReplaceFunction[K any](ctx context.Context, tCtx K, compiledPattern
 }
 
 func replacePattern[K any](target ottl.GetSetter[K], regexPattern, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]], replacementFormat ottl.Optional[ottl.StringGetter[K]]) (ottl.ExprFunc[K], error) {
+	if fastPath := newFastReplacePattern(target, regexPattern, replacement, fn, replacementFormat); fastPath != nil {
+		return fastPath, nil
+	}
 	compiledPattern, err := newDynamicRegex("replace_pattern", regexPattern)
 	if err != nil {
 		return nil, err
@@ -144,4 +147,30 @@ func replacePattern[K any](target ottl.GetSetter[K], regexPattern, replacement o
 		}
 		return nil, nil
 	}, nil
+}
+
+func newFastReplacePattern[K any](target ottl.GetSetter[K], regexPattern, replacement ottl.StringGetter[K], fn ottl.Optional[ottl.FunctionGetter[K]], replacementFormat ottl.Optional[ottl.StringGetter[K]]) ottl.ExprFunc[K] {
+	if !fn.IsEmpty() || !replacementFormat.IsEmpty() {
+		return nil
+	}
+	pattern, patternLiteral := ottl.GetLiteralValue(regexPattern)
+	replacementValue, replacementLiteral := ottl.GetLiteralValue(replacement)
+	if !patternLiteral || !replacementLiteral {
+		return nil
+	}
+	if pattern != "^\x1b" || replacementValue != "" {
+		return nil
+	}
+	return func(ctx context.Context, tCtx K) (any, error) {
+		originalVal, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		if originalValStr, ok := originalVal.(string); ok && strings.HasPrefix(originalValStr, "\x1b") {
+			if err := target.Set(ctx, tCtx, originalValStr[1:]); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}
 }

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -254,6 +254,63 @@ func Test_replacePattern(t *testing.T) {
 	}
 }
 
+func Test_replacePattern_fastEscPrefix(t *testing.T) {
+	target := &ottl.StandardGetSetter[pcommon.Value]{
+		Getter: func(_ context.Context, tCtx pcommon.Value) (any, error) {
+			return tCtx.Str(), nil
+		},
+		Setter: func(_ context.Context, tCtx pcommon.Value, val any) error {
+			tCtx.SetStr(val.(string))
+			return nil
+		},
+	}
+	pattern, err := ottl.NewTestingLiteralGetter[pcommon.Value, string](true, ottl.StandardStringGetter[pcommon.Value]{
+		Getter: func(context.Context, pcommon.Value) (any, error) {
+			return "^\x1b", nil
+		},
+	})
+	require.NoError(t, err)
+	replacement, err := ottl.NewTestingLiteralGetter[pcommon.Value, string](true, ottl.StandardStringGetter[pcommon.Value]{
+		Getter: func(context.Context, pcommon.Value) (any, error) {
+			return "", nil
+		},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "prefix",
+			in:   "\x1b[32mmessage",
+			want: "[32mmessage",
+		},
+		{
+			name: "middle escape is not changed",
+			in:   "message\x1b[32m",
+			want: "message\x1b[32m",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value := pcommon.NewValueStr(tt.in)
+			exprFunc, err := replacePattern[pcommon.Value](target, pattern, replacement, ottl.Optional[ottl.FunctionGetter[pcommon.Value]]{}, ottl.Optional[ottl.StringGetter[pcommon.Value]]{})
+			require.NoError(t, err)
+			_, err = exprFunc(context.Background(), value)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, value.Str())
+		})
+	}
+}
+
 func Test_replacePattern_bad_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[any]{

--- a/pkg/ottl/sawmillsfuncs/func_endswith.go
+++ b/pkg/ottl/sawmillsfuncs/func_endswith.go
@@ -49,6 +49,30 @@ func endsWithAny(s string, suffixes []string) bool {
 	return false
 }
 
+func endsWithAnyFoldASCII(s string, suffixes []string) bool {
+	for _, suffix := range suffixes {
+		if len(suffix) > len(s) {
+			continue
+		}
+		offset := len(s) - len(suffix)
+		matches := true
+		for i := 0; i < len(suffix); i++ {
+			c := s[offset+i]
+			if c >= 'A' && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+			if c != suffix[i] {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
+}
+
 func endsWith[K any](
 	target ottl.StringGetter[K],
 	suffixes []string,
@@ -76,6 +100,9 @@ func endsWith[K any](
 			// Avoid lowercasing already-lowercase hot-path values.
 			if endsWithAny(val, suffixes) {
 				return true, nil
+			}
+			if isASCII(val) {
+				return endsWithAnyFoldASCII(val, suffixes), nil
 			}
 			val = strings.ToLower(val)
 		}

--- a/pkg/ottl/sawmillsfuncs/func_endswith.go
+++ b/pkg/ottl/sawmillsfuncs/func_endswith.go
@@ -73,17 +73,41 @@ func endsWithAnyFoldASCII(s string, suffixes []string) bool {
 	return false
 }
 
+func maxSuffixLen(suffixes []string) int {
+	maxLen := 0
+	for _, suffix := range suffixes {
+		if len(suffix) > maxLen {
+			maxLen = len(suffix)
+		}
+	}
+	return maxLen
+}
+
+func hasNonASCIIInSuffixWindow(s string, maxLen int) bool {
+	if maxLen > len(s) {
+		maxLen = len(s)
+	}
+	for i := len(s) - maxLen; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return true
+		}
+	}
+	return false
+}
+
 func endsWith[K any](
 	target ottl.StringGetter[K],
 	suffixes []string,
 	caseSensitive bool,
 ) ottl.ExprFunc[K] {
+	longestSuffix := 0
 	if !caseSensitive {
 		lowerSuffixes := make([]string, len(suffixes))
 		for i, suffix := range suffixes {
 			lowerSuffixes[i] = strings.ToLower(suffix)
 		}
 		suffixes = lowerSuffixes
+		longestSuffix = maxSuffixLen(suffixes)
 	}
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
@@ -101,8 +125,11 @@ func endsWith[K any](
 			if endsWithAny(val, suffixes) {
 				return true, nil
 			}
-			if isASCII(val) {
-				return endsWithAnyFoldASCII(val, suffixes), nil
+			if endsWithAnyFoldASCII(val, suffixes) {
+				return true, nil
+			}
+			if !hasNonASCIIInSuffixWindow(val, longestSuffix) {
+				return false, nil
 			}
 			val = strings.ToLower(val)
 		}

--- a/pkg/ottl/sawmillsfuncs/func_endswith_test.go
+++ b/pkg/ottl/sawmillsfuncs/func_endswith_test.go
@@ -5,6 +5,7 @@ package sawmillsfuncs
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,4 +93,65 @@ func TestEndsWithDoesNotMutateSuffixes(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, []string{"STRING"}, suffixes)
+}
+
+func TestEndsWithCaseInsensitiveUnicode(t *testing.T) {
+	cases := []struct {
+		name   string
+		value  string
+		suffix string
+		want   bool
+	}{
+		{"cyrillic upper haystack lower suffix", "hello МИР", "мир", true},
+		{"greek omega upper lower suffix", "hello Ω", "ω", true},
+		{"diacritic case", "log linË", "linë", true},
+		{"ascii haystack case-folded match", "MIXED Body Line", "line", true},
+		{"ascii haystack no-match stays false", "MIXED Body Line", "body", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := endsWith[any](
+				&ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return tc.value, nil },
+				},
+				[]string{tc.suffix},
+				false,
+			)
+			got, err := fn(t.Context(), nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEndsWithCaseInsensitiveASCIIFoldDoesNotAllocateByBodySize(t *testing.T) {
+	run := func(body string) (allocsPerOp, bytesPerOp float64) {
+		fn := endsWith(
+			&ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) { return body, nil },
+			},
+			[]string{"xyz-no-such-thing"},
+			false,
+		)
+		br := testing.Benchmark(func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				_, _ = fn(t.Context(), nil)
+			}
+		})
+		return float64(br.AllocsPerOp()), float64(br.AllocedBytesPerOp())
+	}
+
+	short := "Some MIXED-Case Body Line"
+	long := short + " " + strings.Repeat("Padding ", 2000)
+
+	shortAllocs, shortBytes := run(short)
+	longAllocs, longBytes := run(long)
+
+	require.LessOrEqualf(t, longAllocs, shortAllocs+1,
+		"endsWith allocations scaled with body size: %.1f short -> %.1f long", shortAllocs, longAllocs)
+	require.LessOrEqualf(t, longAllocs, 5.0,
+		"endsWith allocated %.1f objects per run on a 16 kB body", longAllocs)
+	require.LessOrEqualf(t, longBytes, shortBytes+512,
+		"endsWith bytes/op scaled with body size: %.1f short -> %.1f long", shortBytes, longBytes)
 }

--- a/pkg/ottl/sawmillsfuncs/func_endswith_test.go
+++ b/pkg/ottl/sawmillsfuncs/func_endswith_test.go
@@ -155,3 +155,35 @@ func TestEndsWithCaseInsensitiveASCIIFoldDoesNotAllocateByBodySize(t *testing.T)
 	require.LessOrEqualf(t, longBytes, shortBytes+512,
 		"endsWith bytes/op scaled with body size: %.1f short -> %.1f long", shortBytes, longBytes)
 }
+
+func TestEndsWithCaseInsensitiveSuffixWindowDoesNotAllocateByBodySize(t *testing.T) {
+	run := func(body string) (allocsPerOp, bytesPerOp float64) {
+		fn := endsWith(
+			&ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) { return body, nil },
+			},
+			[]string{"xyz-no-such-thing"},
+			false,
+		)
+		br := testing.Benchmark(func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				_, _ = fn(t.Context(), nil)
+			}
+		})
+		return float64(br.AllocsPerOp()), float64(br.AllocedBytesPerOp())
+	}
+
+	short := "Привет Some MIXED-Case Body Line"
+	long := "Привет " + strings.Repeat("Padding ", 2000) + "Some MIXED-Case Body Line"
+
+	shortAllocs, shortBytes := run(short)
+	longAllocs, longBytes := run(long)
+
+	require.LessOrEqualf(t, longAllocs, shortAllocs+1,
+		"endsWith allocations scaled with body size: %.1f short -> %.1f long", shortAllocs, longAllocs)
+	require.LessOrEqualf(t, longAllocs, 5.0,
+		"endsWith allocated %.1f objects per run on a body with non-ASCII outside the suffix window", longAllocs)
+	require.LessOrEqualf(t, longBytes, shortBytes+512,
+		"endsWith bytes/op scaled with body size when non-ASCII was outside the suffix window: %.1f short -> %.1f long", shortBytes, longBytes)
+}

--- a/pkg/ottl/sawmillsfuncs/func_startswith.go
+++ b/pkg/ottl/sawmillsfuncs/func_startswith.go
@@ -49,17 +49,75 @@ func startsWithAny(s string, prefixes []string) bool {
 	return false
 }
 
+func startsWithAnyFoldASCII(s string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if len(prefix) > len(s) {
+			continue
+		}
+		matches := true
+		for i := 0; i < len(prefix); i++ {
+			c := s[i]
+			if c >= 'A' && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+			if c != prefix[i] {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
+}
+
+func maxPrefixLen(prefixes []string) int {
+	maxLen := 0
+	for _, prefix := range prefixes {
+		if len(prefix) > maxLen {
+			maxLen = len(prefix)
+		}
+	}
+	return maxLen
+}
+
+func allASCII(prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if !isASCII(prefix) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasNonASCIIInPrefixWindow(s string, maxLen int) bool {
+	if maxLen > len(s) {
+		maxLen = len(s)
+	}
+	for i := 0; i < maxLen; i++ {
+		if s[i] >= 0x80 {
+			return true
+		}
+	}
+	return false
+}
+
 func startsWith[K any](
 	target ottl.StringGetter[K],
 	prefixes []string,
 	caseSensitive bool,
 ) ottl.ExprFunc[K] {
+	asciiPrefixes := false
+	longestPrefix := 0
 	if !caseSensitive {
 		lowerPrefixes := make([]string, len(prefixes))
 		for i, prefix := range prefixes {
 			lowerPrefixes[i] = strings.ToLower(prefix)
 		}
 		prefixes = lowerPrefixes
+		asciiPrefixes = allASCII(prefixes)
+		longestPrefix = maxPrefixLen(prefixes)
 	}
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
@@ -76,6 +134,16 @@ func startsWith[K any](
 			// Avoid lowercasing already-lowercase hot-path values.
 			if startsWithAny(val, prefixes) {
 				return true, nil
+			}
+			if startsWithAnyFoldASCII(val, prefixes) {
+				return true, nil
+			}
+			if asciiPrefixes {
+				if !hasNonASCIIInPrefixWindow(val, longestPrefix) {
+					return false, nil
+				}
+			} else if isASCII(val) {
+				return false, nil
 			}
 			val = strings.ToLower(val)
 		}

--- a/pkg/ottl/sawmillsfuncs/func_startswith_test.go
+++ b/pkg/ottl/sawmillsfuncs/func_startswith_test.go
@@ -5,6 +5,7 @@ package sawmillsfuncs
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -92,4 +93,79 @@ func TestStartsWithDoesNotMutatePrefixes(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, []string{"THIS"}, prefixes)
+}
+
+func TestStartsWithCaseInsensitiveUnicode(t *testing.T) {
+	cases := []struct {
+		name   string
+		value  string
+		prefix string
+		want   bool
+	}{
+		{"cyrillic upper haystack lower prefix", "Привет мир", "привет", true},
+		{"greek omega upper lower prefix", "Ωmega", "ω", true},
+		{"diacritic case", "Ëxample log line", "ëxample", true},
+		{"unicode fallback for ascii prefix", "\u212aelvin log line", "kelvin", true},
+		{"ascii haystack case-folded match", "MIXED Body Line", "mixed", true},
+		{"ascii haystack no-match stays false", "MIXED Body Line", "body", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := startsWith[any](
+				&ottl.StandardStringGetter[any]{
+					Getter: func(context.Context, any) (any, error) { return tc.value, nil },
+				},
+				[]string{tc.prefix},
+				false,
+			)
+			got, err := fn(t.Context(), nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestStartsWithCaseInsensitiveMixedASCIIPrefixes(t *testing.T) {
+	fn := startsWith[any](
+		&ottl.StandardStringGetter[any]{
+			Getter: func(context.Context, any) (any, error) { return "MIXED Body Line", nil },
+		},
+		[]string{"ω", "mixed"},
+		false,
+	)
+	got, err := fn(t.Context(), nil)
+	require.NoError(t, err)
+	require.Equal(t, true, got)
+}
+
+func TestStartsWithCaseInsensitiveASCIIFoldDoesNotAllocateByBodySize(t *testing.T) {
+	run := func(body string) (allocsPerOp, bytesPerOp float64) {
+		fn := startsWith(
+			&ottl.StandardStringGetter[any]{
+				Getter: func(context.Context, any) (any, error) { return body, nil },
+			},
+			[]string{"xyz-no-such-thing"},
+			false,
+		)
+		br := testing.Benchmark(func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				_, _ = fn(t.Context(), nil)
+			}
+		})
+		return float64(br.AllocsPerOp()), float64(br.AllocedBytesPerOp())
+	}
+
+	short := "Some MIXED-Case Body Line"
+	long := short + " " + strings.Repeat("Padding ", 2000)
+
+	shortAllocs, shortBytes := run(short)
+	longAllocs, longBytes := run(long)
+
+	require.LessOrEqualf(t, longAllocs, shortAllocs+1,
+		"startsWith allocations scaled with body size: %.1f short -> %.1f long", shortAllocs, longAllocs)
+	require.LessOrEqualf(t, longAllocs, 5.0,
+		"startsWith allocated %.1f objects per run on a 16 kB body", longAllocs)
+	require.LessOrEqualf(t, longBytes, shortBytes+512,
+		"startsWith bytes/op scaled with body size: %.1f short -> %.1f long", shortBytes, longBytes)
 }


### PR DESCRIPTION
ottl: Fast-path string transforms

Keep the trusted OTTL performance changes on a clean main branch.

- fast-path replace_pattern(body, \"^\\x1b\", \"\") without regex work
- avoid per-record body-sized lowercase allocations for StartsWith/EndsWith ASCII cases
- gate EndsWith Unicode fallback on the suffix window and preserve Unicode correctness

Verification:
- go test ./sawmillsfuncs -run 'TestEndsWithCaseInsensitive(SuffixWindowDoesNotAllocateByBodySize|ASCIIFoldDoesNotAllocateByBodySize|Unicode)' -count=1
- go test ./ottlfuncs ./sawmillsfuncs -count=1
- make test (from pkg/ottl)