### PR TITLE
fix(loadbalancingexporter): keep central queue lanes above backend floor

### DIFF
--- a/.chloggen/saw-7500-central-queue-backend-lane-floor.yaml
+++ b/.chloggen/saw-7500-central-queue-backend-lane-floor.yaml
@@ -1,0 +1,12 @@
+change_type: bug_fix
+
+component: exporter/loadbalancing
+
+note: Keep adaptive central queue lanes from collapsing below the healthy backend count while send consumers bootstrap conservatively.
+
+issues: [7500]
+
+subtext: |
+  Dynamic lanes now keep a healthy-backend floor instead of using the first conservative effective-consumer sample as a hard lane cap. This prevents backlog created during adaptive consumer ramp-up from being pinned to one hot lane/backend while still letting effective consumers gate actual send concurrency.
+
+change_logs: [user]

--- a/docs/superpowers/plans/2026-05-24-saw-7500-runtime-lb-fair-share-governor-goal.md
+++ b/docs/superpowers/plans/2026-05-24-saw-7500-runtime-lb-fair-share-governor-goal.md
@@ -178,13 +178,14 @@ Expected: all targeted tests pass.
 - [x] Keep effective consumers as the send-concurrency gate.
 - [x] Keep stale consumer counts capped by the current healthy backend count.
 - [x] Prove the old behavior fails with `effective_lanes=1` or otherwise below the healthy backend floor.
+- [x] Prove low fill-rate estimates cannot shrink lane count below the healthy-backend floor.
 - [x] Prove the new behavior keeps the healthy-backend lane floor while the consumer controller can still report `effective_consumers=1`.
 
 Run:
 
 ```bash
 cd exporter/loadbalancingexporter
-go test . -run 'TestCentralQueueLanePolicyKeepsBackendLaneFloorWhenConsumersBootstrapBelowBackends|TestLogExporterCentralQueueLaneBootstrapUsesHealthyBackendFloor|TestLogExporterCentralQueueDynamicLanesDoNotCollapseToFractionalBackendShare' -count=1
+go test . -run 'TestCentralQueueLanePolicyKeepsBackendLaneFloorWhenFillRateIsLow|TestCentralQueueLanePolicyKeepsBackendLaneFloorWhenConsumersBootstrapBelowBackends|TestLogExporterCentralQueueLaneBootstrapUsesHealthyBackendFloor|TestLogExporterCentralQueueDynamicLanesDoNotCollapseToFractionalBackendShare' -count=1
 ```
 
 Expected before implementation: the new tests fail because lane count follows the conservative effective-consumer sample.

--- a/docs/superpowers/plans/2026-05-24-saw-7500-runtime-lb-fair-share-governor-goal.md
+++ b/docs/superpowers/plans/2026-05-24-saw-7500-runtime-lb-fair-share-governor-goal.md
@@ -26,6 +26,8 @@ The previous SAW-7500 fix made the APSE2 zero-drain failure safe by ensuring a f
 - KEDA did eventually scale workers when queue pressure crossed target, and the cluster stayed healthy.
 - The queue still had to build before KEDA compensated because the LB side stayed pinned at the conservative floor.
 
+The first live APSE2 attempt with `v1.1026.0` proved the consumer fair-share governor could ramp above that floor, but also exposed a second limiter: lane routing was allowed to collapse to the first conservative `effective_consumers` sample. Backlog enqueued during bootstrap could therefore stay concentrated on one lane/backend even after consumers and workers became available.
+
 The follow-up fix should preserve the safety property but avoid making static active-LB tuning the only way to get useful drain concurrency.
 
 ## Current Limiting Factor
@@ -51,7 +53,7 @@ Implement a runtime fair-share governor:
 5. After pressure, recover gradually.
 6. Never exceed configured `num_consumers`.
 7. Never acquire consumers when there are zero ready backends.
-8. Keep dynamic lanes derived from `effective_consumers`.
+8. Keep send concurrency derived from `effective_consumers`, but keep dynamic lane partitioning from falling below the healthy backend count so bootstrap backlog is not pinned to one hot lane/backend.
 9. Do not require Kubernetes API permissions.
 
 Approximate policy:
@@ -153,7 +155,7 @@ Expected: all policy and acquire tests pass.
 
 - [x] Add or update a test where backend pressure reduces a ramped value quickly.
 - [x] Add or update a test where pressure clears and consumers recover gradually, not all at once.
-- [x] Confirm `central_queue.effective_lanes` tracks `effective_consumers`, not configured `num_consumers`.
+- [x] Confirm `central_queue.effective_lanes` remains dynamic and not tied to configured `num_consumers`; send concurrency is still gated by `effective_consumers`, while lane partitioning keeps a healthy-backend floor.
 - [x] If a new limit reason is added, update telemetry tests to assert it is exported.
 
 Run:
@@ -165,7 +167,31 @@ go test . -run 'TestCentralQueueConsumerPolicy|TestCentralQueueConsumerTelemetry
 
 Expected: all targeted tests pass.
 
-## Task 4: Full Contrib Verification And PR
+## Task 4: Live APSE2 Follow-Up Lane Floor
+
+**Files:**
+- Modify: `exporter/loadbalancingexporter/central_queue_lane_policy.go`
+- Modify: `exporter/loadbalancingexporter/central_queue_lane_policy_test.go`
+- Modify: `exporter/loadbalancingexporter/central_queue_lane_exporter_test.go`
+
+- [x] Add red tests proving a low bootstrap `effective_consumers` sample does not cap dynamic lanes below healthy backend count.
+- [x] Keep effective consumers as the send-concurrency gate.
+- [x] Keep stale consumer counts capped by the current healthy backend count.
+- [x] Prove the old behavior fails with `effective_lanes=1` or otherwise below the healthy backend floor.
+- [x] Prove the new behavior keeps the healthy-backend lane floor while the consumer controller can still report `effective_consumers=1`.
+
+Run:
+
+```bash
+cd exporter/loadbalancingexporter
+go test . -run 'TestCentralQueueLanePolicyKeepsBackendLaneFloorWhenConsumersBootstrapBelowBackends|TestLogExporterCentralQueueLaneBootstrapUsesHealthyBackendFloor|TestLogExporterCentralQueueDynamicLanesDoNotCollapseToFractionalBackendShare' -count=1
+```
+
+Expected before implementation: the new tests fail because lane count follows the conservative effective-consumer sample.
+
+Expected after implementation: the tests pass and queue routing has enough lanes to distribute backlog across healthy backends, while send acquisition remains limited by the consumer policy.
+
+## Task 5: Full Contrib Verification And PR
 
 **Files:**
 - Commit only touched files.
@@ -191,7 +217,7 @@ git commit -m "fix(loadbalancingexporter): ramp central queue consumers when bac
 - [ ] Publish or confirm the next `exporter/loadbalancingexporter/v0.149.0-sawmills.N` tag.
 - [ ] Update SAW-7500 Linear comment with PR link, commit SHA, tests, and release tag.
 
-## Task 5: Bump `sawmills-collector`
+## Task 6: Bump `sawmills-collector`
 
 **Files:**
 - Modify: `builder-config.yaml`
@@ -216,7 +242,7 @@ git diff --check
 - [ ] Confirm `sawmills-collector` release tag exists.
 - [ ] Update SAW-7500 Linear comment.
 
-## Task 6: Config And LD Review
+## Task 7: Config And LD Review
 
 **Files/Systems:**
 - LaunchDarkly production/staging flags
@@ -232,7 +258,7 @@ git diff --check
 - [ ] Dry-run APSE2 generated config before live deploy.
 - [ ] Read back exact LD variation IDs/values into SAW-7500.
 
-## Task 7: Staging Validation
+## Task 8: Staging Validation
 
 **Systems:**
 - Sawmills staging collector deployment suitable for LB central queue validation.
@@ -248,7 +274,7 @@ git diff --check
   - backend p95/p99 remains below 2 seconds unless a stricter live gate is established.
 - [ ] Update SAW-7500 with staging evidence.
 
-## Task 8: APSE2-Only BigID Validation
+## Task 9: APSE2-Only BigID Validation
 
 **Target only:**
 - BigID `production-mt-1-ap-southeast-2`
@@ -290,7 +316,7 @@ The goal is complete only when:
 - the runtime fair-share governor is implemented,
 - red/green tests prove static upper-bound pinning is fixed,
 - pressure backoff is proven,
-- dynamic lanes still follow effective consumers,
+- effective consumers gate send concurrency while dynamic lanes keep a healthy-backend floor,
 - contrib PR is merged and released,
 - `sawmills-collector` PR is merged and released,
 - LD/config readback is documented,

--- a/exporter/loadbalancingexporter/central_queue_lane_exporter_test.go
+++ b/exporter/loadbalancingexporter/central_queue_lane_exporter_test.go
@@ -64,7 +64,7 @@ func TestLogExporterCentralQueueUsesRoutableBackendCountForDynamicLanes(t *testi
 	require.Equal(t, 2, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
 }
 
-func TestLogExporterCentralQueueLaneBootstrapUsesActiveLoadBalancerReplicas(t *testing.T) {
+func TestLogExporterCentralQueueLaneBootstrapUsesHealthyBackendFloor(t *testing.T) {
 	controller := centralQueueLanePathTestController()
 	consumers := newCentralQueueConsumerController(120, 256<<10, 3)
 	p := &logExporterImp{
@@ -75,10 +75,10 @@ func TestLogExporterCentralQueueLaneBootstrapUsesActiveLoadBalancerReplicas(t *t
 		ignoreTraceID:            true,
 	}
 
-	require.Equal(t, 2, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
+	require.Equal(t, 6, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
 }
 
-func TestLogExporterCentralQueueDynamicLanesUseLastEffectiveConsumers(t *testing.T) {
+func TestLogExporterCentralQueueDynamicLanesKeepHealthyBackendFloor(t *testing.T) {
 	controller := centralQueueLanePathTestController()
 	consumers := newCentralQueueConsumerController(120, 256<<10, 3)
 	p := &logExporterImp{
@@ -92,7 +92,7 @@ func TestLogExporterCentralQueueDynamicLanesUseLastEffectiveConsumers(t *testing
 	require.True(t, acquired)
 	require.Equal(t, 2, decision.effectiveConsumers)
 
-	require.Equal(t, 2, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
+	require.Equal(t, 6, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
 }
 
 func TestLogExporterCentralQueueDynamicLanesCapStaleEffectiveConsumersByCurrentBackends(t *testing.T) {
@@ -113,7 +113,7 @@ func TestLogExporterCentralQueueDynamicLanesCapStaleEffectiveConsumersByCurrentB
 	require.Equal(t, 2, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
 }
 
-func TestLogExporterCentralQueueDynamicLanesKeepMinimumLaneWhenBackendShareIsFractional(t *testing.T) {
+func TestLogExporterCentralQueueDynamicLanesDoNotCollapseToFractionalBackendShare(t *testing.T) {
 	controller := centralQueueLanePathTestController()
 	consumers := newCentralQueueConsumerController(120, 256<<10, 4)
 	p := &logExporterImp{
@@ -127,7 +127,7 @@ func TestLogExporterCentralQueueDynamicLanesKeepMinimumLaneWhenBackendShareIsFra
 	require.True(t, acquired)
 	require.Equal(t, 1, decision.effectiveConsumers)
 
-	require.Equal(t, 1, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
+	require.Equal(t, 3, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
 }
 
 func TestLogExporterCentralQueueTraceIDRoutingUsesStableLaneCount(t *testing.T) {
@@ -221,7 +221,7 @@ func TestMetricExporterCentralQueueUsesRoutableBackendCountForDynamicLanes(t *te
 	require.Equal(t, 2, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
 }
 
-func TestMetricExporterCentralQueueDynamicLanesUseLastEffectiveConsumers(t *testing.T) {
+func TestMetricExporterCentralQueueDynamicLanesKeepHealthyBackendFloor(t *testing.T) {
 	controller := centralQueueLanePathTestController()
 	consumers := newCentralQueueConsumerController(120, 256<<10, 3)
 	p := &metricExporterImp{
@@ -234,7 +234,7 @@ func TestMetricExporterCentralQueueDynamicLanesUseLastEffectiveConsumers(t *test
 	require.True(t, acquired)
 	require.Equal(t, 2, decision.effectiveConsumers)
 
-	require.Equal(t, 2, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
+	require.Equal(t, 6, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
 }
 
 func TestMetricExporterCentralQueueDynamicLanesUseConfiguredConsumerCapacity(t *testing.T) {
@@ -245,7 +245,7 @@ func TestMetricExporterCentralQueueDynamicLanesUseConfiguredConsumerCapacity(t *
 		centralQueueNumConsumers: 2,
 	}
 
-	require.Equal(t, 2, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
+	require.Equal(t, 4, p.effectiveCentralQueueLaneCount(time.Unix(10, 0)))
 }
 
 func centralQueueLanePathTestController() *centralQueueLaneController {

--- a/exporter/loadbalancingexporter/central_queue_lane_policy.go
+++ b/exporter/loadbalancingexporter/central_queue_lane_policy.go
@@ -96,11 +96,12 @@ func (p centralQueueLanePolicy) compute(inputs centralQueueLaneInputs) int {
 		backends = minLanes
 	}
 
-	candidate := clampInt(backends, minLanes, maxLanes)
+	backendFloor := clampInt(backends, minLanes, maxLanes)
+	candidate := backendFloor
 	if inputs.compressedIngestBytesPerSec > 0 && p.targetFillDuration > 0 && p.targetBytes > 0 {
 		backendLanes := backends * max(p.backendMultiplier, 1)
 		fillLanes := int(math.Ceil(float64(inputs.compressedIngestBytesPerSec) * p.targetFillDuration.Seconds() / float64(p.targetBytes)))
-		candidate = min(backendLanes, fillLanes, maxLanes)
+		candidate = max(backendFloor, min(backendLanes, fillLanes, maxLanes))
 		candidate = clampInt(candidate, minLanes, maxLanes)
 	}
 

--- a/exporter/loadbalancingexporter/central_queue_lane_policy.go
+++ b/exporter/loadbalancingexporter/central_queue_lane_policy.go
@@ -85,14 +85,11 @@ func (p centralQueueLanePolicy) compute(inputs centralQueueLaneInputs) int {
 	minLanes := max(p.minLanes, 1)
 	maxLanes := max(p.maxLanes, minLanes)
 
-	backends := 0
-	if inputs.effectiveConsumersKnown {
+	backends := inputs.healthyBackends
+	if backends <= 0 && inputs.effectiveConsumersKnown {
 		backends = inputs.effectiveConsumers
 	}
-	if !inputs.effectiveConsumersKnown && backends <= 0 {
-		backends = inputs.healthyBackends
-	}
-	if !inputs.effectiveConsumersKnown && backends <= 0 {
+	if backends <= 0 {
 		backends = inputs.resolvedBackends
 	}
 	if backends <= 0 {

--- a/exporter/loadbalancingexporter/central_queue_lane_policy_test.go
+++ b/exporter/loadbalancingexporter/central_queue_lane_policy_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCentralQueueLanePolicyCapsFewBackendsByFillRate(t *testing.T) {
+func TestCentralQueueLanePolicyKeepsFewBackendFloorWhenFillRateIsLow(t *testing.T) {
 	policy := centralQueueLanePolicy{
 		minLanes:           1,
 		maxLanes:           64,
@@ -27,7 +27,7 @@ func TestCentralQueueLanePolicyCapsFewBackendsByFillRate(t *testing.T) {
 		previousEffectiveLaneCountSet: true,
 	})
 
-	require.Equal(t, 1, lanes)
+	require.Equal(t, 2, lanes)
 }
 
 func TestCentralQueueLanePolicyAllowsManyBackendsWhenFillRateSupportsIt(t *testing.T) {
@@ -135,6 +135,26 @@ func TestCentralQueueLanePolicyKeepsBackendLaneFloorWhenConsumersBootstrapBelowB
 	})
 
 	require.Equal(t, 4, lanes)
+}
+
+func TestCentralQueueLanePolicyKeepsBackendLaneFloorWhenFillRateIsLow(t *testing.T) {
+	policy := centralQueueLanePolicy{
+		minLanes:           1,
+		maxLanes:           64,
+		backendMultiplier:  2,
+		targetFillDuration: 500 * time.Millisecond,
+		targetBytes:        256 << 10,
+		hysteresisFactor:   2,
+	}
+
+	lanes := policy.compute(centralQueueLaneInputs{
+		healthyBackends:             8,
+		effectiveConsumers:          8,
+		effectiveConsumersKnown:     true,
+		compressedIngestBytesPerSec: 1,
+	})
+
+	require.Equal(t, 8, lanes)
 }
 
 func TestCentralQueueLaneControllerRecomputesFromBackendCountAndRate(t *testing.T) {

--- a/exporter/loadbalancingexporter/central_queue_lane_policy_test.go
+++ b/exporter/loadbalancingexporter/central_queue_lane_policy_test.go
@@ -97,7 +97,7 @@ func TestCentralQueueLanePolicyUsesBackendCountWhenRateUnknown(t *testing.T) {
 	require.Equal(t, 4, lanes)
 }
 
-func TestCentralQueueLanePolicyUsesEffectiveConsumersForBackendLaneCap(t *testing.T) {
+func TestCentralQueueLanePolicyUsesHealthyBackendsForLaneCapWhenFillRateSupportsIt(t *testing.T) {
 	policy := centralQueueLanePolicy{
 		minLanes:           1,
 		maxLanes:           64,
@@ -114,7 +114,27 @@ func TestCentralQueueLanePolicyUsesEffectiveConsumersForBackendLaneCap(t *testin
 		compressedIngestBytesPerSec: 64 << 20,
 	})
 
-	require.Equal(t, 8, lanes)
+	require.Equal(t, 64, lanes)
+}
+
+func TestCentralQueueLanePolicyKeepsBackendLaneFloorWhenConsumersBootstrapBelowBackends(t *testing.T) {
+	policy := centralQueueLanePolicy{
+		minLanes:           1,
+		maxLanes:           64,
+		backendMultiplier:  2,
+		targetFillDuration: 500 * time.Millisecond,
+		targetBytes:        256 << 10,
+		hysteresisFactor:   2,
+	}
+
+	lanes := policy.compute(centralQueueLaneInputs{
+		healthyBackends:             4,
+		effectiveConsumers:          1,
+		effectiveConsumersKnown:     true,
+		compressedIngestBytesPerSec: 0,
+	})
+
+	require.Equal(t, 4, lanes)
 }
 
 func TestCentralQueueLaneControllerRecomputesFromBackendCountAndRate(t *testing.T) {
@@ -152,8 +172,8 @@ func TestCentralQueueLaneControllerRecomputesWhenEffectiveConsumersChange(t *tes
 	controller := newCentralQueueLaneController(cfg)
 	now := time.Unix(10, 0)
 
-	require.Equal(t, 2, controller.laneCountWithConsumers(8, 2, true, now))
-	require.Equal(t, 4, controller.laneCountWithConsumers(8, 4, true, now.Add(time.Second)))
+	require.Equal(t, 2, controller.laneCountWithConsumers(0, 2, true, now))
+	require.Equal(t, 4, controller.laneCountWithConsumers(0, 4, true, now.Add(time.Second)))
 }
 
 func TestCentralQueueLaneControllerHonorsFixedOverride(t *testing.T) {


### PR DESCRIPTION
Sanitized Sawmills fork metadata.

Summary: keeps dynamic central queue lanes from dropping below the healthy-backend floor while effective consumers continue to gate send concurrency.

Verification: covered by lane policy and exporter regression tests.