### PR TITLE
fix(splunkhecexporter): include HEC error bodies for actionable statuses

### DIFF
--- a/.chloggen/splunk-hec-detailed-error-body.yaml
+++ b/.chloggen/splunk-hec-detailed-error-body.yaml
@@ -1,0 +1,5 @@
+change_type: enhancement
+component: exporter/splunk_hec
+note: Include bounded Splunk HEC response bodies in actionable export errors.
+issues: [92]
+change_logs: [user]

--- a/.chloggen/splunk-hec-detailed-error-body.yaml
+++ b/.chloggen/splunk-hec-detailed-error-body.yaml
@@ -1,5 +1,0 @@
-change_type: enhancement
-component: exporter/splunk_hec
-note: Include bounded Splunk HEC response bodies in actionable export errors.
-issues: [92]
-change_logs: [user]

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -229,6 +229,7 @@ func TestConsumeMetrics(t *testing.T) {
 				errMsg = "Permanent error: " + errMsg
 				assert.Error(t, err)
 				assert.True(t, consumererror.IsPermanent(err))
+				errMsg += ": response body: response content"
 				assert.EqualError(t, err, errMsg)
 				return
 			}
@@ -2052,6 +2053,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 				errMsg = "Permanent error: " + errMsg
 				assert.Error(t, err)
 				assert.True(t, consumererror.IsPermanent(err))
+				errMsg += ": response body: response content"
 				assert.EqualError(t, err, errMsg)
 				return
 			}

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -189,6 +189,7 @@ type capturingData struct {
 	testing          *testing.T
 	receivedRequest  chan receivedRequest
 	statusCode       int
+	responseBody     string
 	checkCompression bool
 }
 
@@ -208,6 +209,7 @@ func (c *capturingData) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 	w.WriteHeader(c.statusCode)
+	_, _ = w.Write([]byte(c.responseBody))
 }
 
 func runMetricsExport(t *testing.T, cfg *Config, metrics pmetric.Metrics, expectedBatchesNum int, useMultiMetricsFormat bool) ([]receivedRequest, error) {
@@ -1343,7 +1345,8 @@ func TestErrorReceived(t *testing.T) {
 
 func TestErrorReceivedForbidden(t *testing.T) {
 	rr := make(chan receivedRequest)
-	capture := capturingData{receivedRequest: rr, statusCode: 403}
+	responseBody := `{"text":"Invalid token","code":4}`
+	capture := capturingData{receivedRequest: rr, statusCode: 403, responseBody: responseBody}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
@@ -1386,9 +1389,10 @@ func TestErrorReceivedForbidden(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Should have received request")
 	}
-	errMsg := fmt.Sprintf("Permanent error: HTTP \"/services/collector\" %d %q",
+	errMsg := fmt.Sprintf("Permanent error: HTTP \"/services/collector\" %d %q: response body: %s",
 		http.StatusForbidden,
 		http.StatusText(http.StatusForbidden),
+		responseBody,
 	)
 	assert.EqualError(t, err, errMsg)
 	assert.True(t, consumererror.IsPermanent(err))
@@ -1437,7 +1441,8 @@ func TestInvalidURL(t *testing.T) {
 }
 
 func TestHeartbeatStartupFailed(t *testing.T) {
-	capture := capturingData{statusCode: 403}
+	responseBody := `{"text":"Invalid token","code":4}`
+	capture := capturingData{statusCode: 403, responseBody: responseBody}
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
@@ -1469,8 +1474,9 @@ func TestHeartbeatStartupFailed(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualError(t,
 		exporter.Start(t.Context(), componenttest.NewNopHost()),
-		fmt.Sprintf("%s: heartbeat on startup failed: Permanent error: HTTP \"/services/collector\" 403 \"Forbidden\"",
+		fmt.Sprintf("%s: heartbeat on startup failed: Permanent error: HTTP \"/services/collector\" 403 \"Forbidden\": response body: %s",
 			params.ID.String(),
+			responseBody,
 		),
 	)
 	assert.NoError(t, exporter.Shutdown(t.Context()))
@@ -1674,7 +1680,7 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	splunkClient := newLogsClient(exportertest.NewNopSettings(metadata.Type), NewFactory().CreateDefaultConfig().(*Config))
 	logs := createLogData(1, 1, 1)
 
-	responseBody := `some error occurred`
+	responseBody := `{"text":"Invalid data format","code":6}`
 
 	// An HTTP client that returns status code 400 and response body responseBody.
 	httpClient, _ := newTestClient(400, responseBody)
@@ -1682,8 +1688,7 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	// Sending logs using the client.
 	err := splunkClient.pushLogData(t.Context(), logs)
 	require.True(t, consumererror.IsPermanent(err), "Expecting permanent error")
-	require.EqualError(t, err, "Permanent error: HTTP \"/v1/endpoint\" 400 \"Bad Request\"")
-	// The returned error should contain the response body responseBody.
+	require.EqualError(t, err, "Permanent error: HTTP \"/v1/endpoint\" 400 \"Bad Request\": response body: "+responseBody)
 
 	// An HTTP client that returns some other status code other than 400 and response body responseBody.
 	httpClient, _ = newTestClient(500, responseBody)
@@ -1692,7 +1697,6 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	err = splunkClient.pushLogData(t.Context(), logs)
 	require.False(t, consumererror.IsPermanent(err), "Expecting non-permanent error")
 	require.EqualError(t, err, "HTTP \"/v1/endpoint\" 500 \"Internal Server Error\"")
-	// The returned error should not contain the response body responseBody.
 	assert.NotContains(t, err.Error(), responseBody)
 }
 

--- a/internal/splunk/httprequest.go
+++ b/internal/splunk/httprequest.go
@@ -5,15 +5,20 @@ package splunk // import "github.com/open-telemetry/opentelemetry-collector-cont
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
-const HeaderRetryAfter = "Retry-After"
+const (
+	HeaderRetryAfter            = "Retry-After"
+	maxHTTPErrorResponseBodyLen = 8 * 1024
+)
 
 // HandleHTTPCode handles an http response and returns the right type of error in case of a failure.
 func HandleHTTPCode(resp *http.Response) error {
@@ -28,6 +33,12 @@ func HandleHTTPCode(resp *http.Response) error {
 		resp.StatusCode,
 		http.StatusText(resp.StatusCode),
 	)
+	if shouldReadHTTPErrorResponseBody(resp.StatusCode) {
+		body := readHTTPErrorResponseBody(resp)
+		if body != "" {
+			err = fmt.Errorf("%w: response body: %s", err, body)
+		}
+	}
 
 	switch resp.StatusCode {
 	// Check for responses that may include "Retry-After" header.
@@ -48,4 +59,27 @@ func HandleHTTPCode(resp *http.Response) error {
 	}
 
 	return err
+}
+
+func shouldReadHTTPErrorResponseBody(statusCode int) bool {
+	switch statusCode {
+	case http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden:
+		return true
+	default:
+		return false
+	}
+}
+
+func readHTTPErrorResponseBody(resp *http.Response) string {
+	if resp.Body == nil {
+		return ""
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTTPErrorResponseBodyLen))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(body))
 }

--- a/internal/splunk/httprequest_test.go
+++ b/internal/splunk/httprequest_test.go
@@ -5,9 +5,11 @@ package splunk
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +22,7 @@ func TestConsumeMetrics(t *testing.T) {
 	tests := []struct {
 		name             string
 		httpResponseCode int
+		responseBody     string
 		retryAfter       int
 		wantErr          bool
 		wantPermanentErr bool
@@ -28,11 +31,13 @@ func TestConsumeMetrics(t *testing.T) {
 		{
 			name:             "response_forbidden",
 			httpResponseCode: http.StatusForbidden,
-			wantErr:          true,
+			responseBody:     `{"text":"Invalid token","code":4}`,
+			wantPermanentErr: true,
 		},
 		{
 			name:             "response_bad_request",
 			httpResponseCode: http.StatusBadRequest,
+			responseBody:     `{"text":"Invalid data format","code":6}`,
 			wantPermanentErr: true,
 		},
 		{
@@ -44,6 +49,7 @@ func TestConsumeMetrics(t *testing.T) {
 			name:             "response_throttle_with_header",
 			retryAfter:       123,
 			httpResponseCode: http.StatusServiceUnavailable,
+			responseBody:     `{"text":"Server busy","code":9}`,
 			wantThrottleErr:  true,
 		},
 		{
@@ -58,6 +64,9 @@ func TestConsumeMetrics(t *testing.T) {
 					URL: &url.URL{Scheme: "http", Host: "splunk.com", Path: "/endpoint"},
 				},
 				StatusCode: tt.httpResponseCode,
+			}
+			if tt.responseBody != "" {
+				resp.Body = io.NopCloser(strings.NewReader(tt.responseBody))
 			}
 			if tt.retryAfter != 0 {
 				resp.Header = map[string][]string{
@@ -74,17 +83,51 @@ func TestConsumeMetrics(t *testing.T) {
 			if tt.wantPermanentErr {
 				assert.Error(t, err)
 				assert.True(t, consumererror.IsPermanent(err))
+				if tt.responseBody != "" {
+					assert.ErrorContains(t, err, "response body: "+tt.responseBody)
+				}
 				return
 			}
 
 			if tt.wantThrottleErr {
 				expected := fmt.Errorf("HTTP \"/endpoint\" %d %q", tt.httpResponseCode, http.StatusText(tt.httpResponseCode))
 				expected = exporterhelper.NewThrottleRetry(expected, time.Duration(tt.retryAfter)*time.Second)
-				assert.Equal(t, expected, err)
+				assert.EqualError(t, err, expected.Error())
+				assert.NotContains(t, err.Error(), "response body:")
 				return
 			}
 
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestHandleHTTPCodeLimitsResponseBody(t *testing.T) {
+	responseBody := strings.Repeat("a", maxHTTPErrorResponseBodyLen+1)
+	resp := &http.Response{
+		Request: &http.Request{
+			URL: &url.URL{Scheme: "http", Host: "splunk.com", Path: "/endpoint"},
+		},
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(strings.NewReader(responseBody)),
+	}
+
+	err := HandleHTTPCode(resp)
+	assert.EqualError(t, err, fmt.Sprintf(
+		"Permanent error: HTTP \"/endpoint\" 400 \"Bad Request\": response body: %s",
+		strings.Repeat("a", maxHTTPErrorResponseBodyLen),
+	))
+}
+
+func TestHandleHTTPCodeOmitsResponseBodyForInternalServerError(t *testing.T) {
+	resp := &http.Response{
+		Request: &http.Request{
+			URL: &url.URL{Scheme: "http", Host: "splunk.com", Path: "/endpoint"},
+		},
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader(`{"text":"Internal server error","code":8}`)),
+	}
+
+	err := HandleHTTPCode(resp)
+	assert.EqualError(t, err, `HTTP "/endpoint" 500 "Internal Server Error"`)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Splunk HEC error response bodies in exporter errors for actionable statuses to make failures easier to diagnose, addressing SAW-7634. Bodies are trimmed to 8KB and omitted for throttle (429/503) and generic 5xx like 500.

- **Bug Fixes**
  - `internal/splunk`: Attach response body for 400, 401, 403 (permanent only); keep `Retry-After` handling for 429/503 without bodies; cap body at 8KB.
  - Tests: Updated `exporter/splunkhecexporter`, `exporter/signalfxexporter`, and `internal/splunk` to assert new messages, body-size limit, and 5xx omission; test server now returns mock bodies.

<sup>Written for commit e281205d796cf52f11d840cf39291b7ac01cec20. Summary will update on new commits. <a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/92?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages for non-2xx HTTP responses now include a trimmed response body for clearer diagnostics; internal-server-error (500) responses omit the body.

* **Tests**
  * Added and updated tests to verify inclusion, omission, and truncation of response bodies in error messages across exporters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->