### PR TITLE
fix(loadbalancingexporter): split oversized central queue log items

### DIFF
--- a/exporter/loadbalancingexporter/central_queue_logs_splitter.go
+++ b/exporter/loadbalancingexporter/central_queue_logs_splitter.go
@@ -15,10 +15,11 @@ import (
 const centralQueueLogSplitHeadroom = 4096
 
 type centralQueueLogSplitter struct {
-	exporter *logExporterImp
-	codec    *queuePayloadCodec
-	limit    int
-	now      time.Time
+	exporter  *logExporterImp
+	codec     *queuePayloadCodec
+	hardLimit int
+	limit     int
+	now       time.Time
 
 	marshaler              *plog.ProtoMarshaler
 	emptyTraceFallbackKeys map[[2]int]pcommon.TraceID
@@ -56,6 +57,7 @@ func newCentralQueueLogSplitter(exporter *logExporterImp, limit int, now time.Ti
 	return &centralQueueLogSplitter{
 		exporter:               exporter,
 		codec:                  exporter.centralCodec,
+		hardLimit:              limit,
 		limit:                  effectiveLimit,
 		now:                    now,
 		marshaler:              &plog.ProtoMarshaler{},
@@ -64,7 +66,19 @@ func newCentralQueueLogSplitter(exporter *logExporterImp, limit int, now time.Ti
 	}
 }
 
-func (s *centralQueueLogSplitter) consume(_ context.Context, ld plog.Logs) error {
+func centralQueueEffectiveUncompressedItemLimit(settings centralQueueSettings) int {
+	limit := settings.maxUncompressedBatchBytes
+	if settings.maxInflightUncompressedBytes > 0 && (limit <= 0 || settings.maxInflightUncompressedBytes < int64(limit)) {
+		limit = int(settings.maxInflightUncompressedBytes)
+	}
+	return limit
+}
+
+func (s *centralQueueLogSplitter) consume(ctx context.Context, ld plog.Logs) error {
+	if err := s.rejectUnsplittableRecords(ctx, ld); err != nil {
+		return err
+	}
+
 	var errs error
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rl := ld.ResourceLogs().At(i)
@@ -77,8 +91,7 @@ func (s *centralQueueLogSplitter) consume(_ context.Context, ld plog.Logs) error
 				lane := s.lane(queueRoutingKey)
 				if !lane.empty() && !lane.canFit(rl, sl, rec, s.marshaler, s.limit) {
 					if err := s.flushLane(lane); err != nil {
-						errs = multierr.Append(errs, err)
-						continue
+						return multierr.Append(errs, err)
 					}
 				}
 				lane.appendRecord(rl, sl, rec, s.marshaler)
@@ -90,6 +103,37 @@ func (s *centralQueueLogSplitter) consume(_ context.Context, ld plog.Logs) error
 		errs = multierr.Append(errs, s.flushLane(lane))
 	}
 	return errs
+}
+
+func (s *centralQueueLogSplitter) rejectUnsplittableRecords(ctx context.Context, ld plog.Logs) error {
+	if s.hardLimit <= 0 {
+		return nil
+	}
+
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rl := ld.ResourceLogs().At(i)
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				single := plog.NewLogs()
+				insertLogRecord(single, rl, sl, sl.LogRecords().At(k))
+				payload, err := s.marshaler.MarshalLogs(single)
+				if err != nil {
+					return err
+				}
+				if len(payload) <= s.hardLimit {
+					continue
+				}
+				encoded, err := s.codec.Encode(payload)
+				if err != nil {
+					return err
+				}
+				s.exporter.centralQueue.settings.telemetry.recordRejected(ctx, int64(len(encoded)))
+				return errCentralQueueItemTooLarge
+			}
+		}
+	}
+	return nil
 }
 
 func (s *centralQueueLogSplitter) lane(routingKey []byte) *centralQueueLogLaneBuilder {
@@ -154,8 +198,7 @@ func (s *centralQueueLogSplitter) flushLane(lane *centralQueueLogLaneBuilder) er
 }
 
 func (s *centralQueueLogSplitter) itemExceedsLimit(item centralQueueItem) bool {
-	hardLimit := s.exporter.centralQueue.settings.maxUncompressedBatchBytes
-	return hardLimit > 0 && item.uncompressedBytes > hardLimit
+	return s.hardLimit > 0 && item.uncompressedBytes > s.hardLimit
 }
 
 func (s *centralQueueLogSplitter) exactSplitAndEnqueue(routingKey []byte, logs plog.Logs) error {
@@ -201,7 +244,6 @@ func (s *centralQueueLogSplitter) exactSplitAndEnqueue(routingKey []byte, logs p
 					if err := flushCurrent(); err != nil {
 						return err
 					}
-					current = plog.NewLogs()
 					insertLogRecord(current, rl, sl, rec)
 					currentRecords = 1
 					singleItem, singleErr := newCentralQueueLogsItem(routingKey, current, s.codec, s.now)

--- a/exporter/loadbalancingexporter/central_queue_logs_splitter.go
+++ b/exporter/loadbalancingexporter/central_queue_logs_splitter.go
@@ -1,0 +1,323 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.uber.org/multierr"
+)
+
+const centralQueueLogSplitHeadroom = 4096
+
+type centralQueueLogSplitter struct {
+	exporter *logExporterImp
+	codec    *queuePayloadCodec
+	limit    int
+	now      time.Time
+
+	marshaler              *plog.ProtoMarshaler
+	emptyTraceFallbackKeys map[[2]int]pcommon.TraceID
+	lanes                  map[string]*centralQueueLogLaneBuilder
+}
+
+type centralQueueLogLaneBuilder struct {
+	routingKey []byte
+	logs       plog.Logs
+	size       *centralQueueLogSizeState
+	records    int
+}
+
+type centralQueueLogSizeState struct {
+	resources []centralQueueLogResourceSizeState
+	bytes     int
+}
+
+type centralQueueLogResourceSizeState struct {
+	resource plog.ResourceLogs
+	size     int
+	scopes   []centralQueueLogScopeSizeState
+}
+
+type centralQueueLogScopeSizeState struct {
+	scope plog.ScopeLogs
+	size  int
+}
+
+func newCentralQueueLogSplitter(exporter *logExporterImp, limit int, now time.Time) *centralQueueLogSplitter {
+	effectiveLimit := limit
+	if effectiveLimit > centralQueueLogSplitHeadroom {
+		effectiveLimit -= centralQueueLogSplitHeadroom
+	}
+	return &centralQueueLogSplitter{
+		exporter:               exporter,
+		codec:                  exporter.centralCodec,
+		limit:                  effectiveLimit,
+		now:                    now,
+		marshaler:              &plog.ProtoMarshaler{},
+		emptyTraceFallbackKeys: make(map[[2]int]pcommon.TraceID),
+		lanes:                  make(map[string]*centralQueueLogLaneBuilder),
+	}
+}
+
+func (s *centralQueueLogSplitter) consume(_ context.Context, ld plog.Logs) error {
+	var errs error
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		rl := ld.ResourceLogs().At(i)
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				rec := sl.LogRecords().At(k)
+				balancingKey := s.exporter.routingKeyForLogRecord(rec, [2]int{i, j}, s.emptyTraceFallbackKeys)
+				queueRoutingKey := centralQueueLaneRoutingKey(signalKindLogs, balancingKey[:], s.exporter.centralQueueLaneCount)
+				lane := s.lane(queueRoutingKey)
+				if !lane.empty() && !lane.canFit(rl, sl, rec, s.marshaler, s.limit) {
+					if err := s.flushLane(lane); err != nil {
+						errs = multierr.Append(errs, err)
+						continue
+					}
+				}
+				lane.appendRecord(rl, sl, rec, s.marshaler)
+			}
+		}
+	}
+
+	for _, lane := range s.lanes {
+		errs = multierr.Append(errs, s.flushLane(lane))
+	}
+	return errs
+}
+
+func (s *centralQueueLogSplitter) lane(routingKey []byte) *centralQueueLogLaneBuilder {
+	key := string(routingKey)
+	lane, ok := s.lanes[key]
+	if ok {
+		return lane
+	}
+	lane = newCentralQueueLogLaneBuilder(routingKey)
+	s.lanes[key] = lane
+	return lane
+}
+
+func newCentralQueueLogLaneBuilder(routingKey []byte) *centralQueueLogLaneBuilder {
+	return &centralQueueLogLaneBuilder{
+		routingKey: append([]byte(nil), routingKey...),
+		logs:       plog.NewLogs(),
+		size:       &centralQueueLogSizeState{},
+	}
+}
+
+func (b *centralQueueLogLaneBuilder) empty() bool {
+	return b.records == 0
+}
+
+func (b *centralQueueLogLaneBuilder) reset() {
+	b.logs = plog.NewLogs()
+	b.size.reset()
+	b.records = 0
+}
+
+func (b *centralQueueLogLaneBuilder) canFit(srcRL plog.ResourceLogs, srcSL plog.ScopeLogs, rec plog.LogRecord, marshaler *plog.ProtoMarshaler, limit int) bool {
+	if limit <= 0 {
+		return true
+	}
+	return b.size.bytes+b.size.deltaForRecord(srcRL, srcSL, rec, marshaler) <= limit
+}
+
+func (b *centralQueueLogLaneBuilder) appendRecord(srcRL plog.ResourceLogs, srcSL plog.ScopeLogs, rec plog.LogRecord, marshaler *plog.ProtoMarshaler) {
+	b.size.addRecord(srcRL, srcSL, rec, marshaler)
+	insertLogRecord(b.logs, srcRL, srcSL, rec)
+	b.records++
+}
+
+func (s *centralQueueLogSplitter) flushLane(lane *centralQueueLogLaneBuilder) error {
+	if lane.empty() {
+		return nil
+	}
+	defer lane.reset()
+
+	item, err := newCentralQueueLogsItem(lane.routingKey, lane.logs, s.codec, s.now)
+	if err != nil {
+		return err
+	}
+	if !s.itemExceedsLimit(item) {
+		return s.exporter.centralQueue.enqueue(item)
+	}
+	if lane.records == 1 {
+		return errCentralQueueItemTooLarge
+	}
+	return s.exactSplitAndEnqueue(lane.routingKey, lane.logs)
+}
+
+func (s *centralQueueLogSplitter) itemExceedsLimit(item centralQueueItem) bool {
+	hardLimit := s.exporter.centralQueue.settings.maxUncompressedBatchBytes
+	return hardLimit > 0 && item.uncompressedBytes > hardLimit
+}
+
+func (s *centralQueueLogSplitter) exactSplitAndEnqueue(routingKey []byte, logs plog.Logs) error {
+	current := plog.NewLogs()
+	currentRecords := 0
+
+	flushCurrent := func() error {
+		if currentRecords == 0 {
+			return nil
+		}
+		item, err := newCentralQueueLogsItem(routingKey, current, s.codec, s.now)
+		if err == nil && s.itemExceedsLimit(item) {
+			err = errCentralQueueItemTooLarge
+		}
+		if err == nil {
+			err = s.exporter.centralQueue.enqueue(item)
+		}
+		if err != nil {
+			return err
+		}
+		current = plog.NewLogs()
+		currentRecords = 0
+		return nil
+	}
+
+	for i := 0; i < logs.ResourceLogs().Len(); i++ {
+		rl := logs.ResourceLogs().At(i)
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				rec := sl.LogRecords().At(k)
+				candidate := plog.NewLogs()
+				current.CopyTo(candidate)
+				insertLogRecord(candidate, rl, sl, rec)
+				item, err := newCentralQueueLogsItem(routingKey, candidate, s.codec, s.now)
+				if err != nil {
+					return err
+				}
+				if s.itemExceedsLimit(item) {
+					if currentRecords == 0 {
+						return errCentralQueueItemTooLarge
+					}
+					if err := flushCurrent(); err != nil {
+						return err
+					}
+					current = plog.NewLogs()
+					insertLogRecord(current, rl, sl, rec)
+					currentRecords = 1
+					singleItem, singleErr := newCentralQueueLogsItem(routingKey, current, s.codec, s.now)
+					if singleErr == nil && s.itemExceedsLimit(singleItem) {
+						singleErr = errCentralQueueItemTooLarge
+					}
+					if singleErr != nil {
+						return singleErr
+					}
+					continue
+				}
+				current = candidate
+				currentRecords++
+			}
+		}
+	}
+	return flushCurrent()
+}
+
+func (s *centralQueueLogSizeState) reset() {
+	s.resources = nil
+	s.bytes = 0
+}
+
+func (s *centralQueueLogSizeState) deltaForRecord(srcRL plog.ResourceLogs, srcSL plog.ScopeLogs, rec plog.LogRecord, marshaler *plog.ProtoMarshaler) int {
+	recordDelta := logProtoDeltaSize(marshaler.LogRecordSize(rec))
+	resourceIndex := s.findResource(srcRL)
+	if resourceIndex == -1 {
+		resource := plog.NewLogs().ResourceLogs().AppendEmpty()
+		srcRL.Resource().CopyTo(resource.Resource())
+		resource.SetSchemaUrl(srcRL.SchemaUrl())
+		resourceSize := marshaler.ResourceLogsSize(resource)
+		scope := plog.NewLogs().ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty()
+		srcSL.Scope().CopyTo(scope.Scope())
+		scope.SetSchemaUrl(srcSL.SchemaUrl())
+		scopeSize := marshaler.ScopeLogsSize(scope) + recordDelta
+		return logProtoDeltaSize(resourceSize + logProtoDeltaSize(scopeSize))
+	}
+
+	resource := s.resources[resourceIndex]
+	scopeIndex := s.findScope(resourceIndex, srcSL)
+	if scopeIndex == -1 {
+		scope := plog.NewLogs().ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty()
+		srcSL.Scope().CopyTo(scope.Scope())
+		scope.SetSchemaUrl(srcSL.SchemaUrl())
+		scopeSize := marshaler.ScopeLogsSize(scope) + recordDelta
+		newResourceSize := resource.size + logProtoDeltaSize(scopeSize)
+		return logProtoDeltaSize(newResourceSize) - logProtoDeltaSize(resource.size)
+	}
+
+	oldScopeSize := resource.scopes[scopeIndex].size
+	newScopeSize := oldScopeSize + recordDelta
+	newResourceSize := resource.size + logProtoDeltaSize(newScopeSize) - logProtoDeltaSize(oldScopeSize)
+	return logProtoDeltaSize(newResourceSize) - logProtoDeltaSize(resource.size)
+}
+
+func (s *centralQueueLogSizeState) addRecord(srcRL plog.ResourceLogs, srcSL plog.ScopeLogs, rec plog.LogRecord, marshaler *plog.ProtoMarshaler) {
+	delta := s.deltaForRecord(srcRL, srcSL, rec, marshaler)
+	s.bytes += delta
+
+	recordDelta := logProtoDeltaSize(marshaler.LogRecordSize(rec))
+	resourceIndex := s.findResource(srcRL)
+	if resourceIndex == -1 {
+		resource := plog.NewLogs().ResourceLogs().AppendEmpty()
+		srcRL.Resource().CopyTo(resource.Resource())
+		resource.SetSchemaUrl(srcRL.SchemaUrl())
+		resourceSize := marshaler.ResourceLogsSize(resource)
+		scope := resource.ScopeLogs().AppendEmpty()
+		srcSL.Scope().CopyTo(scope.Scope())
+		scope.SetSchemaUrl(srcSL.SchemaUrl())
+		scopeSize := marshaler.ScopeLogsSize(scope) + recordDelta
+		s.resources = append(s.resources, centralQueueLogResourceSizeState{
+			resource: resource,
+			size:     resourceSize + logProtoDeltaSize(scopeSize),
+			scopes: []centralQueueLogScopeSizeState{{
+				scope: scope,
+				size:  scopeSize,
+			}},
+		})
+		return
+	}
+
+	scopeIndex := s.findScope(resourceIndex, srcSL)
+	if scopeIndex == -1 {
+		scope := s.resources[resourceIndex].resource.ScopeLogs().AppendEmpty()
+		srcSL.Scope().CopyTo(scope.Scope())
+		scope.SetSchemaUrl(srcSL.SchemaUrl())
+		scopeSize := marshaler.ScopeLogsSize(scope) + recordDelta
+		s.resources[resourceIndex].scopes = append(s.resources[resourceIndex].scopes, centralQueueLogScopeSizeState{
+			scope: scope,
+			size:  scopeSize,
+		})
+		s.resources[resourceIndex].size += logProtoDeltaSize(scopeSize)
+		return
+	}
+
+	oldScopeSize := s.resources[resourceIndex].scopes[scopeIndex].size
+	newScopeSize := oldScopeSize + recordDelta
+	s.resources[resourceIndex].scopes[scopeIndex].size = newScopeSize
+	s.resources[resourceIndex].size += logProtoDeltaSize(newScopeSize) - logProtoDeltaSize(oldScopeSize)
+}
+
+func (s *centralQueueLogSizeState) findResource(resource plog.ResourceLogs) int {
+	for i, existing := range s.resources {
+		if resourceLogsMatches(existing.resource, resource) {
+			return i
+		}
+	}
+	return -1
+}
+
+func (s *centralQueueLogSizeState) findScope(resourceIndex int, scope plog.ScopeLogs) int {
+	for i, existing := range s.resources[resourceIndex].scopes {
+		if scopeLogsMatches(existing.scope, scope) {
+			return i
+		}
+	}
+	return -1
+}

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -198,7 +198,7 @@ func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 }
 
 func (e *logExporterImp) consumeLogsCentralQueue(ctx context.Context, ld plog.Logs) error {
-	splitter := newCentralQueueLogSplitter(e, e.centralQueue.settings.maxUncompressedBatchBytes, time.Now())
+	splitter := newCentralQueueLogSplitter(e, centralQueueEffectiveUncompressedItemLimit(e.centralQueue.settings), time.Now())
 	return splitter.consume(ctx, ld)
 }
 

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -197,44 +197,9 @@ func (e *logExporterImp) ConsumeLogs(ctx context.Context, ld plog.Logs) error {
 	return e.consumeLogsBatched(ctx, ld)
 }
 
-func (e *logExporterImp) consumeLogsCentralQueue(_ context.Context, ld plog.Logs) error {
-	batches := e.groupLogsByRoutingKey(ld)
-	var errs error
-	now := time.Now()
-	for routingKey, logs := range batches {
-		queueRoutingKey := centralQueueLaneRoutingKey(signalKindLogs, routingKey[:], e.centralQueueLaneCount)
-		item, err := newCentralQueueLogsItem(queueRoutingKey, logs, e.centralCodec, now)
-		if err != nil {
-			errs = multierr.Append(errs, err)
-			continue
-		}
-		errs = multierr.Append(errs, e.centralQueue.enqueue(item))
-	}
-	return errs
-}
-
-func (e *logExporterImp) groupLogsByRoutingKey(ld plog.Logs) map[pcommon.TraceID]plog.Logs {
-	batches := make(map[pcommon.TraceID]plog.Logs)
-	emptyTraceFallbackKeys := make(map[[2]int]pcommon.TraceID)
-
-	for i := 0; i < ld.ResourceLogs().Len(); i++ {
-		rl := ld.ResourceLogs().At(i)
-		for j := 0; j < rl.ScopeLogs().Len(); j++ {
-			sl := rl.ScopeLogs().At(j)
-			for k := 0; k < sl.LogRecords().Len(); k++ {
-				rec := sl.LogRecords().At(k)
-				balancingKey := e.routingKeyForLogRecord(rec, [2]int{i, j}, emptyTraceFallbackKeys)
-				batch, ok := batches[balancingKey]
-				if !ok {
-					batch = plog.NewLogs()
-					batches[balancingKey] = batch
-				}
-				insertLogRecord(batch, rl, sl, rec)
-			}
-		}
-	}
-
-	return batches
+func (e *logExporterImp) consumeLogsCentralQueue(ctx context.Context, ld plog.Logs) error {
+	splitter := newCentralQueueLogSplitter(e, e.centralQueue.settings.maxUncompressedBatchBytes, time.Now())
+	return splitter.consume(ctx, ld)
 }
 
 func (e *logExporterImp) runCentralQueue(ctx context.Context) {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -253,6 +254,95 @@ func TestConsumeLogsCentralQueueUsesLaneRoutingForIgnoredTraceIDs(t *testing.T) 
 		mergeLogChunksByMove(merged, decoded)
 	}
 	require.Equal(t, first.LogRecordCount(), merged.LogRecordCount())
+}
+
+func TestConsumeLogsCentralQueueSplitsOversizedLogBatchByUncompressedBytes(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	logs := sharedScopeLogsWithoutTraceIDs(repeatedStrings(20, strings.Repeat("a", 512))...)
+	limit := mustMarshalLogsSize(t, firstNLogRecords(logs, 4)) + 32
+	fallbackRoutingKey := pcommon.TraceID{7}
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    limit,
+			targetCompressedBytes:        1 << 20,
+		}),
+		centralCodec:          codec,
+		ignoreTraceID:         true,
+		centralQueueLaneCount: 64,
+		randomTraceID: func() pcommon.TraceID {
+			return fallbackRoutingKey
+		},
+	}
+	p.started.Store(true)
+
+	require.NoError(t, p.ConsumeLogs(t.Context(), logs))
+	require.Greater(t, p.centralQueue.len(), 1)
+
+	expectedRoutingKey := centralQueueLaneRoutingKey(signalKindLogs, fallbackRoutingKey[:], 64)
+	merged := plog.NewLogs()
+	for _, item := range p.centralQueue.items {
+		require.LessOrEqual(t, item.uncompressedBytes, limit)
+		require.Equal(t, expectedRoutingKey, item.routingKey)
+		decoded, err := decodeCentralQueueLogsItem(item, codec)
+		require.NoError(t, err)
+		mergeLogChunksByMove(merged, decoded)
+	}
+	require.NoError(t, plogtest.CompareLogs(logs, merged))
+}
+
+func TestConsumeLogsCentralQueueRejectsSingleOversizedLogRecord(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    512,
+		}),
+		centralCodec:          codec,
+		centralQueueLaneCount: 64,
+	}
+	p.started.Store(true)
+
+	err := p.ConsumeLogs(t.Context(), sharedResourceScopeLog(strings.Repeat("a", 2048)))
+	require.ErrorIs(t, err, errCentralQueueItemTooLarge)
+	require.Equal(t, 0, p.centralQueue.len())
+}
+
+func TestConsumeLogsCentralQueueSplitsBySizeNotRawRoutingKey(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	logs := sharedScopeLogsWithTraceIDs(repeatedTraceIDs(8)...)
+	limit := mustMarshalLogsSize(t, firstNLogRecords(logs, 4)) + 32
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    limit,
+			targetCompressedBytes:        1 << 20,
+		}),
+		centralCodec:          codec,
+		centralQueueLaneCount: 1,
+	}
+	p.started.Store(true)
+
+	require.NoError(t, p.ConsumeLogs(t.Context(), logs))
+	require.Greater(t, p.centralQueue.len(), 1)
+	require.Less(t, p.centralQueue.len(), logs.LogRecordCount())
+
+	expectedRoutingKey := centralQueueLaneRoutingKey(signalKindLogs, []byte{1}, 1)
+	merged := plog.NewLogs()
+	for _, item := range p.centralQueue.items {
+		require.LessOrEqual(t, item.uncompressedBytes, limit)
+		require.Equal(t, expectedRoutingKey, item.routingKey)
+		decoded, err := decodeCentralQueueLogsItem(item, codec)
+		require.NoError(t, err)
+		mergeLogChunksByMove(merged, decoded)
+	}
+	require.NoError(t, plogtest.CompareLogs(logs, merged))
 }
 
 func TestLogsCentralQueueWindowUsesRoutingKeyWhenIgnoringTraceIDs(t *testing.T) {
@@ -1910,6 +2000,61 @@ func sharedScopeLogsWithoutTraceIDs(bodies ...string) plog.Logs {
 		rec.Body().SetStr(body)
 	}
 	return logs
+}
+
+func sharedScopeLogsWithTraceIDs(traceIDs ...pcommon.TraceID) plog.Logs {
+	logs := plog.NewLogs()
+	rl := logs.ResourceLogs().AppendEmpty()
+	rl.Resource().Attributes().PutStr("resource", "shared")
+	sl := rl.ScopeLogs().AppendEmpty()
+	sl.Scope().SetName("shared-scope")
+	for i, traceID := range traceIDs {
+		rec := sl.LogRecords().AppendEmpty()
+		rec.SetTraceID(traceID)
+		rec.Body().SetStr(fmt.Sprintf("body-%d-%s", i, strings.Repeat("a", 128)))
+	}
+	return logs
+}
+
+func repeatedTraceIDs(count int) []pcommon.TraceID {
+	traceIDs := make([]pcommon.TraceID, 0, count)
+	for i := 0; i < count; i++ {
+		traceID := pcommon.TraceID{}
+		copy(traceID[:], strconv.Itoa(i+1))
+		traceIDs = append(traceIDs, traceID)
+	}
+	return traceIDs
+}
+
+func repeatedStrings(count int, value string) []string {
+	values := make([]string, count)
+	for i := range values {
+		values[i] = value
+	}
+	return values
+}
+
+func firstNLogRecords(src plog.Logs, count int) plog.Logs {
+	logs := plog.NewLogs()
+	copied := 0
+	for i := 0; i < src.ResourceLogs().Len() && copied < count; i++ {
+		rl := src.ResourceLogs().At(i)
+		for j := 0; j < rl.ScopeLogs().Len() && copied < count; j++ {
+			sl := rl.ScopeLogs().At(j)
+			for k := 0; k < sl.LogRecords().Len() && copied < count; k++ {
+				insertLogRecord(logs, rl, sl, sl.LogRecords().At(k))
+				copied++
+			}
+		}
+	}
+	return logs
+}
+
+func mustMarshalLogsSize(t *testing.T, logs plog.Logs) int {
+	t.Helper()
+	payload, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
+	require.NoError(t, err)
+	return len(payload)
 }
 
 func simpleLogWithoutID() plog.Logs {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -312,6 +312,101 @@ func TestConsumeLogsCentralQueueRejectsSingleOversizedLogRecord(t *testing.T) {
 	require.Equal(t, 0, p.centralQueue.len())
 }
 
+func TestConsumeLogsCentralQueueRecordsRejectedMetricForSingleOversizedLogRecord(t *testing.T) {
+	reader := componenttest.NewTelemetry()
+	t.Cleanup(func() {
+		require.NoError(t, reader.Shutdown(context.WithoutCancel(t.Context())))
+	})
+	telemetry, err := newCentralQueueTelemetry(reader.NewTelemetrySettings(), signalKindLogs)
+	require.NoError(t, err)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionNone)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	logs := sharedResourceScopeLog(strings.Repeat("a", 2048))
+	payload, err := (&plog.ProtoMarshaler{}).MarshalLogs(logs)
+	require.NoError(t, err)
+	encoded, err := codec.Encode(payload)
+	require.NoError(t, err)
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    512,
+			telemetry:                    telemetry,
+		}),
+		centralCodec:          codec,
+		centralQueueLaneCount: 64,
+	}
+	p.started.Store(true)
+
+	err = p.ConsumeLogs(t.Context(), logs)
+	require.ErrorIs(t, err, errCentralQueueItemTooLarge)
+	require.Equal(t, 0, p.centralQueue.len())
+	requireCentralQueueIntSum(
+		t,
+		reader,
+		"otelcol_loadbalancer_central_queue_rejected_compressed_bytes",
+		"By",
+		attribute.NewSet(attribute.String("signal", string(signalKindLogs))),
+		int64(len(encoded)),
+	)
+}
+
+func TestConsumeLogsCentralQueueRejectsOversizedLogRecordBeforePartialEnqueue(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    768,
+		}),
+		centralCodec:          codec,
+		ignoreTraceID:         true,
+		centralQueueLaneCount: 64,
+		randomTraceID: func() pcommon.TraceID {
+			return pcommon.TraceID{7}
+		},
+	}
+	p.started.Store(true)
+	logs := sharedScopeLogsWithoutTraceIDs(
+		strings.Repeat("a", 512),
+		strings.Repeat("b", 512),
+		strings.Repeat("c", 2048),
+	)
+
+	err := p.ConsumeLogs(t.Context(), logs)
+	require.ErrorIs(t, err, errCentralQueueItemTooLarge)
+	require.Equal(t, 0, p.centralQueue.len())
+}
+
+func TestConsumeLogsCentralQueueSplitsAtInflightUncompressedLimit(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	logs := sharedScopeLogsWithoutTraceIDs(repeatedStrings(12, strings.Repeat("a", 512))...)
+	inflightLimit := mustMarshalLogsSize(t, firstNLogRecords(logs, 3)) + 32
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: int64(inflightLimit),
+			maxUncompressedBatchBytes:    1 << 20,
+			targetCompressedBytes:        1 << 20,
+		}),
+		centralCodec:          codec,
+		ignoreTraceID:         true,
+		centralQueueLaneCount: 64,
+		randomTraceID: func() pcommon.TraceID {
+			return pcommon.TraceID{7}
+		},
+	}
+	p.started.Store(true)
+
+	require.NoError(t, p.ConsumeLogs(t.Context(), logs))
+	require.Greater(t, p.centralQueue.len(), 1)
+	for _, item := range p.centralQueue.items {
+		require.LessOrEqual(t, item.uncompressedBytes, inflightLimit)
+	}
+}
+
 func TestConsumeLogsCentralQueueSplitsBySizeNotRawRoutingKey(t *testing.T) {
 	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
 	t.Cleanup(func() { require.NoError(t, codec.Close()) })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split oversized central-queue log batches in `loadbalancingexporter` to honor uncompressed size limits and prevent rejects or partial enqueues. Also respects `maxInflightUncompressedBytes`. Addresses SAW-7590 where Elasticsearch bulk logs were dropped with “central queue item exceeds max uncompressed batch bytes”.

- **Bug Fixes**
  - Added `centralQueueLogSplitter` to route by lane key and split by uncompressed size with a 4KB headroom.
  - `consumeLogsCentralQueue` now uses an effective limit derived from `maxUncompressedBatchBytes` and `maxInflightUncompressedBytes`.
  - Rejects a single too-large record up front with `errCentralQueueItemTooLarge` and records rejected compressed bytes via telemetry.
  - Preserves lane routing and log order; supports ignored Trace IDs via a fallback key; avoids partial enqueues on rejection.
  - Added tests for size-based splitting (batch and inflight), single-record rejection (no partial enqueues, telemetry), and routing key preservation.

<sup>Written for commit c09b0c91c5966632bcbf82413220d00495d8ff9a. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/81?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New log-splitting and lane-buffering logic that breaks oversized log inputs into central-queue items respecting configured uncompressed size limits and headroom.
  * Per-record routing-aware splitting to maintain routing stability while enforcing per-item size caps.

* **Tests**
  * Added comprehensive tests covering splitting behavior, single-record rejections, metrics for rejected records, and routing correctness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->