### PR TITLE
ci: use Namespace runners for Sawmills workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,6 +3,7 @@ self-hosted-runner:
     - oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
     - namespace-profile-sawmills-runner
     - namespace-profile-sawmills-runner-arm64
+    - namespace-profile-sawmills-runner-xlarge
 
 config-variables: null
 

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,8 @@
 self-hosted-runner:
   labels:
     - oracle-bare-metal-64cpu-1024gb-x86-64-ubuntu-24
+    - namespace-profile-sawmills-runner
+    - namespace-profile-sawmills-runner-arm64
 
 config-variables: null
 

--- a/.github/actions/setup-go-tools/action.yml
+++ b/.github/actions/setup-go-tools/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Pattern(s) for actions/setup-go cache-dependency-path, relative to repo-path.
     required: false
     default: "**/*.sum"
+  use-namespace-cache:
+    description: Whether to use Namespace's persistent Go cache volume instead of actions/setup-go cache.
+    required: false
+    default: "false"
   gomoddownload:
     description: Whether to run `make -j2 gomoddownload` when Go cache is cold.
     required: false
@@ -37,11 +41,20 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
         # Always format the path. "./pattern" is valid, handling both root (.) and subdirs.
+        cache: ${{ inputs.use-namespace-cache != 'true' }}
         cache-dependency-path: ${{ format('{0}/{1}', inputs.repo-path, inputs.cache-dependency-path) }}
+    - name: Set up Namespace Go cache
+      if: inputs.use-namespace-cache == 'true'
+      uses: namespacelabs/nscloud-cache-action@15799a6b54e5765f85b2aac25b3f0df43ed571c0 # v1.4.3
+      with:
+        path: |
+          /home/runner/go/pkg/mod
+          /home/runner/.cache/go-build
+        cache: go
 
     - name: Install dependencies (gomoddownload)
       # Only download if setup-go didn't restore a cache.
-      if: inputs.gomoddownload == 'true' && steps.go-setup.outputs.cache-hit != 'true'
+      if: inputs.gomoddownload == 'true' && inputs.use-namespace-cache != 'true' && steps.go-setup.outputs.cache-hit != 'true'
       shell: bash
       working-directory: ${{ inputs.repo-path }}
       run: make -j2 gomoddownload

--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -21,13 +21,14 @@ concurrency:
 
 jobs:
   setup-environment:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner-arm64' || 'ubuntu-22.04-arm' }}
     if: ${{ github.actor != 'dependabot[bot]' && (!contains(github.event.pull_request.labels.*.name, 'Skip ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - run: ./.github/workflows/scripts/check-disk-space.sh
   arm-unittest-matrix:
     needs: [setup-environment]
@@ -53,12 +54,13 @@ jobs:
           - cmd-0
           - other
     timeout-minutes: 30
-    runs-on: ubuntu-22.04-arm
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner-arm64' || 'ubuntu-22.04-arm' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       # Unit tests without JUnit output are much faster, so it's fine to run on every PR.
       # The only time we don't run them is when we already ran them with JUnit output.
       - name: Run Unit Tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,13 +23,14 @@ concurrency:
 jobs:
   setup-environment:
     timeout-minutes: 30
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - run: ./.github/workflows/scripts/check-disk-space.sh
   check-collector-module-version:
     runs-on: ubuntu-24.04
@@ -63,13 +64,14 @@ jobs:
           - pkg
           - cmd-0
           - other
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Lint
         run: GOOS=${{ matrix.goos }} GOARCH=amd64 make -j2 golint GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh
@@ -109,7 +111,7 @@ jobs:
           - internal
           - pkg
           - cmd-0
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     timeout-minutes: 30
     needs: [setup-environment]
     steps:
@@ -118,17 +120,19 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Run `govulncheck`
         run: make gogovulncheck GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh
   checks:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - run: make genotelcontribcol
       - name: CheckDoc
         run: make checkdoc
@@ -214,14 +218,16 @@ jobs:
           - pkg
           - cmd-0
           - other
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || matrix.runner }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Cache Test Build
+        if: github.repository != 'Sawmills/opentelemetry-collector-contrib'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.cache/go-build
@@ -317,13 +323,14 @@ jobs:
           - internal
           - pkg
           - cmd-0
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Cache Docker images.
         uses: AndreKurait/docker-cache@0fe76702a40db986d9663c24954fc14c6a6031b7 # 0.6.0
         with:
@@ -341,13 +348,14 @@ jobs:
           # its integration tests `go test -exec sudo -run Sudo -tags=integration`
           - extension/cgroupruntimeextension
           - receiver/icmpcheckreceiver
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Cache Docker images.
         uses: AndreKurait/docker-cache@0fe76702a40db986d9663c24954fc14c6a6031b7 # 0.6.0
         with:
@@ -375,36 +383,39 @@ jobs:
           fi
 
   correctness-traces:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Correctness
         run: make -C testbed run-correctness-traces-tests
       - run: ./.github/workflows/scripts/check-disk-space.sh
   correctness-metrics:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Correctness
         run: make -C testbed run-correctness-metrics-tests
       - run: ./.github/workflows/scripts/check-disk-space.sh
 
   build-examples:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
           gomoddownload: "false"
       - run: make genotelcontribcol
       - name: Build Examples
@@ -412,7 +423,7 @@ jobs:
       - run: ./.github/workflows/scripts/check-disk-space.sh
 
   cross-compile:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     strategy:
       fail-fast: false
@@ -457,6 +468,7 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Generate collector files
         run: make genotelcontribcol
       - name: Build Collector ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.arm }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -348,14 +348,13 @@ jobs:
           # its integration tests `go test -exec sudo -run Sudo -tags=integration`
           - extension/cgroupruntimeextension
           - receiver/icmpcheckreceiver
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Cache Docker images.
         uses: AndreKurait/docker-cache@0fe76702a40db986d9663c24954fc14c6a6031b7 # 0.6.0
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -382,7 +382,7 @@ jobs:
           fi
 
   correctness-traces:
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -394,7 +394,7 @@ jobs:
         run: make -C testbed run-correctness-traces-tests
       - run: ./.github/workflows/scripts/check-disk-space.sh
   correctness-metrics:
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -422,7 +422,7 @@ jobs:
       - run: ./.github/workflows/scripts/check-disk-space.sh
 
   cross-compile:
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,14 +64,14 @@ jobs:
           - pkg
           - cmd-0
           - other
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && ((matrix.goos == 'windows' && matrix.group == 'internal') || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && (matrix.group == 'internal' || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || matrix.group == 'extension') && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && ((matrix.goos == 'windows' && matrix.group == 'internal') || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'true' || 'false' }}
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && (matrix.group == 'internal' || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || matrix.group == 'extension') && 'true' || 'false' }}
       - name: Lint
         run: GOOS=${{ matrix.goos }} GOARCH=amd64 make -j2 golint GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,7 +64,7 @@ jobs:
           - pkg
           - cmd-0
           - other
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -111,7 +111,7 @@ jobs:
           - internal
           - pkg
           - cmd-0
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: [setup-environment]
     steps:
@@ -120,7 +120,6 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Run `govulncheck`
         run: make gogovulncheck GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh
@@ -218,16 +217,14 @@ jobs:
           - pkg
           - cmd-0
           - other
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || matrix.runner }}
+    runs-on: ${{ matrix.runner }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Cache Test Build
-        if: github.repository != 'Sawmills/opentelemetry-collector-contrib'
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: ~/.cache/go-build
@@ -323,14 +320,13 @@ jobs:
           - internal
           - pkg
           - cmd-0
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Cache Docker images.
         uses: AndreKurait/docker-cache@0fe76702a40db986d9663c24954fc14c6a6031b7 # 0.6.0
         with:
@@ -422,7 +418,7 @@ jobs:
       - run: ./.github/workflows/scripts/check-disk-space.sh
 
   cross-compile:
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     strategy:
       fail-fast: false
@@ -467,7 +463,6 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
       - name: Generate collector files
         run: make genotelcontribcol
       - name: Build Collector ${{ matrix.os }} ${{ matrix.arch }} ${{ matrix.arm }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,14 +64,14 @@ jobs:
           - pkg
           - cmd-0
           - other
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && (matrix.group == 'internal' || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || matrix.group == 'extension') && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && ((matrix.goos == 'windows' && matrix.group == 'internal') || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && (matrix.group == 'internal' || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || matrix.group == 'extension') && 'true' || 'false' }}
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && ((matrix.goos == 'windows' && matrix.group == 'internal') || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'true' || 'false' }}
       - name: Lint
         run: GOOS=${{ matrix.goos }} GOARCH=amd64 make -j2 golint GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,14 +64,14 @@ jobs:
           - pkg
           - cmd-0
           - other
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && ((matrix.goos == 'windows' && matrix.group == 'internal') || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && (matrix.group == 'internal' || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && ((matrix.goos == 'windows' && matrix.group == 'internal') || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'true' || 'false' }}
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && (matrix.group == 'internal' || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'true' || 'false' }}
       - name: Lint
         run: GOOS=${{ matrix.goos }} GOARCH=amd64 make -j2 golint GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,14 +64,14 @@ jobs:
           - pkg
           - cmd-0
           - other
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && ((matrix.goos == 'windows' && matrix.group == 'internal') || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'namespace-profile-sawmills-runner-xlarge' || 'ubuntu-24.04' }}
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && 'true' || 'false' }}
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && ((matrix.goos == 'windows' && matrix.group == 'internal') || matrix.group == 'receiver-1' || matrix.group == 'receiver-3' || (matrix.goos == 'linux' && matrix.group == 'extension')) && 'true' || 'false' }}
       - name: Lint
         run: GOOS=${{ matrix.goos }} GOARCH=amd64 make -j2 golint GROUP=${{ matrix.group }}
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/queuedrain-hardening.yml
+++ b/.github/workflows/queuedrain-hardening.yml
@@ -36,7 +36,7 @@ permissions: read-all
 jobs:
   harness:
     if: github.repository == 'Sawmills/opentelemetry-collector-contrib'
-    runs-on: ubuntu-24.04
+    runs-on: namespace-profile-sawmills-runner
     timeout-minutes: 35
     env:
       ARTIFACT_ROOT: /tmp/queuedrain-artifacts
@@ -50,6 +50,7 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: "true"
 
       - name: Install kind
         run: go install sigs.k8s.io/kind@v0.30.0

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
+      PR_BASE: ${{ github.event.pull_request.base.ref }}
     outputs:
       mode: ${{ steps.changes.outputs.mode }}
       go_sources: ${{ steps.changes.outputs.go_sources }}
@@ -25,8 +26,9 @@ jobs:
         id: changes
         env:
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
         run: |
-          changed_files="$(git diff --name-only --diff-filter=ACDMRTUXB "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")"
+          changed_files="$(git diff --name-only --diff-filter=ACDMRTUXB "$(git merge-base "origin/${PR_BASE}" "$PR_HEAD")" "$PR_HEAD")"
           echo changed_files
           echo "$changed_files"
           LIMIT=50
@@ -36,7 +38,19 @@ jobs:
             exit 0
           fi
 
-          non_docs_changes=$(printf '%s\n' "$changed_files" | grep -vE '^(.+\.md|docs/.+\.md|\.github/ISSUE_TEMPLATE/.+|LICENSE)$' || true)
+          renamed_or_copied_paths="$(git diff -M -C -C --name-only --diff-filter=RC "$(git merge-base "origin/${PR_BASE}" "$PR_HEAD")" "$PR_HEAD")"
+          if [[ -n "$renamed_or_copied_paths" ]]; then
+            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          deleted_go_files="$(git diff --name-only --diff-filter=D "$(git merge-base "origin/${PR_BASE}" "$PR_HEAD")" "$PR_HEAD" | grep -E '\.go$' || true)"
+          if [[ -n "$deleted_go_files" ]]; then
+            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          non_docs_changes=$(printf '%s\n' "$changed_files" | grep -vE '^(.+\.md|docs/.+\.md|LICENSE)$' || true)
           if [[ -z "$non_docs_changes" ]]; then
             echo "mode=docs_only" >> "$GITHUB_OUTPUT"
             exit 0
@@ -44,16 +58,6 @@ jobs:
 
           non_go_changes=$(printf '%s\n' "$changed_files" | grep -vE '.*\.go$' || true)
           if [[ -n "$non_go_changes" ]]; then
-            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          renamed_or_copied_paths="$(git diff -M -C --name-only --diff-filter=RC "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")"
-          if [[ -n "$renamed_or_copied_paths" ]]; then
-            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          deleted_go_files="$(git diff --name-only --diff-filter=D "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD" | grep -E '\.go$' || true)"
-          if [[ -n "$deleted_go_files" ]]; then
             echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -96,7 +100,7 @@ jobs:
     strategy:
       matrix:
         runner: [windows-2022, windows-2025, windows-11-arm, ubuntu-latest]
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && matrix.runner == 'ubuntu-latest' && 'namespace-profile-sawmills-runner' || matrix.runner }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.actor == github.event.pull_request.user.login && github.event.pull_request.user.type == 'User' && github.event.pull_request.head.repo.full_name == github.repository && matrix.runner == 'ubuntu-latest' && 'namespace-profile-sawmills-runner' || matrix.runner }}
     env:
       # The gcc installed on the Windows arm64 runner doesn't ship native ARM libraries so we need to disable CGO.
       CGO_ENABLED: ${{ matrix.runner == 'windows-11-arm' && '0' || '' }}
@@ -111,7 +115,7 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && matrix.runner == 'ubuntu-latest' && 'true' || 'false' }}
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.actor == github.event.pull_request.user.login && github.event.pull_request.user.type == 'User' && github.event.pull_request.head.repo.full_name == github.repository && matrix.runner == 'ubuntu-latest' && 'true' || 'false' }}
 
       - name: Run changed tests
         if: needs.changedfiles.outputs.go_tests
@@ -129,10 +133,10 @@ jobs:
         run: |
           if [[ "${{ matrix.runner }}" == "windows-2025" ]]; then
             make run-changed-source-package-tests
-            make for-affected-components CMD="make lint test-twice"
+            make run-changed-dependent-module-tests CMD="make lint test-twice"
           else
             make run-changed-source-package-tests
-            make for-affected-components CMD="make test-twice"
+            make run-changed-dependent-module-tests CMD="make test-twice"
           fi
 
       - run: ./.github/workflows/scripts/check-disk-space.sh

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -94,13 +94,47 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
-  scoped-tests-matrix:
+  scoped-tests-ubuntu:
+    needs: changedfiles
+    if: needs.changedfiles.outputs.mode == 'scoped'
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.actor == github.event.pull_request.user.login && github.event.pull_request.user.type == 'User' && github.event.pull_request.head.repo.full_name == github.repository && 'namespace-profile-sawmills-runner' || 'ubuntu-latest' }}
+    steps:
+      - name: Echo changed files
+        shell: bash
+        run: |
+          echo "mode: ${{ needs.changedfiles.outputs.mode }}"
+          echo "go_sources: ${{ needs.changedfiles.outputs.go_sources }}"
+          echo "go_tests: ${{ needs.changedfiles.outputs.go_tests }}"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-go-tools
+        with:
+          go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.actor == github.event.pull_request.user.login && github.event.pull_request.user.type == 'User' && github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
+
+      - name: Run changed tests
+        if: needs.changedfiles.outputs.go_tests
+        env:
+          CHANGED_GOLANG_TESTS: ${{ needs.changedfiles.outputs.go_tests }}
+        run: |
+          make run-changed-tests
+
+      - name: Run tests on dependent components
+        if: needs.changedfiles.outputs.go_sources
+        env:
+          CHANGED_GOLANG_SOURCES: ${{ needs.changedfiles.outputs.go_sources }}
+        run: |
+          make run-changed-source-package-tests
+          make run-changed-dependent-module-tests CMD="make lint test-twice"
+
+      - run: ./.github/workflows/scripts/check-disk-space.sh
+
+  scoped-tests-cross-platform:
     needs: changedfiles
     if: needs.changedfiles.outputs.mode == 'scoped'
     strategy:
       matrix:
-        runner: [windows-2022, windows-2025, windows-11-arm, ubuntu-latest]
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.actor == github.event.pull_request.user.login && github.event.pull_request.user.type == 'User' && github.event.pull_request.head.repo.full_name == github.repository && matrix.runner == 'ubuntu-latest' && 'namespace-profile-sawmills-runner' || matrix.runner }}
+        runner: [windows-2022, windows-2025, windows-11-arm]
+    runs-on: ${{ matrix.runner }}
     env:
       # The gcc installed on the Windows arm64 runner doesn't ship native ARM libraries so we need to disable CGO.
       CGO_ENABLED: ${{ matrix.runner == 'windows-11-arm' && '0' || '' }}
@@ -115,7 +149,6 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.actor == github.event.pull_request.user.login && github.event.pull_request.user.type == 'User' && github.event.pull_request.head.repo.full_name == github.repository && matrix.runner == 'ubuntu-latest' && 'true' || 'false' }}
 
       - name: Run changed tests
         if: needs.changedfiles.outputs.go_tests
@@ -129,15 +162,9 @@ jobs:
         env:
           CHANGED_GOLANG_SOURCES: ${{ needs.changedfiles.outputs.go_sources }}
         shell: bash
-        # Only run linter on windows-2025 to avoid redundant runs
         run: |
-          if [[ "${{ matrix.runner }}" == "windows-2025" ]]; then
-            make run-changed-source-package-tests
-            make run-changed-dependent-module-tests CMD="make lint test-twice"
-          else
-            make run-changed-source-package-tests
-            make run-changed-dependent-module-tests CMD="make test-twice"
-          fi
+          make run-changed-source-package-tests
+          make run-changed-dependent-module-tests CMD="make test-twice"
 
       - run: ./.github/workflows/scripts/check-disk-space.sh
 
@@ -146,12 +173,12 @@ jobs:
     # wait for all runners completion
     if: ${{ always() }}
     runs-on: ubuntu-24.04
-    needs: [changedfiles, scoped-tests-matrix]
+    needs: [changedfiles, scoped-tests-ubuntu]
     steps:
       - name: Print result
         run: |
           echo "mode=${{ needs.changedfiles.outputs.mode }}"
-          echo "scoped_result=${{ needs.scoped-tests-matrix.result }}"
+          echo "scoped_ubuntu_result=${{ needs.scoped-tests-ubuntu.result }}"
       - name: Interpret result
         run: |
           mode="${{ needs.changedfiles.outputs.mode }}"
@@ -160,10 +187,10 @@ jobs:
               echo "Docs-only PR; scoped-tests passes."
               ;;
             scoped)
-              if [[ success == "${{ needs.scoped-tests-matrix.result }}" ]]; then
-                echo "Scoped matrix passed."
+              if [[ success == "${{ needs.scoped-tests-ubuntu.result }}" ]]; then
+                echo "Scoped Ubuntu gate passed."
               else
-                echo "Scoped matrix failed."
+                echo "Scoped Ubuntu gate failed."
                 exit 1
               fi
               ;;

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -9,10 +9,10 @@ permissions: read-all
 jobs:
   changedfiles:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
     outputs:
+      mode: ${{ steps.changes.outputs.mode }}
       go_sources: ${{ steps.changes.outputs.go_sources }}
       go_tests: ${{ steps.changes.outputs.go_tests }}
     steps:
@@ -25,52 +25,78 @@ jobs:
         id: changes
         env:
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
-        # Skip scoped tests if too many files are changed
         run: |
-          changed_files="$(git diff --name-only --diff-filter=ACMRTUXB "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")"
+          changed_files="$(git diff --name-only --diff-filter=ACDMRTUXB "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")"
           echo changed_files
           echo "$changed_files"
           LIMIT=50
 
-          go_sources=$(echo "$changed_files" | tr ' ' '\n' | grep -E '\.go$' | grep -v -E '.*_test\.go$' || true)
-          echo go_sources
-          echo "$go_sources"
-          if [[ -n "$go_sources" ]]; then
-            count=$(echo "$go_sources" | wc -l)
-            if [ "$count" -gt "$LIMIT" ]; then
-              echo "Skipping scoped go_sources: This PR modified $count .go files which is over the $LIMIT files threshold."
-            else
-              {
-                echo 'go_sources<<EOF'
-                echo "$go_sources"
-                echo EOF
-              } >> "$GITHUB_OUTPUT"
-            fi
+          if [[ -z "$changed_files" ]]; then
+            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          go_tests=$(echo "$changed_files" | tr ' ' '\n' | grep -E '.*_test\.go$' || true)
-          echo go_tests
-          echo "$go_tests"
+          non_docs_changes=$(printf '%s\n' "$changed_files" | grep -vE '^(.+\.md|docs/.+\.md|\.github/ISSUE_TEMPLATE/.+|LICENSE)$' || true)
+          if [[ -z "$non_docs_changes" ]]; then
+            echo "mode=docs_only" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          non_go_changes=$(printf '%s\n' "$changed_files" | grep -vE '.*\.go$' || true)
+          if [[ -n "$non_go_changes" ]]; then
+            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          renamed_or_copied_paths="$(git diff -M -C --name-only --diff-filter=RC "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD")"
+          if [[ -n "$renamed_or_copied_paths" ]]; then
+            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          deleted_go_files="$(git diff --name-only --diff-filter=D "$(git merge-base origin/main "$PR_HEAD")" "$PR_HEAD" | grep -E '\.go$' || true)"
+          if [[ -n "$deleted_go_files" ]]; then
+            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          go_sources=$(printf '%s\n' "$changed_files" | grep -E '\.go$' | grep -vE '.*_test\.go$' || true)
+          go_tests=$(printf '%s\n' "$changed_files" | grep -E '.*_test\.go$' || true)
+
+          go_count=$(printf '%s\n%s\n' "$go_sources" "$go_tests" | awk 'NF { count++ } END { print count + 0 }')
+          if (( go_count == 0 )); then
+            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if (( go_count > LIMIT )); then
+            echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "mode=scoped" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$go_sources" ]]; then
+            {
+              echo 'go_sources<<EOF'
+              echo "$go_sources"
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
+          fi
+
           if [[ -n "$go_tests" ]]; then
-            count=$(echo "$go_tests" | wc -l)
-            if [ "$count" -gt "$LIMIT" ]; then
-              echo "Skipping scoped go_tests: This PR modified $count test files which is over the $LIMIT files threshold."
-            else
-              {
-                echo 'go_tests<<EOF'
-                echo "$go_tests"
-                echo EOF
-              } >> "$GITHUB_OUTPUT"
-            fi
+            {
+              echo 'go_tests<<EOF'
+              echo "$go_tests"
+              echo EOF
+            } >> "$GITHUB_OUTPUT"
           fi
 
   scoped-tests-matrix:
     needs: changedfiles
-    if: needs.changedfiles.outputs.go_sources != '' || needs.changedfiles.outputs.go_tests != ''
+    if: needs.changedfiles.outputs.mode == 'scoped'
     strategy:
       matrix:
         runner: [windows-2022, windows-2025, windows-11-arm, ubuntu-latest]
-    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && matrix.runner == 'ubuntu-latest' && 'namespace-profile-sawmills-runner' || matrix.runner }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && matrix.runner == 'ubuntu-latest' && 'namespace-profile-sawmills-runner' || matrix.runner }}
     env:
       # The gcc installed on the Windows arm64 runner doesn't ship native ARM libraries so we need to disable CGO.
       CGO_ENABLED: ${{ matrix.runner == 'windows-11-arm' && '0' || '' }}
@@ -78,13 +104,14 @@ jobs:
       - name: Echo changed files
         shell: bash
         run: |
+          echo "mode: ${{ needs.changedfiles.outputs.mode }}"
           echo "go_sources: ${{ needs.changedfiles.outputs.go_sources }}"
           echo "go_tests: ${{ needs.changedfiles.outputs.go_tests }}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
-          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && matrix.runner == 'ubuntu-latest' && 'true' || 'false' }}
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository && matrix.runner == 'ubuntu-latest' && 'true' || 'false' }}
 
       - name: Run changed tests
         if: needs.changedfiles.outputs.go_tests
@@ -101,8 +128,10 @@ jobs:
         # Only run linter on windows-2025 to avoid redundant runs
         run: |
           if [[ "${{ matrix.runner }}" == "windows-2025" ]]; then
+            make run-changed-source-package-tests
             make for-affected-components CMD="make lint test-twice"
           else
+            make run-changed-source-package-tests
             make for-affected-components CMD="make test-twice"
           fi
 
@@ -111,17 +140,35 @@ jobs:
   scoped-tests:
     # Keeps the name of the job required for merging in the GH configuration, make it
     # wait for all runners completion
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
-    needs: [scoped-tests-matrix]
+    needs: [changedfiles, scoped-tests-matrix]
     steps:
       - name: Print result
-        run: echo ${{ needs.scoped-tests-matrix.result }}
+        run: |
+          echo "mode=${{ needs.changedfiles.outputs.mode }}"
+          echo "scoped_result=${{ needs.scoped-tests-matrix.result }}"
       - name: Interpret result
         run: |
-          if [[ success == ${{ needs.scoped-tests-matrix.result }} ]]
-          then
-            echo "All matrix jobs passed!"
-          else
-            echo "One or more matrix jobs failed."
-            false
-          fi
+          mode="${{ needs.changedfiles.outputs.mode }}"
+          case "$mode" in
+            docs_only)
+              echo "Docs-only PR; scoped-tests passes."
+              ;;
+            scoped)
+              if [[ success == "${{ needs.scoped-tests-matrix.result }}" ]]; then
+                echo "Scoped matrix passed."
+              else
+                echo "Scoped matrix failed."
+                exit 1
+              fi
+              ;;
+            full_fallback)
+              echo "This PR exceeds the safe scoped-test boundary and is blocked by the required fast gate."
+              exit 1
+              ;;
+            *)
+              echo "Unexpected mode: $mode"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         runner: [windows-2022, windows-2025, windows-11-arm, ubuntu-latest]
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && matrix.runner == 'ubuntu-latest' && 'namespace-profile-sawmills-runner' || matrix.runner }}
     env:
       # The gcc installed on the Windows arm64 runner doesn't ship native ARM libraries so we need to disable CGO.
       CGO_ENABLED: ${{ matrix.runner == 'windows-11-arm' && '0' || '' }}
@@ -84,6 +84,7 @@ jobs:
       - uses: ./.github/actions/setup-go-tools
         with:
           go-version: oldstable
+          use-namespace-cache: ${{ github.repository == 'Sawmills/opentelemetry-collector-contrib' && matrix.runner == 'ubuntu-latest' && 'true' || 'false' }}
 
       - name: Run changed tests
         if: needs.changedfiles.outputs.go_tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,27 @@ Make sure to follow CONTRIBUTING.md on any contributions.
 Non-exhaustively, the important points are:
 
 * Whenever applicable, all code changes should have tests that actually validate the changes.
+## Sawmills fork CI gate
+
+In the `Sawmills/opentelemetry-collector-contrib` fork:
+
+* `scoped-tests` is the only required PR status check on `main`.
+* `scoped-tests` is intentionally fail-closed:
+  * docs-only PRs pass fast
+  * narrow pure-Go PRs run the blocking Ubuntu scoped lane
+  * broad or non-Go PRs fail the fast gate instead of silently falling back
+* The Windows scoped lanes are advisory PR signal only; they are not merge-blocking.
+* Full `build-and-test` and `build-and-test-arm` still run on PRs for signal and on `main` / `merge_group` for full coverage.
+* Namespace runner/cache behavior in workflows must stay repo-guarded so upstream `open-telemetry/opentelemetry-collector-contrib` continues to use GitHub-hosted runners.
+* Privileged/sudo test jobs must stay on GitHub-hosted Linux runners unless the replacement runner is explicitly verified to support them.
+
+Key files:
+
+* `.github/workflows/scoped-test.yaml`
+* `.github/workflows/build-and-test.yml`
+* `.github/workflows/build-and-test-arm.yml`
+* `.github/actions/setup-go-tools/action.yml`
+* `Makefile.Common`
 
 ## Commit formatting
 

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -337,9 +337,12 @@ run-changed-source-package-tests:
 			dir="$$(dirname "$$path")"; \
 			current="$$dir"; \
 			found=""; \
-			while [ "$$current" != "." ] && [ "$$current" != "/" ]; do \
+			while true; do \
 				if [ -f "$$current/go.mod" ]; then \
 					found="$$current"; \
+					break; \
+				fi; \
+				if [ "$$current" = "." ] || [ "$$current" = "/" ]; then \
 					break; \
 				fi; \
 				current="$$(dirname "$$current")"; \
@@ -358,6 +361,57 @@ run-changed-source-package-tests:
 			(cd "$${dir}" && \
 				echo "running source package tests in $${dir}" && \
 				$(GOTESTSUM) --packages="./..." -- $(GOTEST_OPT) ); \
+			done \
+		fi \
+	fi
+.PHONY: run-changed-dependent-module-tests
+run-changed-dependent-module-tests:
+	@echo "Checking for changed dependent module tests..."
+	@if [ -z '$${CHANGED_GOLANG_SOURCES}' ]; then \
+		echo "No go source changes detected in shippable code."; \
+	else \
+		cd $(SRC_ROOT); \
+		CHANGED_MODULE_DIRS=$$(for path in $${CHANGED_GOLANG_SOURCES}; do \
+			dir="$$(dirname "$$path")"; \
+			current="$$dir"; \
+			found=""; \
+			while true; do \
+				if [ -f "$$current/go.mod" ]; then \
+					found="$$current"; \
+					break; \
+				fi; \
+				if [ "$$current" = "." ] || [ "$$current" = "/" ]; then \
+					break; \
+				fi; \
+				current="$$(dirname "$$current")"; \
+			done; \
+			if [ -n "$$found" ]; then \
+				echo "$$found"; \
+			fi; \
+		done | awk '!seen[$$0]++'); \
+		CHANGED_MODULE_PATHS=$$(for dir in $${CHANGED_MODULE_DIRS}; do \
+			awk '/^module / { print $$2; exit }' "$$dir/go.mod"; \
+		done | awk '!seen[$$0]++'); \
+		DEPENDENT_MODULE_DIRS=$$(for module_path in $${CHANGED_MODULE_PATHS}; do \
+			grep --include=go.mod -rl "$$module_path" .; \
+		done | xargs -r dirname | awk '!seen[$$0]++'); \
+		if [ -z "$${DEPENDENT_MODULE_DIRS}" ]; then \
+			echo "No dependent modules found for the changed source modules."; \
+		else \
+			set -e; for dir in $$(echo $${DEPENDENT_MODULE_DIRS}); do \
+				skip=""; \
+				for changed_dir in $${CHANGED_MODULE_DIRS}; do \
+					if [ "$$dir" = "$$changed_dir" ]; then \
+						skip="1"; \
+						break; \
+					fi; \
+				done; \
+				if [ -n "$$skip" ]; then \
+					continue; \
+				fi; \
+				(cd "$${dir}" && \
+					echo "running dependent module command in $${dir}" && \
+					$${CMD} ); \
 			done \
 		fi \
 	fi

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -326,6 +326,41 @@ for-affected-components:
 # Do not pass GOTESTSUM_OPT so that we do not re-run failures
 # and run each changed test three times.
 # This helps us catch flakes more easily before they land on main.
+.PHONY: run-changed-source-package-tests
+run-changed-source-package-tests:
+	@echo "Checking for changed source package tests..."
+	@if [ -z '$${CHANGED_GOLANG_SOURCES}' ]; then \
+		echo "No go source changes detected in shippable code."; \
+	else \
+		cd $(SRC_ROOT); \
+		AFFECTED_SOURCE_DIRS=$$(for path in $${CHANGED_GOLANG_SOURCES}; do \
+			dir="$$(dirname "$$path")"; \
+			current="$$dir"; \
+			found=""; \
+			while [ "$$current" != "." ] && [ "$$current" != "/" ]; do \
+				if [ -f "$$current/go.mod" ]; then \
+					found="$$current"; \
+					break; \
+				fi; \
+				current="$$(dirname "$$current")"; \
+			done; \
+			if [ -n "$$found" ]; then \
+				echo "$$found"; \
+			else \
+				echo "$$dir"; \
+			fi; \
+		done | awk '!seen[$$0]++'); \
+		if [ -z '$${AFFECTED_SOURCE_DIRS}' ]; then \
+			echo "Failed to find the affected source directories."; \
+			exit 1; \
+		else \
+			set -e; for dir in $$(echo $${AFFECTED_SOURCE_DIRS}); do \
+			(cd "$${dir}" && \
+				echo "running source package tests in $${dir}" && \
+				$(GOTESTSUM) --packages="./..." -- $(GOTEST_OPT) ); \
+			done \
+		fi \
+	fi
 CHANGED_GOLANG_TESTS?=$(shell git diff main --name-only | grep -E '.*_test\.go$$')
 .PHONY: run-changed-tests
 run-changed-tests:


### PR DESCRIPTION
Sanitized Sawmills fork metadata.

Summary: routes Sawmills repository workflows to Namespace runners while preserving GitHub-hosted runners for forks and non-Sawmills repositories.

Verification: covered by CI workflow checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes required merge gating and when PRs pass vs fail without running full CI; mis-tuned mode or runner guards could block valid PRs or leave gaps, though upstream repos stay on GitHub-hosted runners.
> 
> **Overview**
> For **`Sawmills/opentelemetry-collector-contrib` only**, CI jobs switch from GitHub-hosted Ubuntu/ARM runners to **Namespace** profiles (`sawmills-runner`, `arm64`, `xlarge`) on selected **`build-and-test`**, **`build-and-test-arm`**, **`queuedrain-hardening`**, and scoped Ubuntu lanes. **`setup-go-tools`** gains optional **`use-namespace-cache`** (persistent mod/build cache via `nscloud-cache-action`, with **`actions/setup-go`** cache disabled when enabled). **`actionlint`** whitelists the new runner labels.
> 
> **`scoped-test`** is reworked into a **fail-closed** merge gate: **`changedfiles`** emits **`mode`** (`docs_only`, **`scoped`**, or **`full_fallback`**) using the PR base branch, rename/copy/delete/non-Go/over-50-file rules; only narrow pure-Go PRs run tests. The blocking path is **`scoped-tests-ubuntu`** (Namespace + cache when the PR is from a trusted same-repo user); Windows matrix lanes are advisory and no longer gate merge. **`Makefile.Common`** adds **`run-changed-source-package-tests`** and **`run-changed-dependent-module-tests`** (module/`go.mod`-based dependents) used instead of **`for-affected-components`** in scoped workflows. **`AGENTS.md`** documents the fork gate policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 217f18b39bae435cf89dcb3203dba79992dc526e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Smarter CI runner selection that adapts by repository and platform.
  * Optional namespace-backed Go caching to speed builds and avoid redundant downloads.
  * Scoped test execution to run only affected package tests for changed Go sources.
  * Added targets to run tests for changed packages and their dependent modules.
  * Expanded self-hosted runner options (including ARM and larger-capacity runners).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->