### PR TITLE
test: probe scoped gate timing

### DIFF
--- a/cmd/schemagen/internal/ast_helpers.go
+++ b/cmd/schemagen/internal/ast_helpers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 )
 
+// ExtractDescriptionFromComment normalizes comment text before schema generation.
 func ExtractDescriptionFromComment(group *ast.CommentGroup) (string, bool) {
 	if group == nil {
 		return "", false


### PR DESCRIPTION
Timing probe for the scoped PR gate on a narrow same-repo Go source change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Probe and tighten the scoped PR gate, adding a fast path with Namespace runners and a persistent Go cache to speed CI on targeted Go changes. Restricts the fast gate to Ubuntu for consistent timing.

- **New Features**
  - Classifies PRs as `docs_only`, `scoped`, or `full_fallback`; blocks `full_fallback` via a required fast gate.
  - Stricter change detection; ignores docs-only and falls back on non-Go, renames/copies, deletions, or >50 Go files; outputs changed Go sources/tests.
  - Runs `make run-changed-source-package-tests` for affected packages; aggregator always runs and interprets the mode/matrix result.
  - `setup-go-tools` adds `use-namespace-cache` to enable `namespacelabs/nscloud-cache-action` for module/build caches.

- **Refactors**
  - Routes hot-path jobs to Namespace runners (`namespace-profile-sawmills-runner`, `-xlarge`, `-arm64`) for this repo; keeps privileged tests on GitHub-hosted runners; fast gate runs Ubuntu-only for stability.
  - Applies Namespace cache/runners across build, lint, checks, correctness, ARM, and `queuedrain-hardening` workflows.
  - Adds runner labels to `.github/actionlint.yaml`.
  - Clarifies `schemagen` by documenting `ExtractDescriptionFromComment`; no-op change to re-run the probe after gate hardening.

<sup>Written for commit 72d4edde1bf4840ddf7def9a7d21d639be2e9643. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/91?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

