### PR TITLE
fix(loadbalancingexporter): keep adaptive queue draining with fractional backend share

### DIFF
--- a/.chloggen/saw-7500-adaptive-cq-fractional-share.yaml
+++ b/.chloggen/saw-7500-adaptive-cq-fractional-share.yaml
@@ -1,0 +1,12 @@
+change_type: bug_fix
+
+component: exporter/loadbalancing
+
+note: Keep adaptive central queue consumers draining when ready backend capacity is fractional across active load balancers.
+
+issues: [7500]
+
+subtext: |
+  Positive ready backend capacity now rounds up to one bounded central queue consumer per load balancer instead of flooring to zero, preventing many-LB/few-worker deployments from deadlocking the central queue while workers scale.
+
+change_logs: [user]

--- a/exporter/loadbalancingexporter/central_queue_consumer_policy.go
+++ b/exporter/loadbalancingexporter/central_queue_consumer_policy.go
@@ -169,7 +169,14 @@ func (p centralQueueConsumerPolicy) backendSafeConsumersPerLB(readyBackends int)
 		lbReplicas = 1
 	}
 	totalBackendCapacity := int64(readyBackends) * int64(inflightPerBackend)
-	return ceilDivInt64ToInt(totalBackendCapacity, int64(lbReplicas))
+	backendSafe := totalBackendCapacity / int64(lbReplicas)
+	if backendSafe <= 0 {
+		return 1
+	}
+	if backendSafe > int64(math.MaxInt) {
+		return math.MaxInt
+	}
+	return int(backendSafe)
 }
 
 func ceilDivInt64ToInt(numerator, denominator int64) int {

--- a/exporter/loadbalancingexporter/central_queue_consumer_policy.go
+++ b/exporter/loadbalancingexporter/central_queue_consumer_policy.go
@@ -168,8 +168,8 @@ func (p centralQueueConsumerPolicy) backendSafeConsumersPerLB(readyBackends int)
 	if lbReplicas <= 0 {
 		lbReplicas = 1
 	}
-	totalBackendCapacity := readyBackends * inflightPerBackend
-	return totalBackendCapacity / lbReplicas
+	totalBackendCapacity := int64(readyBackends) * int64(inflightPerBackend)
+	return ceilDivInt64ToInt(totalBackendCapacity, int64(lbReplicas))
 }
 
 func ceilDivInt64ToInt(numerator, denominator int64) int {

--- a/exporter/loadbalancingexporter/central_queue_consumer_policy_test.go
+++ b/exporter/loadbalancingexporter/central_queue_consumer_policy_test.go
@@ -83,6 +83,25 @@ func TestCentralQueueConsumerPolicyKeepsOneConsumerWhenBackendShareIsFractional(
 	require.Equal(t, centralQueueConsumerLimitReasonBackendCapacity, decision.limitReason)
 }
 
+func TestCentralQueueConsumerPolicyDoesNotRoundUpNonZeroBackendShare(t *testing.T) {
+	policy := centralQueueConsumerPolicy{
+		maxConsumers:               120,
+		minConsumers:               1,
+		targetCompressedBytes:      256 << 10,
+		maxInflightSendsPerBackend: 1,
+		activeLoadBalancerReplicas: 3,
+	}
+
+	decision := policy.compute(centralQueueConsumerInputs{
+		queueCompressedBytes: 1 << 30,
+		readyBackends:        7,
+	})
+
+	require.Equal(t, 2, decision.backendSafeConsumersPerLB)
+	require.Equal(t, 2, decision.effectiveConsumers)
+	require.Equal(t, centralQueueConsumerLimitReasonBackendCapacity, decision.limitReason)
+}
+
 func TestCentralQueueConsumerPolicyQueueGrowthIncreasesDemandUntilBackendSafeCap(t *testing.T) {
 	policy := centralQueueConsumerPolicy{
 		maxConsumers:               120,

--- a/exporter/loadbalancingexporter/central_queue_consumer_policy_test.go
+++ b/exporter/loadbalancingexporter/central_queue_consumer_policy_test.go
@@ -64,22 +64,22 @@ func TestCentralQueueConsumerControllerReportsDecisionChanges(t *testing.T) {
 	require.Equal(t, 3, third.effectiveConsumers)
 }
 
-func TestCentralQueueConsumerPolicyStopsWhenBackendShareIsFractional(t *testing.T) {
+func TestCentralQueueConsumerPolicyKeepsOneConsumerWhenBackendShareIsFractional(t *testing.T) {
 	policy := centralQueueConsumerPolicy{
 		maxConsumers:               120,
 		minConsumers:               1,
 		targetCompressedBytes:      256 << 10,
 		maxInflightSendsPerBackend: 1,
-		activeLoadBalancerReplicas: 4,
+		activeLoadBalancerReplicas: 10,
 	}
 
 	decision := policy.compute(centralQueueConsumerInputs{
 		queueCompressedBytes: 1 << 30,
-		readyBackends:        3,
+		readyBackends:        4,
 	})
 
-	require.Equal(t, 0, decision.backendSafeConsumersPerLB)
-	require.Equal(t, 0, decision.effectiveConsumers)
+	require.Equal(t, 1, decision.backendSafeConsumersPerLB)
+	require.Equal(t, 1, decision.effectiveConsumers)
 	require.Equal(t, centralQueueConsumerLimitReasonBackendCapacity, decision.limitReason)
 }
 

--- a/exporter/loadbalancingexporter/central_queue_consumers_test.go
+++ b/exporter/loadbalancingexporter/central_queue_consumers_test.go
@@ -24,6 +24,20 @@ func TestTryAcquireCentralQueueConsumerBlocksWhenEffectiveConsumersAreFull(t *te
 	require.EqualValues(t, 2, active.Load())
 }
 
+func TestTryAcquireCentralQueueConsumerAllowsProgressWhenBackendShareIsFractional(t *testing.T) {
+	var active atomic.Int64
+	controller := newCentralQueueConsumerController(120, 256<<10, 10)
+	lb := centralQueueConsumerTestLoadBalancerWithRoutableBackendCount(4)
+
+	acquired := tryAcquireCentralQueueConsumer(t.Context(), &active, controller, nil, lb, 1<<30)
+
+	require.True(t, acquired)
+	require.EqualValues(t, 1, active.Load())
+	require.Equal(t, 1, controller.last.backendSafeConsumersPerLB)
+	require.Equal(t, 1, controller.last.effectiveConsumers)
+	require.Equal(t, centralQueueConsumerLimitReasonBackendCapacity, controller.last.limitReason)
+}
+
 func TestTryIncrementCentralQueueActiveConsumersDoesNotOversubscribeConcurrentAcquires(t *testing.T) {
 	previousProcs := runtime.GOMAXPROCS(8)
 	t.Cleanup(func() {

--- a/exporter/loadbalancingexporter/central_queue_lane_exporter_test.go
+++ b/exporter/loadbalancingexporter/central_queue_lane_exporter_test.go
@@ -124,8 +124,8 @@ func TestLogExporterCentralQueueDynamicLanesKeepMinimumLaneWhenBackendShareIsFra
 	}
 	var active atomic.Int64
 	decision, acquired, _ := consumers.tryAcquire(&active, 1<<30, 3, false)
-	require.False(t, acquired)
-	require.Equal(t, 0, decision.effectiveConsumers)
+	require.True(t, acquired)
+	require.Equal(t, 1, decision.effectiveConsumers)
 
 	require.Equal(t, 1, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
 }

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -715,6 +715,51 @@ func TestLogsCentralQueueFirstRetryUsesInitialDelay(t *testing.T) {
 	require.NoError(t, waitForInflight(t.Context(), &p.centralWG))
 }
 
+func TestLogsCentralQueueRetriesDeadlineExceededExportError(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+
+	endpoint := "endpoint-1:4317"
+	var calls atomic.Int64
+	var delivered atomic.Int64
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+		}),
+		centralCodec: codec,
+		loadBalancer: &loadBalancer{
+			ring: newHashRing([]string{endpoint}),
+			exporters: map[string]*wrappedExporter{endpoint: newWrappedExporter(newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+				if calls.Add(1) == 1 {
+					return context.DeadlineExceeded
+				}
+				delivered.Add(int64(ld.LogRecordCount()))
+				return nil
+			}), endpoint)},
+			endpointHealth: newEndpointHealthManager(endpointHealthSettings{}),
+			res:            &mockResolver{},
+		},
+		telemetry: tb,
+		logger:    ts.Logger,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	p.centralWG.Add(1)
+	go p.runCentralQueue(ctx)
+	item, err := newCentralQueueLogsItem([]byte("route-a"), simpleLogs(), codec, time.Now())
+	require.NoError(t, err)
+	require.NoError(t, p.centralQueue.enqueue(item))
+
+	require.Eventually(t, func() bool {
+		return calls.Load() == 2 && delivered.Load() == 1 && p.centralQueue.len() == 0
+	}, 2*time.Second, 20*time.Millisecond)
+	cancel()
+	require.NoError(t, waitForInflight(t.Context(), &p.centralWG))
+}
+
 func TestLogsCentralQueueReroutesFailedEndpointItem(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	cfg := endpoint2Config()


### PR DESCRIPTION
Sanitized Sawmills fork metadata.

Summary: keeps adaptive queue draining live when backend share is fractional by preserving a bounded liveness floor for positive backend capacity.

Verification: covered by policy, acquire, dynamic-lane, and deadline retry regression tests.