### PR TITLE
perf(loadbalancingexporter): avoid central queue lane index allocation

### DIFF
--- a/.chloggen/saw-7500-central-queue-lane-index-allocfree.yaml
+++ b/.chloggen/saw-7500-central-queue-lane-index-allocfree.yaml
@@ -1,0 +1,15 @@
+change_type: enhancement
+
+component: exporter/loadbalancing
+
+note: Avoid per-record allocation when hashing central queue routing keys into dynamic lanes.
+
+issues: [7500]
+
+subtext: |
+  The lane indexer now hashes the signal prefix and routing key incrementally
+  instead of allocating a temporary concatenated buffer for every log or metric
+  lane decision. The routing hash remains byte-for-byte equivalent to the
+  previous `signal + NUL + routing_key` input.
+
+change_logs: [user]

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -1084,9 +1084,15 @@ func centralQueueBalancedLaneRoutingKeyForRingUncached(ring *hashRing, signal si
 }
 
 var (
-	centralQueueLogsLaneHashSeed    = crc32.ChecksumIEEE([]byte("logs\x00"))
-	centralQueueMetricsLaneHashSeed = crc32.ChecksumIEEE([]byte("metrics\x00"))
+	centralQueueLogsLaneHashSeed    = centralQueueLaneHashSeed(signalKindLogs)
+	centralQueueMetricsLaneHashSeed = centralQueueLaneHashSeed(signalKindMetrics)
 )
+
+func centralQueueLaneHashSeed(signal signalKind) uint32 {
+	hashInput := make([]byte, len(signal)+1)
+	copy(hashInput, string(signal))
+	return crc32.ChecksumIEEE(hashInput)
+}
 
 func centralQueueLaneIndex(signal signalKind, routingKey []byte, laneCount int) uint32 {
 	var crc uint32

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -1083,12 +1083,28 @@ func centralQueueBalancedLaneRoutingKeyForRingUncached(ring *hashRing, signal si
 	return base
 }
 
+var (
+	centralQueueLogsLaneHashSeed    = crc32.ChecksumIEEE([]byte("logs\x00"))
+	centralQueueMetricsLaneHashSeed = crc32.ChecksumIEEE([]byte("metrics\x00"))
+)
+
 func centralQueueLaneIndex(signal signalKind, routingKey []byte, laneCount int) uint32 {
-	hashInput := make([]byte, len(routingKey)+len(signal)+1)
-	copy(hashInput, string(signal))
-	hashInput[len(signal)] = 0
-	copy(hashInput[len(signal)+1:], routingKey)
-	return crc32.ChecksumIEEE(hashInput) % uint32(laneCount)
+	var crc uint32
+	switch signal {
+	case signalKindLogs:
+		crc = centralQueueLogsLaneHashSeed
+	case signalKindMetrics:
+		crc = centralQueueMetricsLaneHashSeed
+	default:
+		hashInput := make([]byte, len(routingKey)+len(signal)+1)
+		copy(hashInput, string(signal))
+		hashInput[len(signal)] = 0
+		copy(hashInput[len(signal)+1:], routingKey)
+		return crc32.ChecksumIEEE(hashInput) % uint32(laneCount)
+	}
+
+	crc = crc32.Update(crc, crc32.IEEETable, routingKey)
+	return crc % uint32(laneCount)
 }
 
 func centralQueueLaneKey(signal signalKind, lane, salt uint32) []byte {

--- a/exporter/loadbalancingexporter/central_queue_benchmark_test.go
+++ b/exporter/loadbalancingexporter/central_queue_benchmark_test.go
@@ -5,6 +5,7 @@ package loadbalancingexporter
 
 import (
 	"fmt"
+	"hash/crc32"
 	"testing"
 	"time"
 
@@ -53,6 +54,31 @@ func TestCentralQueueBalancedLaneRoutingKeyCacheMatchesUncached(t *testing.T) {
 	}
 }
 
+func TestCentralQueueLaneIndexAvoidsAllocations(t *testing.T) {
+	routingKey := []byte("0123456789abcdef")
+
+	for _, signal := range []signalKind{signalKindLogs, signalKindMetrics} {
+		allocs := testing.AllocsPerRun(100, func() {
+			centralQueueLaneIndexBenchmarkSink = centralQueueLaneIndex(signal, routingKey, 256)
+		})
+
+		require.Zero(t, allocs)
+	}
+}
+
+func TestCentralQueueLaneIndexMatchesConcatenatedHash(t *testing.T) {
+	routingKey := []byte("0123456789abcdef")
+
+	for _, signal := range []signalKind{signalKindLogs, signalKindMetrics} {
+		hashInput := make([]byte, len(routingKey)+len(signal)+1)
+		copy(hashInput, string(signal))
+		hashInput[len(signal)] = 0
+		copy(hashInput[len(signal)+1:], routingKey)
+
+		require.Equal(t, crc32.ChecksumIEEE(hashInput)%256, centralQueueLaneIndex(signal, routingKey, 256))
+	}
+}
+
 func BenchmarkCentralQueueBalancedLaneRoutingKeyBigIDTopology(b *testing.B) {
 	endpoints := centralQueueBenchmarkBigIDEndpoints()
 	ring := newHashRing(endpoints)
@@ -62,6 +88,23 @@ func BenchmarkCentralQueueBalancedLaneRoutingKeyBigIDTopology(b *testing.B) {
 	b.ResetTimer()
 	for i := range b.N {
 		_ = centralQueueBalancedLaneRoutingKeyForRing(ring, signalKindLogs, uint32(i%laneCount))
+	}
+}
+
+var centralQueueLaneIndexBenchmarkSink uint32
+
+func BenchmarkCentralQueueLaneIndex(b *testing.B) {
+	routingKeys := [][]byte{
+		[]byte("0123456789abcdef"),
+		[]byte("fedcba9876543210"),
+		[]byte("bigid-production-mt3-a"),
+		[]byte("bigid-production-mt3-b"),
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := range b.N {
+		centralQueueLaneIndexBenchmarkSink = centralQueueLaneIndex(signalKindLogs, routingKeys[i&3], 256)
 	}
 }
 


### PR DESCRIPTION
loadbalancingexporter: Avoid central queue lane index allocation

Removes a per-record allocation from the central queue lane-index hot path while preserving the exact previous lane mapping.

Description:
- Replace per-call `signal + NUL + routing_key` buffer construction with precomputed CRC seeds for logs and metrics.
- Add red/green allocation and hash-equivalence tests plus a focused lane-index benchmark.
- Add SAW-7500 changelog entry.

Evidence:
- RED: `TestCentralQueueLaneIndexAvoidsAllocations` failed on old implementation with 1 alloc/call.
- RED benchmark: `BenchmarkCentralQueueLaneIndex` old path ~17.8 ns/op, 28 B/op, 1 alloc/op.
- GREEN: `go test ./...` from `exporter/loadbalancingexporter`.
- GREEN: `make chlog-validate`.
- GREEN benchmark: `BenchmarkCentralQueueLaneIndex` ~6.3 ns/op, 0 B/op, 0 allocs/op.
- Adversarial review: first pass BLOCK on mutable prefix slices + weak allocation test; fixed both; second pass PASS, no findings.

Refs: SAW-7500

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized hot-path optimization with equivalence tests; routing behavior for logs/metrics should be unchanged, with only non-logs/metrics signals still allocating as before.
> 
> **Overview**
> **Removes a per-record heap allocation** on the load-balancing exporter central queue path when mapping a routing key to a dynamic lane for **logs** and **metrics**.
> 
> Instead of building a fresh `signal + NUL + routing_key` buffer on every call, lane indexing now **starts from package-level CRC seeds** for those signals and **extends the hash incrementally** with `crc32.Update` on the routing key. Lane modulo behavior is unchanged; tests assert **byte-for-byte equivalence** with the old concatenated input. Other signal kinds still use the previous allocate-and-hash path.
> 
> Adds **zero-allocation and hash-equivalence tests**, a **`BenchmarkCentralQueueLaneIndex`**, and a **SAW-7500 changelog** entry for the enhancement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6d6b6db05876581b6a52d48fb76b1d6590e0642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a per-record allocation in `loadbalancingexporter` central queue lane indexing for logs and metrics while preserving exact lane mapping. This reduces hot-path cost and GC pressure (~17.8 ns/op, 1 alloc → ~6.3 ns/op, 0 allocs), supporting SAW-7500 stability goals.

- **Refactors**
  - Precompute CRC seeds for "logs\x00" and "metrics\x00" from signal constants and use `crc32.Update` with the routing key; other signals keep the concatenate-and-hash path.
  - Add allocation-avoidance and hash-equivalence tests, plus `BenchmarkCentralQueueLaneIndex` with a no-alloc sink.
  - Add SAW-7500 changelog entry.

<sup>Written for commit d6d6b6db05876581b6a52d48fb76b1d6590e0642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/95?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancements**
  * Optimized the load-balancing exporter's central queue routing to reduce memory allocations and improve performance during record processing.

* **Tests**
  * Added tests and benchmarks to validate the queue routing optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sawmills/opentelemetry-collector-contrib/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->