### PR TITLE
fix(loadbalancingexporter): balance central queue log lanes

### DIFF
--- a/.chloggen/saw-7500-central-queue-balanced-lane-routing.yaml
+++ b/.chloggen/saw-7500-central-queue-balanced-lane-routing.yaml
@@ -1,0 +1,12 @@
+change_type: bug_fix
+
+component: exporter/loadbalancing
+
+note: Balance central queue log lane routing across healthy backends.
+
+issues: [7500]
+
+subtext: |
+  Central queue log lanes now use ring-aware routing keys so low lane counts distribute across available backends instead of concentrating backlog on one hot backend during bootstrap.
+
+change_logs: [user]

--- a/docs/superpowers/plans/2026-05-24-saw-7500-runtime-lb-fair-share-governor-goal.md
+++ b/docs/superpowers/plans/2026-05-24-saw-7500-runtime-lb-fair-share-governor-goal.md
@@ -363,6 +363,7 @@ git diff --check
 The goal is complete only when:
 
 - the runtime fair-share governor is implemented,
+- every checked task has a passing adversarial subagent review recorded with the task evidence,
 - red/green tests prove static upper-bound pinning is fixed,
 - pressure backoff is proven,
 - effective consumers gate send concurrency while dynamic lanes keep a healthy-backend floor,
@@ -371,4 +372,5 @@ The goal is complete only when:
 - LD/config readback is documented,
 - staging validation is green,
 - APSE2-only live validation is green,
+- a final adversarial subagent review of the entire goal passes after all code, release, config, staging, and APSE2 live evidence is collected,
 - SAW-7500 has final evidence and rollback/tuning notes.

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -1030,14 +1030,73 @@ func centralQueueLaneRoutingKey(signal signalKind, routingKey []byte, laneCount 
 	if laneCount <= 0 {
 		return append([]byte(nil), routingKey...)
 	}
+	lane := centralQueueLaneIndex(signal, routingKey, laneCount)
+	return centralQueueLaneKey(signal, lane, 0)
+}
+
+func centralQueueBalancedLaneRoutingKeyForLoadBalancerLane(lb *loadBalancer, signal signalKind, lane uint32) []byte {
+	if lb == nil {
+		return centralQueueLaneKey(signal, lane, 0)
+	}
+	lb.updateLock.RLock()
+	defer lb.updateLock.RUnlock()
+	return centralQueueBalancedLaneRoutingKeyForRing(lb.ring, signal, lane)
+}
+
+func centralQueueBalancedLaneRoutingKeyForRing(ring *hashRing, signal signalKind, lane uint32) []byte {
+	base := centralQueueLaneKey(signal, lane, 0)
+	endpoints := centralQueueHashRingEndpoints(ring)
+	if len(endpoints) <= 1 {
+		return base
+	}
+	target := endpoints[int(lane)%len(endpoints)]
+	if endpointWithPort(ring.endpointFor(base)) == endpointWithPort(target) {
+		return base
+	}
+	for salt := uint32(1); salt <= 1024; salt++ {
+		candidate := centralQueueLaneKey(signal, lane, salt)
+		if endpointWithPort(ring.endpointFor(candidate)) == endpointWithPort(target) {
+			return candidate
+		}
+	}
+	return base
+}
+
+func centralQueueHashRingEndpoints(ring *hashRing) []string {
+	if ring == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for _, item := range ring.items {
+		endpoint := endpointWithPort(item.endpoint)
+		seen[endpoint] = struct{}{}
+	}
+	endpoints := make([]string, 0, len(seen))
+	for endpoint := range seen {
+		endpoints = append(endpoints, endpoint)
+	}
+	sort.Strings(endpoints)
+	return endpoints
+}
+
+func centralQueueLaneIndex(signal signalKind, routingKey []byte, laneCount int) uint32 {
 	hashInput := make([]byte, len(routingKey)+len(signal)+1)
 	copy(hashInput, string(signal))
 	hashInput[len(signal)] = 0
 	copy(hashInput[len(signal)+1:], routingKey)
-	lane := crc32.ChecksumIEEE(hashInput) % uint32(laneCount)
+	return crc32.ChecksumIEEE(hashInput) % uint32(laneCount)
+}
+
+func centralQueueLaneKey(signal signalKind, lane, salt uint32) []byte {
 	laneRoutingKey := make([]byte, len(signal)+1+4)
+	if salt > 0 {
+		laneRoutingKey = make([]byte, len(signal)+1+4+4)
+	}
 	copy(laneRoutingKey, string(signal))
 	laneRoutingKey[len(signal)] = 0
 	binary.BigEndian.PutUint32(laneRoutingKey[len(signal)+1:], lane)
+	if salt > 0 {
+		binary.BigEndian.PutUint32(laneRoutingKey[len(signal)+1+4:], salt)
+	}
 	return laneRoutingKey
 }

--- a/exporter/loadbalancingexporter/central_queue_lane_policy_test.go
+++ b/exporter/loadbalancingexporter/central_queue_lane_policy_test.go
@@ -30,6 +30,14 @@ func TestCentralQueueLanePolicyKeepsFewBackendFloorWhenFillRateIsLow(t *testing.
 	require.Equal(t, 2, lanes)
 }
 
+func centralQueueAPSE2TestEndpoints() []string {
+	return []string{
+		"10.157.26.60:10418",
+		"10.157.38.82:10418",
+		"10.157.4.62:10418",
+	}
+}
+
 func TestCentralQueueLanePolicyAllowsManyBackendsWhenFillRateSupportsIt(t *testing.T) {
 	policy := centralQueueLanePolicy{
 		minLanes:           1,
@@ -46,6 +54,37 @@ func TestCentralQueueLanePolicyAllowsManyBackendsWhenFillRateSupportsIt(t *testi
 	})
 
 	require.Equal(t, 64, lanes)
+}
+
+func centralQueueRoutingKeyEndpointDistribution(endpoints []string, ring *hashRing, routingKeys [][]byte) map[string]int {
+	distribution := make(map[string]int, len(endpoints))
+	for _, endpoint := range endpoints {
+		distribution[endpoint] = 0
+	}
+	for _, routingKey := range routingKeys {
+		distribution[ring.endpointFor(routingKey)]++
+	}
+	return distribution
+}
+
+func maxLaneEndpointCount(distribution map[string]int) int {
+	var maxCount int
+	for _, count := range distribution {
+		if count > maxCount {
+			maxCount = count
+		}
+	}
+	return maxCount
+}
+
+func minLaneEndpointCount(distribution map[string]int) int {
+	minCount := int(^uint(0) >> 1)
+	for _, count := range distribution {
+		if count < minCount {
+			minCount = count
+		}
+	}
+	return minCount
 }
 
 func TestCentralQueueLanePolicyDefaultAllowsBigIDScaleWhenFillRateSupportsIt(t *testing.T) {

--- a/exporter/loadbalancingexporter/central_queue_logs_splitter.go
+++ b/exporter/loadbalancingexporter/central_queue_logs_splitter.go
@@ -24,6 +24,7 @@ type centralQueueLogSplitter struct {
 
 	marshaler              *plog.ProtoMarshaler
 	emptyTraceFallbackKeys map[[2]int]pcommon.TraceID
+	laneRoutingKeys        map[uint32][]byte
 	lanes                  map[string]*centralQueueLogLaneBuilder
 }
 
@@ -64,6 +65,7 @@ func newCentralQueueLogSplitter(exporter *logExporterImp, limit int, now time.Ti
 		laneCount:              exporter.effectiveCentralQueueLaneCount(now),
 		marshaler:              &plog.ProtoMarshaler{},
 		emptyTraceFallbackKeys: make(map[[2]int]pcommon.TraceID),
+		laneRoutingKeys:        make(map[uint32][]byte),
 		lanes:                  make(map[string]*centralQueueLogLaneBuilder),
 	}
 }
@@ -89,7 +91,7 @@ func (s *centralQueueLogSplitter) consume(ctx context.Context, ld plog.Logs) err
 			for k := 0; k < sl.LogRecords().Len(); k++ {
 				rec := sl.LogRecords().At(k)
 				balancingKey := s.exporter.routingKeyForLogRecord(rec, [2]int{i, j}, s.emptyTraceFallbackKeys)
-				queueRoutingKey := centralQueueLaneRoutingKey(signalKindLogs, balancingKey[:], s.laneCount)
+				queueRoutingKey := s.balancedLaneRoutingKey(balancingKey)
 				lane := s.lane(queueRoutingKey)
 				if !lane.empty() && !lane.canFit(rl, sl, rec, s.marshaler, s.limit) {
 					if err := s.flushLane(lane); err != nil {
@@ -105,6 +107,19 @@ func (s *centralQueueLogSplitter) consume(ctx context.Context, ld plog.Logs) err
 		errs = multierr.Append(errs, s.flushLane(lane))
 	}
 	return errs
+}
+
+func (s *centralQueueLogSplitter) balancedLaneRoutingKey(balancingKey pcommon.TraceID) []byte {
+	if s.laneCount <= 0 {
+		return balancingKey[:]
+	}
+	lane := centralQueueLaneIndex(signalKindLogs, balancingKey[:], s.laneCount)
+	if key, ok := s.laneRoutingKeys[lane]; ok {
+		return key
+	}
+	key := centralQueueBalancedLaneRoutingKeyForLoadBalancerLane(s.exporter.loadBalancer, signalKindLogs, lane)
+	s.laneRoutingKeys[lane] = key
+	return key
 }
 
 func (s *centralQueueLogSplitter) rejectUnsplittableRecords(ctx context.Context, ld plog.Logs) error {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -295,6 +295,38 @@ func TestConsumeLogsCentralQueueUsesLaneRoutingForIgnoredTraceIDs(t *testing.T) 
 	require.Equal(t, first.LogRecordCount(), merged.LogRecordCount())
 }
 
+func TestConsumeLogsCentralQueueBalancesAPSE2LanesAcrossHealthyBackends(t *testing.T) {
+	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
+	t.Cleanup(func() { require.NoError(t, codec.Close()) })
+	const laneCount = 5
+	endpoints := centralQueueAPSE2TestEndpoints()
+	ring := newHashRing(endpoints)
+	p := &logExporterImp{
+		centralQueue: newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 1 << 20,
+			maxUncompressedBatchBytes:    1 << 20,
+			targetCompressedBytes:        1 << 20,
+		}),
+		centralCodec:          codec,
+		centralQueueLaneCount: laneCount,
+		loadBalancer:          &loadBalancer{ring: ring},
+	}
+	p.started.Store(true)
+
+	for _, traceID := range distinctCentralQueueLaneTraceIDs(t, laneCount, laneCount) {
+		require.NoError(t, p.ConsumeLogs(t.Context(), simpleLogWithID(traceID)))
+	}
+
+	routingKeys := make([][]byte, 0, laneCount)
+	for _, item := range p.centralQueue.queuedItems() {
+		routingKeys = append(routingKeys, item.routingKey)
+	}
+	require.Len(t, routingKeys, laneCount)
+	distribution := centralQueueRoutingKeyEndpointDistribution(endpoints, ring, routingKeys)
+	require.LessOrEqual(t, maxLaneEndpointCount(distribution)-minLaneEndpointCount(distribution), 1, "distribution=%v", distribution)
+}
+
 func TestConsumeLogsCentralQueueSplitsOversizedLogBatchByUncompressedBytes(t *testing.T) {
 	codec := newQueuePayloadCodec(QueuePayloadCompressionZstd)
 	t.Cleanup(func() { require.NoError(t, codec.Close()) })


### PR DESCRIPTION
Sanitized Sawmills fork metadata.

Summary: balances central queue log lanes across healthy backends so dynamic lanes do not concentrate drain work on a single worker.

Verification: covered by production-path lane distribution regression tests and full loadbalancing exporter tests.