### PR TITLE
fix(loadbalancingexporter): fail open before quarantine concentration

### DIFF
--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -80,7 +80,7 @@ The `loadbalancingexporter` will, irrespective of the chosen resolver (`static`,
 * Resiliency options 1 (`timeout`, `retry_on_failure` and `sending_queue` settings in `loadbalancing` section) - are useful for highly elastic environment (like k8s), where list of resolved endpoints frequently changed due to deployments, scale-up or scale-down events. In case of permanent change of list of resolved exporters this options provide capability to re-route data into new set of healthy backends. Disabled by default.
 * Resiliency options 2 (`timeout`, `retry_on_failure` and `sending_queue` settings in `otlp` section) - are useful for temporary problems with specific backend, like network flukes. Persistent Queue is NOT supported here as all sub-exporter shares the same `sending_queue` configuration, including `storage`. Enabled by default.
 * When `central_queue` is enabled, the child `otlp` exporters' `sending_queue` and `retry_on_failure` are disabled. In that mode the central queue owns retry/backpressure and endpoint-health rerouting, so per-backend retries would keep work pinned to a failed backend and delay rerouting.
-* The `endpoint_health` option can be enabled to quarantine a resolver-present backend after the first endpoint-local transport failure. When `reroute_on_failure` is enabled, the failed telemetry is rerouted once to another eligible backend, which can temporarily break routing affinity to preserve availability. If every resolver-present backend is quarantined, endpoint health fails open and keeps those endpoints eligible so traffic is not blackholed. `endpoint_health.active_probe` can also be enabled to locally test backend reachability with TCP connects before customer telemetry is routed there.
+* The `endpoint_health` option can be enabled to quarantine a resolver-present backend after the first endpoint-local transport failure. When `reroute_on_failure` is enabled, the failed telemetry is rerouted once to another eligible backend, which can temporarily break routing affinity to preserve availability. If quarantine would leave too few eligible backends or quarantine too much of the resolver-present set, endpoint health fails open and keeps those endpoints eligible so traffic is not concentrated onto a smaller backend set. `endpoint_health.active_probe` can also be enabled to locally test backend reachability with TCP connects before customer telemetry is routed there.
 
 Unfortunately, data loss is still possible for any resolver type if all of the exporter's targets remains unavailable once redelivery is exhausted. Due consideration needs to be given to the exporter queue and retry configuration when running in a highly elastic environment.
 
@@ -132,6 +132,8 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `quarantine_duration` keeps a backend out of the eligible routing ring for this duration after an endpoint-local failure. Default: `30s`.
   * `reroute_on_failure` reroutes failed telemetry once to another eligible backend when the failure is endpoint-local. Default: `true`.
   * `max_reroute_attempts` limits endpoint-failure reroute attempts. Default: `1`.
+  * `min_eligible_backends` fails open when quarantine would leave fewer than this many resolver-present backends eligible. Default: `1`.
+  * `max_quarantined_percent` fails open when more than this percentage of resolver-present backends are quarantined. Default: `100`.
   * `active_probe` actively checks every resolver-present backend from the local exporter before routing customer telemetry to it. It is disabled by default and fails open if every backend is locally unhealthy.
     * `enabled` turns active probing on or off. Default: `false`.
     * `type` is the probe type. Only `tcp_connect` is currently supported. Default: `tcp_connect`.
@@ -187,6 +189,8 @@ exporters:
       quarantine_duration: 30s
       reroute_on_failure: true
       max_reroute_attempts: 1
+      min_eligible_backends: 2
+      max_quarantined_percent: 50
       active_probe:
         enabled: true
         type: tcp_connect

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -148,6 +148,10 @@ type ZstdPayloadCodecConfig struct {
 
 const defaultEndpointHealthQuarantineDuration = 30 * time.Second
 const (
+	defaultEndpointHealthMinEligibleBackends   = 1
+	defaultEndpointHealthMaxQuarantinedPercent = 100
+)
+const (
 	defaultEndpointHealthActiveProbeInterval       = 5 * time.Second
 	defaultEndpointHealthActiveProbeTimeout        = 250 * time.Millisecond
 	defaultEndpointHealthActiveProbeJitter         = "20%"
@@ -163,11 +167,13 @@ const (
 )
 
 type EndpointHealthConfig struct {
-	Enabled            bool                            `mapstructure:"enabled"`
-	QuarantineDuration time.Duration                   `mapstructure:"quarantine_duration"`
-	RerouteOnFailure   bool                            `mapstructure:"reroute_on_failure"`
-	MaxRerouteAttempts int                             `mapstructure:"max_reroute_attempts"`
-	ActiveProbe        EndpointHealthActiveProbeConfig `mapstructure:"active_probe"`
+	Enabled               bool                            `mapstructure:"enabled"`
+	QuarantineDuration    time.Duration                   `mapstructure:"quarantine_duration"`
+	RerouteOnFailure      bool                            `mapstructure:"reroute_on_failure"`
+	MaxRerouteAttempts    int                             `mapstructure:"max_reroute_attempts"`
+	MinEligibleBackends   int                             `mapstructure:"min_eligible_backends"`
+	MaxQuarantinedPercent int                             `mapstructure:"max_quarantined_percent"`
+	ActiveProbe           EndpointHealthActiveProbeConfig `mapstructure:"active_probe"`
 }
 
 type EndpointHealthActiveProbeConfig struct {
@@ -477,6 +483,12 @@ func (c EndpointHealthConfig) Validate() error {
 	}
 	if c.MaxRerouteAttempts < 0 {
 		return errors.New("endpoint_health.max_reroute_attempts must be greater than or equal to 0")
+	}
+	if c.MinEligibleBackends <= 0 {
+		return errors.New("endpoint_health.min_eligible_backends must be greater than 0")
+	}
+	if c.MaxQuarantinedPercent <= 0 || c.MaxQuarantinedPercent > 100 {
+		return errors.New("endpoint_health.max_quarantined_percent must be from 1 through 100")
 	}
 	return c.ActiveProbe.Validate()
 }

--- a/exporter/loadbalancingexporter/config.schema.yaml
+++ b/exporter/loadbalancingexporter/config.schema.yaml
@@ -81,6 +81,15 @@ $defs:
       max_reroute_attempts:
         type: integer
         minimum: 0
+      min_eligible_backends:
+        type: integer
+        minimum: 1
+        description: Endpoint health fails open when quarantine would leave fewer than this many eligible resolver-present backends.
+      max_quarantined_percent:
+        type: integer
+        minimum: 1
+        maximum: 100
+        description: Endpoint health fails open when more than this percentage of resolver-present backends are quarantined.
       quarantine_duration:
         type: string
         format: duration

--- a/exporter/loadbalancingexporter/config_test.go
+++ b/exporter/loadbalancingexporter/config_test.go
@@ -466,6 +466,8 @@ func TestConfigValidateEndpointHealth(t *testing.T) {
 	require.Equal(t, defaultEndpointHealthQuarantineDuration, cfg.EndpointHealth.QuarantineDuration)
 	require.True(t, cfg.EndpointHealth.RerouteOnFailure)
 	require.Equal(t, 1, cfg.EndpointHealth.MaxRerouteAttempts)
+	require.Equal(t, defaultEndpointHealthMinEligibleBackends, cfg.EndpointHealth.MinEligibleBackends)
+	require.Equal(t, defaultEndpointHealthMaxQuarantinedPercent, cfg.EndpointHealth.MaxQuarantinedPercent)
 	require.NoError(t, cfg.Validate())
 
 	cfg.EndpointHealth.QuarantineDuration = -time.Second
@@ -488,6 +490,16 @@ func TestConfigValidateEndpointHealth(t *testing.T) {
 	cfg.EndpointHealth.MaxRerouteAttempts = 0
 	cfg.EndpointHealth.RerouteOnFailure = false
 	require.NoError(t, cfg.Validate())
+
+	cfg.EndpointHealth.MinEligibleBackends = 0
+	require.ErrorContains(t, cfg.Validate(), "endpoint_health.min_eligible_backends")
+	cfg.EndpointHealth.MinEligibleBackends = defaultEndpointHealthMinEligibleBackends
+
+	cfg.EndpointHealth.MaxQuarantinedPercent = 0
+	require.ErrorContains(t, cfg.Validate(), "endpoint_health.max_quarantined_percent")
+	cfg.EndpointHealth.MaxQuarantinedPercent = 101
+	require.ErrorContains(t, cfg.Validate(), "endpoint_health.max_quarantined_percent")
+	cfg.EndpointHealth.MaxQuarantinedPercent = defaultEndpointHealthMaxQuarantinedPercent
 }
 
 func TestConfigValidateEndpointHealthActiveProbe(t *testing.T) {
@@ -820,10 +832,12 @@ func TestLoadConfigWithEndpointHealth(t *testing.T) {
 			},
 		},
 		"endpoint_health": map[string]any{
-			"enabled":              true,
-			"quarantine_duration":  "10s",
-			"reroute_on_failure":   true,
-			"max_reroute_attempts": 1,
+			"enabled":                 true,
+			"quarantine_duration":     "10s",
+			"reroute_on_failure":      true,
+			"max_reroute_attempts":    1,
+			"min_eligible_backends":   3,
+			"max_quarantined_percent": 20,
 			"active_probe": map[string]any{
 				"enabled":         true,
 				"type":            "tcp_connect",
@@ -842,6 +856,8 @@ func TestLoadConfigWithEndpointHealth(t *testing.T) {
 	require.Equal(t, 10*time.Second, cfg.EndpointHealth.QuarantineDuration)
 	require.True(t, cfg.EndpointHealth.RerouteOnFailure)
 	require.Equal(t, 1, cfg.EndpointHealth.MaxRerouteAttempts)
+	require.Equal(t, 3, cfg.EndpointHealth.MinEligibleBackends)
+	require.Equal(t, 20, cfg.EndpointHealth.MaxQuarantinedPercent)
 	require.True(t, cfg.EndpointHealth.ActiveProbe.Enabled)
 	require.Equal(t, EndpointHealthActiveProbeTypeTCPConnect, cfg.EndpointHealth.ActiveProbe.Type)
 	require.Equal(t, 5*time.Second, cfg.EndpointHealth.ActiveProbe.Interval)

--- a/exporter/loadbalancingexporter/documentation.md
+++ b/exporter/loadbalancingexporter/documentation.md
@@ -8,7 +8,7 @@ The following telemetry is emitted by this component.
 
 ### otelcol_loadbalancer_backend_fail_open_total
 
-Number of times endpoint health failed open because every resolver-present backend was quarantined.
+Number of times endpoint health failed open because quarantine would leave too few eligible resolver-present backends.
 
 | Unit | Metric Type | Value Type | Monotonic | Stability |
 | ---- | ----------- | ---------- | --------- | --------- |

--- a/exporter/loadbalancingexporter/endpoint_health.go
+++ b/exporter/loadbalancingexporter/endpoint_health.go
@@ -35,12 +35,14 @@ const (
 )
 
 type endpointHealthSettings struct {
-	enabled            bool
-	quarantineDuration time.Duration
-	rerouteOnFailure   bool
-	maxRerouteAttempts int
-	activeProbe        endpointHealthActiveProbeSettings
-	now                func() time.Time
+	enabled               bool
+	quarantineDuration    time.Duration
+	rerouteOnFailure      bool
+	maxRerouteAttempts    int
+	minEligibleBackends   int
+	maxQuarantinedPercent int
+	activeProbe           endpointHealthActiveProbeSettings
+	now                   func() time.Time
 }
 
 type endpointHealthActiveProbeSettings struct {
@@ -110,6 +112,12 @@ func newEndpointHealthManager(settings endpointHealthSettings) *endpointHealthMa
 	if settings.quarantineDuration <= 0 {
 		settings.quarantineDuration = defaultEndpointHealthQuarantineDuration
 	}
+	if settings.minEligibleBackends <= 0 {
+		settings.minEligibleBackends = defaultEndpointHealthMinEligibleBackends
+	}
+	if settings.maxQuarantinedPercent <= 0 || settings.maxQuarantinedPercent > 100 {
+		settings.maxQuarantinedPercent = defaultEndpointHealthMaxQuarantinedPercent
+	}
 	return &endpointHealthManager{
 		settings:  settings,
 		endpoints: make(map[string]*endpointHealthState),
@@ -122,10 +130,12 @@ func endpointHealthSettingsFromConfig(cfg EndpointHealthConfig) endpointHealthSe
 		quarantineDuration = defaultEndpointHealthQuarantineDuration
 	}
 	return endpointHealthSettings{
-		enabled:            cfg.Enabled,
-		quarantineDuration: quarantineDuration,
-		rerouteOnFailure:   cfg.RerouteOnFailure,
-		maxRerouteAttempts: cfg.MaxRerouteAttempts,
+		enabled:               cfg.Enabled,
+		quarantineDuration:    quarantineDuration,
+		rerouteOnFailure:      cfg.RerouteOnFailure,
+		maxRerouteAttempts:    cfg.MaxRerouteAttempts,
+		minEligibleBackends:   cfg.MinEligibleBackends,
+		maxQuarantinedPercent: cfg.MaxQuarantinedPercent,
 		activeProbe: endpointHealthActiveProbeSettings{
 			enabled: cfg.ActiveProbe.Enabled,
 			fall:    cfg.ActiveProbe.Fall,
@@ -463,6 +473,7 @@ func (m *endpointHealthManager) eligibleEndpointsLockedWithRefresh(now time.Time
 	var eligible []string
 	var present []string
 	var nextExpiry time.Time
+	quarantined := 0
 	for _, state := range m.endpoints {
 		if !state.present {
 			continue
@@ -484,6 +495,8 @@ func (m *endpointHealthManager) eligibleEndpointsLockedWithRefresh(now time.Time
 		}
 		if state.quarantinedUntil.IsZero() && !state.probeUnhealthy {
 			eligible = append(eligible, state.endpoint)
+		} else {
+			quarantined++
 		}
 	}
 	if nextExpiry.IsZero() {
@@ -494,13 +507,26 @@ func (m *endpointHealthManager) eligibleEndpointsLockedWithRefresh(now time.Time
 
 	sort.Strings(present)
 	sort.Strings(eligible)
-	failOpen := len(present) > 0 && len(eligible) == 0
+	failOpen := m.shouldFailOpenLocked(len(present), len(eligible), quarantined)
 	failOpenStarted := failOpen && !m.failOpenActive
 	m.failOpenActive = failOpen
 	if failOpen {
 		return present, true, failOpenStarted
 	}
 	return eligible, false, false
+}
+
+func (m *endpointHealthManager) shouldFailOpenLocked(present, eligible, quarantined int) bool {
+	if present == 0 {
+		return false
+	}
+	if quarantined == 0 {
+		return false
+	}
+	if eligible < m.settings.minEligibleBackends {
+		return true
+	}
+	return quarantined*100 > present*m.settings.maxQuarantinedPercent
 }
 
 func (s *endpointHealthState) hasActiveTransportQuarantine(now time.Time) bool {

--- a/exporter/loadbalancingexporter/endpoint_health_test.go
+++ b/exporter/loadbalancingexporter/endpoint_health_test.go
@@ -329,6 +329,69 @@ func TestEndpointHealthFailOpenWhenAllPresentEndpointsQuarantined(t *testing.T) 
 	require.True(t, manager.failOpen())
 }
 
+func TestEndpointHealthFailOpenBeforeMinEligibleBackends(t *testing.T) {
+	now := time.Unix(100, 0)
+	manager := newEndpointHealthManager(endpointHealthSettings{
+		enabled:             true,
+		quarantineDuration:  30 * time.Second,
+		minEligibleBackends: 2,
+		now:                 func() time.Time { return now },
+	})
+	manager.reconcile([]string{"endpoint-1", "endpoint-2", "endpoint-3"})
+
+	first := manager.markFailure("endpoint-1", status.Error(codes.Unavailable, "backend unavailable"))
+	require.True(t, first.quarantined)
+	require.False(t, first.failOpen)
+	require.Equal(t, []string{"endpoint-2", "endpoint-3"}, first.eligible)
+
+	second := manager.markFailure("endpoint-2", context.DeadlineExceeded)
+	require.True(t, second.quarantined)
+	require.True(t, second.failOpen)
+	require.Equal(t, []string{"endpoint-1", "endpoint-2", "endpoint-3"}, second.eligible)
+	require.True(t, manager.failOpen())
+}
+
+func TestEndpointHealthDoesNotFailOpenBeforeMinEligibleBackendsWithoutQuarantine(t *testing.T) {
+	now := time.Unix(100, 0)
+	manager := newEndpointHealthManager(endpointHealthSettings{
+		enabled:             true,
+		quarantineDuration:  30 * time.Second,
+		minEligibleBackends: 2,
+		now:                 func() time.Time { return now },
+	})
+	manager.reconcile([]string{"endpoint-1"})
+
+	eligible := manager.eligibleEndpoints()
+	require.Equal(t, []string{"endpoint-1"}, eligible)
+	require.False(t, manager.failOpen())
+}
+
+func TestEndpointHealthFailOpenWhenMaxQuarantinedPercentExceeded(t *testing.T) {
+	now := time.Unix(100, 0)
+	manager := newEndpointHealthManager(endpointHealthSettings{
+		enabled:               true,
+		quarantineDuration:    30 * time.Second,
+		maxQuarantinedPercent: 25,
+		activeProbe: endpointHealthActiveProbeSettings{
+			enabled: true,
+			fall:    1,
+			rise:    1,
+		},
+		now: func() time.Time { return now },
+	})
+	manager.reconcile([]string{"endpoint-1", "endpoint-2", "endpoint-3", "endpoint-4"})
+
+	first := manager.markFailure("endpoint-1", status.Error(codes.Unavailable, "backend unavailable"))
+	require.True(t, first.quarantined)
+	require.False(t, first.failOpen)
+	require.Equal(t, []string{"endpoint-2", "endpoint-3", "endpoint-4"}, first.eligible)
+
+	second := manager.markProbeFailure("endpoint-2")
+	require.True(t, second.quarantined)
+	require.True(t, second.failOpen)
+	require.Equal(t, []string{"endpoint-1", "endpoint-2", "endpoint-3", "endpoint-4"}, second.eligible)
+}
+
 func TestEndpointHealthReconcileDeletesStateForRemovedEndpoint(t *testing.T) {
 	now := time.Unix(100, 0)
 	manager := newEndpointHealthManager(endpointHealthSettings{

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -79,10 +79,12 @@ func createDefaultConfig() component.Config {
 			PayloadCompression:       QueuePayloadCompressionNone,
 		},
 		EndpointHealth: EndpointHealthConfig{
-			Enabled:            false,
-			QuarantineDuration: defaultEndpointHealthQuarantineDuration,
-			RerouteOnFailure:   true,
-			MaxRerouteAttempts: 1,
+			Enabled:               false,
+			QuarantineDuration:    defaultEndpointHealthQuarantineDuration,
+			RerouteOnFailure:      true,
+			MaxRerouteAttempts:    1,
+			MinEligibleBackends:   defaultEndpointHealthMinEligibleBackends,
+			MaxQuarantinedPercent: defaultEndpointHealthMaxQuarantinedPercent,
 			ActiveProbe: EndpointHealthActiveProbeConfig{
 				Enabled:        false,
 				Type:           EndpointHealthActiveProbeTypeTCPConnect,

--- a/exporter/loadbalancingexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/loadbalancingexporter/internal/metadata/generated_telemetry.go
@@ -72,7 +72,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	var err, errs error
 	builder.LoadbalancerBackendFailOpenTotal, err = builder.meter.Int64Counter(
 		"otelcol_loadbalancer_backend_fail_open_total",
-		metric.WithDescription("Number of times endpoint health failed open because every resolver-present backend was quarantined. [Development]"),
+		metric.WithDescription("Number of times endpoint health failed open because quarantine would leave too few eligible resolver-present backends. [Development]"),
 		metric.WithUnit("{events}"),
 	)
 	errs = errors.Join(errs, err)

--- a/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest.go
+++ b/exporter/loadbalancingexporter/internal/metadatatest/generated_telemetrytest.go
@@ -24,7 +24,7 @@ func NewSettings(tt *componenttest.Telemetry) exporter.Settings {
 func AssertEqualLoadbalancerBackendFailOpenTotal(t *testing.T, tt *componenttest.Telemetry, dps []metricdata.DataPoint[int64], opts ...metricdatatest.Option) {
 	want := metricdata.Metrics{
 		Name:        "otelcol_loadbalancer_backend_fail_open_total",
-		Description: "Number of times endpoint health failed open because every resolver-present backend was quarantined. [Development]",
+		Description: "Number of times endpoint health failed open because quarantine would leave too few eligible resolver-present backends. [Development]",
 		Unit:        "{events}",
 		Data: metricdata.Sum[int64]{
 			Temporality: metricdata.CumulativeTemporality,

--- a/exporter/loadbalancingexporter/metadata.yaml
+++ b/exporter/loadbalancingexporter/metadata.yaml
@@ -64,7 +64,7 @@ telemetry:
     loadbalancer_backend_fail_open_total:
       enabled: true
       stability: development
-      description: Number of times endpoint health failed open because every resolver-present backend was quarantined.
+      description: Number of times endpoint health failed open because quarantine would leave too few eligible resolver-present backends.
       unit: "{events}"
       sum:
         value_type: int

--- a/exporter/loadbalancingexporter/testdata/config.yaml
+++ b/exporter/loadbalancingexporter/testdata/config.yaml
@@ -53,6 +53,8 @@ loadbalancing/6:
     quarantine_duration: 30s
     reroute_on_failure: true
     max_reroute_attempts: 1
+    min_eligible_backends: 2
+    max_quarantined_percent: 50
     active_probe:
       enabled: true
       type: tcp_connect


### PR DESCRIPTION
This change was already in the collector build, it looks like Amir just forgot to merge it to main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds guardrails to `exporter/loadbalancingexporter` endpoint health so it fails open before quarantine concentrates traffic, preventing LB-tier cascades. Addresses SAW-7564 by keeping routing spread when probes/quarantine would otherwise shrink the backend set.

- **Bug Fixes**
  - Added `endpoint_health.min_eligible_backends` (default `1`) and `endpoint_health.max_quarantined_percent` (default `100`) with validation.
  - Updated fail-open logic to trigger when eligible backends drop below the minimum or quarantined backends exceed the percent cap; no fail-open for zero-present or zero-quarantined cases.
  - Updated config defaults, schema, README, and example config; adjusted `otelcol_loadbalancer_backend_fail_open_total` metric description.
  - Added tests for new guardrails and behavior.

<sup>Written for commit 541e35e112d93cdda5af121158c0d3b69d8a3fd8. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/82?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `min_eligible_backends` and `max_quarantined_percent` configuration options to endpoint health settings for fine-grained control over fail-open behavior when quarantining backends.

* **Documentation**
  * Updated metric descriptions and configuration documentation to clarify fail-open behavior when quarantine would reduce eligible backends below configured thresholds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->