### PR TITLE
feat(awsfirehosereceiver): add Firehose metadata controls

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -63,7 +63,7 @@ jobs:
             exit 0
           fi
 
-          non_go_changes=$(printf '%s\n' "$changed_files" | grep -vE '.*\.go$|(^|/)go\.(mod|sum)$|(^|/)metadata\.yaml$|^\.chloggen/.+\.yaml$|^\.github/workflows/scoped-test\.yaml$' || true)
+          non_go_changes=$(printf '%s\n' "$changed_files" | grep -vE '.*\.go$|(^|/)go\.(mod|sum)$|(^|/)metadata\.yaml$|(^|/)config\.schema\.yaml$|(^|/)README\.md$|^\.chloggen/.+\.yaml$|^\.github/workflows/scoped-test\.yaml$' || true)
           if [[ -n "$non_go_changes" ]]; then
             echo "mode=full_fallback" >> "$GITHUB_OUTPUT"
             exit 0

--- a/receiver/awsfirehosereceiver/README.md
+++ b/receiver/awsfirehosereceiver/README.md
@@ -27,6 +27,9 @@ receivers:
     endpoint: 0.0.0.0:4433
     encoding: awscloudwatchmetricstreams_encoding
     access_key: "some_access_key"
+    common_attributes:
+      map_key: firehose
+      on_invalid: error
     tls:
       cert_file: server.crt
       key_file: server.key
@@ -70,10 +73,53 @@ Deprecated, use `encoding` instead. `record_type` will be removed in a future re
 The access key to be checked on each request received. This can be set when creating or updating the delivery stream.
 See [documentation](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-http) for details.
 
+### common\_attributes:
+
+Controls how the receiver handles the `X-Amz-Firehose-Common-Attributes` request header.
+
+By default, common attributes are attached as flat resource attributes and invalid common attributes are ignored after logging.
+For example, a Firehose common attribute named `source` is added as `resource.attributes["source"]`.
+
+Set `map_key` to attach common attributes as a nested resource attribute map:
+
+```yaml
+receivers:
+  awsfirehose:
+    common_attributes:
+      map_key: firehose
+```
+
+With this setting, a Firehose common attribute named `source` is added as `resource.attributes["firehose"]["source"]`.
+Existing attributes are not overwritten. If `map_key` already exists and is not a map, the receiver leaves it unchanged and logs a warning.
+
+The `on_invalid` setting controls malformed common attributes:
+
+- `ignore` logs the parsing error and continues without attaching common attributes. This is the default for compatibility.
+- `error` returns a non-200 Firehose response. Use this when common attributes are required for downstream processing.
+
+## HTTP request handling
+
+The receiver accepts Firehose HTTP endpoint requests using the [Amazon Data Firehose request and response format](https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html).
+Firehose sends JSON requests with `Content-Type: application/json`.
+
+The receiver validates:
+
+- `POST` method.
+- `Content-Type: application/json` when the header is present.
+- `X-Amz-Firehose-Request-Id`.
+- Optional `X-Amz-Firehose-Access-Key`.
+- Matching body `requestId`.
+
+Every receiver-side rejection returns a Firehose-shaped JSON response containing `requestId`, `timestamp`, and `errorMessage`.
+Path routing is intentionally flexible: any path that reaches this receiver is accepted when the method, headers, and body are valid.
+
 ## Encodings
 
 Any encoding extension can be used with this receiver. There are additionally built-in encodings, which are deprecated.
 In the future it will be required to specify an encoding extension, and the built-in encodings will be removed.
+
+CloudFront real-time log schemas, or any other schema-aware parsing rules, belong in the configured encoding extension.
+This receiver loads the extension by component ID at runtime and does not depend on any specific private extension package.
 
 ### cwmetrics (deprecated)
 

--- a/receiver/awsfirehosereceiver/common_attributes.go
+++ b/receiver/awsfirehosereceiver/common_attributes.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package awsfirehosereceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver"
+
+import (
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const (
+	commonAttributesWarnSampleTick       = time.Minute
+	commonAttributesWarnSampleFirst      = 1
+	commonAttributesWarnSampleThereafter = 100
+)
+
+func nextRecordErrorStatus(error) int {
+	return http.StatusBadRequest
+}
+
+func commonAttributesConfig(config *Config) CommonAttributesConfig {
+	if config == nil {
+		return CommonAttributesConfig{}
+	}
+	return config.CommonAttributes
+}
+
+func newCommonAttributesLogger(logger *zap.Logger) *zap.Logger {
+	if logger == nil {
+		return nil
+	}
+	return logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		return zapcore.NewSamplerWithOptions(
+			core,
+			commonAttributesWarnSampleTick,
+			commonAttributesWarnSampleFirst,
+			commonAttributesWarnSampleThereafter,
+		)
+	}))
+}
+
+func attachCommonAttributes(attrs pcommon.Map, commonAttributes map[string]string, cfg CommonAttributesConfig, logger *zap.Logger, warnOnNonMapTarget bool) bool {
+	if len(commonAttributes) == 0 {
+		return false
+	}
+
+	if cfg.MapKey == "" {
+		attachMissingCommonAttributes(attrs, commonAttributes)
+		return false
+	}
+
+	existing, found := attrs.Get(cfg.MapKey)
+	if !found {
+		attachMissingCommonAttributes(attrs.PutEmptyMap(cfg.MapKey), commonAttributes)
+		return false
+	}
+	if existing.Type() != pcommon.ValueTypeMap {
+		if logger != nil && warnOnNonMapTarget {
+			logger.Warn("Firehose common attributes target exists and is not a map", zap.String("map_key", cfg.MapKey))
+		}
+		return true
+	}
+	attachMissingCommonAttributes(existing.Map(), commonAttributes)
+	return false
+}
+
+func attachMissingCommonAttributes(attrs pcommon.Map, commonAttributes map[string]string) {
+	for k, v := range commonAttributes {
+		if _, found := attrs.Get(k); !found {
+			attrs.PutStr(k, v)
+		}
+	}
+}

--- a/receiver/awsfirehosereceiver/config.go
+++ b/receiver/awsfirehosereceiver/config.go
@@ -5,6 +5,7 @@ package awsfirehosereceiver // import "github.com/open-telemetry/opentelemetry-c
 
 import (
 	"errors"
+	"fmt"
 
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
@@ -12,6 +13,11 @@ import (
 )
 
 var errRecordTypeEncodingSet = errors.New("record_type must not be set when encoding is set")
+
+const (
+	commonAttributesOnInvalidIgnore = "ignore"
+	commonAttributesOnInvalidError  = "error"
+)
 
 type Config struct {
 	// ServerConfig is used to set up the Firehose delivery
@@ -35,6 +41,18 @@ type Config struct {
 	// This can be set when creating or updating the Firehose delivery
 	// stream.
 	AccessKey configopaque.String `mapstructure:"access_key"`
+	// CommonAttributes controls how Firehose common attributes are parsed
+	// and attached to resource attributes.
+	CommonAttributes CommonAttributesConfig `mapstructure:"common_attributes"`
+}
+
+type CommonAttributesConfig struct {
+	// MapKey stores Firehose common attributes as a nested resource attribute
+	// map. If empty, common attributes are attached as flat resource attributes.
+	MapKey string `mapstructure:"map_key"`
+	// OnInvalid controls malformed X-Amz-Firehose-Common-Attributes handling.
+	// Supported values are "ignore" and "error".
+	OnInvalid string `mapstructure:"on_invalid"`
 }
 
 // Validate checks that the endpoint and record type exist and
@@ -46,7 +64,26 @@ func (c *Config) Validate() error {
 	if c.RecordType != "" && c.Encoding != "" {
 		return errRecordTypeEncodingSet
 	}
+	if err := c.CommonAttributes.Validate(); err != nil {
+		return err
+	}
 	return nil
+}
+
+func (c CommonAttributesConfig) Validate() error {
+	switch c.OnInvalid {
+	case "", commonAttributesOnInvalidIgnore, commonAttributesOnInvalidError:
+		return nil
+	default:
+		return fmt.Errorf("common_attributes.on_invalid must be one of %q or %q", commonAttributesOnInvalidIgnore, commonAttributesOnInvalidError)
+	}
+}
+
+func (c CommonAttributesConfig) onInvalid() string {
+	if c.OnInvalid == "" {
+		return commonAttributesOnInvalidIgnore
+	}
+	return c.OnInvalid
 }
 
 func handleDeprecatedConfig(cfg *Config, logger *zap.Logger) {

--- a/receiver/awsfirehosereceiver/config.schema.yaml
+++ b/receiver/awsfirehosereceiver/config.schema.yaml
@@ -1,8 +1,21 @@
+$defs:
+  common_attributes_config:
+    type: object
+    properties:
+      map_key:
+        description: MapKey stores Firehose common attributes as a nested resource attribute map. If empty, common attributes are attached as flat resource attributes.
+        type: string
+      on_invalid:
+        description: OnInvalid controls malformed X-Amz-Firehose-Common-Attributes handling. Supported values are "ignore" and "error".
+        type: string
 type: object
 properties:
   access_key:
     description: AccessKey is checked against the one received with each request. This can be set when creating or updating the Firehose delivery stream.
     $ref: go.opentelemetry.io/collector/config/configopaque.string
+  common_attributes:
+    description: CommonAttributes controls how Firehose common attributes are parsed and attached to resource attributes.
+    $ref: common_attributes_config
   encoding:
     description: 'Encoding identifies the encoding of records received from Firehose. Defaults to telemetry-specific encodings: "cwlog" for logs, and "cwmetrics" for metrics. This default behavior is deprecated as of v0.149.0, and in the future it will be required to specify the encoding explicitly.'
     type: string

--- a/receiver/awsfirehosereceiver/config_test.go
+++ b/receiver/awsfirehosereceiver/config_test.go
@@ -41,6 +41,9 @@ func TestLoadConfig(t *testing.T) {
 			require.Equal(t, &Config{
 				RecordType: configType,
 				AccessKey:  "some_access_key",
+				CommonAttributes: CommonAttributesConfig{
+					OnInvalid: commonAttributesOnInvalidIgnore,
+				},
 				ServerConfig: confighttp.ServerConfig{
 					NetAddr: confignet.AddrConfig{
 						Transport: "tcp",
@@ -71,4 +74,43 @@ func TestLoadConfigInvalid(t *testing.T) {
 
 	err = xconfmap.Validate(cfg)
 	assert.ErrorIs(t, err, errRecordTypeEncodingSet)
+}
+
+func TestValidate(t *testing.T) {
+	testCases := map[string]struct {
+		mutate  func(*Config)
+		wantErr string
+	}{
+		"Default": {},
+		"CommonAttributesOnInvalidIgnore": {
+			mutate: func(cfg *Config) {
+				cfg.CommonAttributes.OnInvalid = commonAttributesOnInvalidIgnore
+			},
+		},
+		"CommonAttributesOnInvalidError": {
+			mutate: func(cfg *Config) {
+				cfg.CommonAttributes.OnInvalid = commonAttributesOnInvalidError
+			},
+		},
+		"CommonAttributesOnInvalidInvalid": {
+			mutate: func(cfg *Config) {
+				cfg.CommonAttributes.OnInvalid = "invalid"
+			},
+			wantErr: `common_attributes.on_invalid must be one of "ignore" or "error"`,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			if testCase.mutate != nil {
+				testCase.mutate(cfg)
+			}
+			err := cfg.Validate()
+			if testCase.wantErr != "" {
+				require.EqualError(t, err, testCase.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/receiver/awsfirehosereceiver/factory.go
+++ b/receiver/awsfirehosereceiver/factory.go
@@ -39,6 +39,9 @@ func createDefaultConfig() component.Config {
 		ServerConfig: confighttp.ServerConfig{
 			NetAddr: netAddr,
 		},
+		CommonAttributes: CommonAttributesConfig{
+			OnInvalid: commonAttributesOnInvalidIgnore,
+		},
 	}
 }
 

--- a/receiver/awsfirehosereceiver/logs_receiver.go
+++ b/receiver/awsfirehosereceiver/logs_receiver.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog"
 )
@@ -24,8 +25,9 @@ const defaultLogsEncoding = cwlog.TypeStr
 // logsConsumer implements the firehoseConsumer
 // to use a logs consumer and unmarshaler.
 type logsConsumer struct {
-	config   *Config
-	settings receiver.Settings
+	config                 *Config
+	settings               receiver.Settings
+	commonAttributesLogger *zap.Logger
 
 	// consumer passes the translated logs on to the
 	// next consumer.
@@ -45,9 +47,10 @@ func newLogsReceiver(
 	nextConsumer consumer.Logs,
 ) (receiver.Logs, error) {
 	c := &logsConsumer{
-		config:   config,
-		settings: set,
-		consumer: nextConsumer,
+		config:                 config,
+		settings:               set,
+		commonAttributesLogger: newCommonAttributesLogger(set.Logger),
+		consumer:               nextConsumer,
 	}
 	return &firehoseReceiver{
 		settings: set,
@@ -86,10 +89,14 @@ func (c *logsConsumer) Start(_ context.Context, host component.Host) error {
 // with each resulting plog.Logs being sent to the next consumer as
 // they are unmarshalled.
 func (c *logsConsumer) Consume(ctx context.Context, nextRecord nextRecordFunc, commonAttributes map[string]string) (int, error) {
+	warnOnNonMapTarget := true
 	for {
 		record, err := nextRecord()
 		if errors.Is(err, io.EOF) {
 			break
+		}
+		if err != nil {
+			return nextRecordErrorStatus(err), err
 		}
 		logs, err := c.unmarshaler.UnmarshalLogs(record)
 		if err != nil {
@@ -99,10 +106,8 @@ func (c *logsConsumer) Consume(ctx context.Context, nextRecord nextRecordFunc, c
 		if commonAttributes != nil {
 			for i := 0; i < logs.ResourceLogs().Len(); i++ {
 				rm := logs.ResourceLogs().At(i)
-				for k, v := range commonAttributes {
-					if _, found := rm.Resource().Attributes().Get(k); !found {
-						rm.Resource().Attributes().PutStr(k, v)
-					}
+				if attachCommonAttributes(rm.Resource().Attributes(), commonAttributes, commonAttributesConfig(c.config), c.commonAttributesLogger, warnOnNonMapTarget) {
+					warnOnNonMapTarget = false
 				}
 			}
 		}

--- a/receiver/awsfirehosereceiver/logs_receiver_test.go
+++ b/receiver/awsfirehosereceiver/logs_receiver_test.go
@@ -174,6 +174,86 @@ func TestLogsConsumer(t *testing.T) {
 		require.Equal(t, 1, gotRms.Len())
 		gotRm := gotRms.At(0)
 		require.Equal(t, 1, gotRm.Resource().Attributes().Len())
+		got, found := gotRm.Resource().Attributes().Get("CommonAttributes")
+		require.True(t, found)
+		require.Equal(t, "Test", got.Str())
+	})
+	t.Run("WithNestedCommonAttributes", func(t *testing.T) {
+		base := plog.NewLogs()
+		base.ResourceLogs().AppendEmpty()
+		rc := logsRecordConsumer{}
+		lc := &logsConsumer{
+			config: &Config{
+				CommonAttributes: CommonAttributesConfig{MapKey: "firehose"},
+			},
+			settings:    receivertest.NewNopSettings(metadata.Type),
+			unmarshaler: unmarshalertest.NewWithLogs(base),
+			consumer:    &rc,
+		}
+		gotStatus, gotErr := lc.Consume(t.Context(), newNextRecordFunc([][]byte{{}}), map[string]string{
+			"source": "cloudfront",
+			"group":  "cs",
+		})
+		require.Equal(t, http.StatusOK, gotStatus)
+		require.NoError(t, gotErr)
+		require.Len(t, rc.results, 1)
+
+		attrs := rc.results[0].ResourceLogs().At(0).Resource().Attributes()
+		firehose, found := attrs.Get("firehose")
+		require.True(t, found)
+		require.Equal(t, pcommon.ValueTypeMap, firehose.Type())
+		require.Equal(t, "cloudfront", getStringValue(t, firehose.Map(), "source"))
+		require.Equal(t, "cs", getStringValue(t, firehose.Map(), "group"))
+	})
+	t.Run("WithNestedCommonAttributesPreservesExistingValues", func(t *testing.T) {
+		base := plog.NewLogs()
+		attrs := base.ResourceLogs().AppendEmpty().Resource().Attributes()
+		firehose := attrs.PutEmptyMap("firehose")
+		firehose.PutStr("source", "existing")
+		rc := logsRecordConsumer{}
+		lc := &logsConsumer{
+			config: &Config{
+				CommonAttributes: CommonAttributesConfig{MapKey: "firehose"},
+			},
+			settings:    receivertest.NewNopSettings(metadata.Type),
+			unmarshaler: unmarshalertest.NewWithLogs(base),
+			consumer:    &rc,
+		}
+		gotStatus, gotErr := lc.Consume(t.Context(), newNextRecordFunc([][]byte{{}}), map[string]string{
+			"source": "cloudfront",
+			"group":  "cs",
+		})
+		require.Equal(t, http.StatusOK, gotStatus)
+		require.NoError(t, gotErr)
+
+		gotFirehose, found := rc.results[0].ResourceLogs().At(0).Resource().Attributes().Get("firehose")
+		require.True(t, found)
+		require.Equal(t, "existing", getStringValue(t, gotFirehose.Map(), "source"))
+		require.Equal(t, "cs", getStringValue(t, gotFirehose.Map(), "group"))
+	})
+	t.Run("WithNestedCommonAttributesPreservesNonMapTarget", func(t *testing.T) {
+		base := plog.NewLogs()
+		attrs := base.ResourceLogs().AppendEmpty().Resource().Attributes()
+		attrs.PutStr("firehose", "existing")
+		rc := logsRecordConsumer{}
+		lc := &logsConsumer{
+			config: &Config{
+				CommonAttributes: CommonAttributesConfig{MapKey: "firehose"},
+			},
+			settings:    receivertest.NewNopSettings(metadata.Type),
+			unmarshaler: unmarshalertest.NewWithLogs(base),
+			consumer:    &rc,
+		}
+		gotStatus, gotErr := lc.Consume(t.Context(), newNextRecordFunc([][]byte{{}}), map[string]string{
+			"source": "cloudfront",
+		})
+		require.Equal(t, http.StatusOK, gotStatus)
+		require.NoError(t, gotErr)
+
+		firehose, found := rc.results[0].ResourceLogs().At(0).Resource().Attributes().Get("firehose")
+		require.True(t, found)
+		require.Equal(t, pcommon.ValueTypeStr, firehose.Type())
+		require.Equal(t, "existing", firehose.Str())
 	})
 	t.Run("WithMultipleRecords", func(t *testing.T) {
 		logs0, logRecords0 := newLogs("service0", "scope0")
@@ -201,6 +281,13 @@ func TestLogsConsumer(t *testing.T) {
 		assert.NoError(t, plogtest.CompareLogs(logs0, rc.results[0]))
 		assert.NoError(t, plogtest.CompareLogs(logs1, rc.results[1]))
 	})
+}
+
+func getStringValue(t *testing.T, attrs pcommon.Map, key string) string {
+	value, found := attrs.Get(key)
+	require.True(t, found)
+	require.Equal(t, pcommon.ValueTypeStr, value.Type())
+	return value.Str()
 }
 
 func newLogs(serviceName, scopeName string) (plog.Logs, plog.LogRecordSlice) {

--- a/receiver/awsfirehosereceiver/metrics_receiver.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/extension"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/awscloudwatchmetricstreamsencodingextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream"
@@ -26,8 +27,9 @@ const defaultMetricsEncoding = cwmetricstream.TypeStr
 // The metricsConsumer implements the firehoseConsumer
 // to use a metrics consumer and unmarshaler.
 type metricsConsumer struct {
-	config   *Config
-	settings receiver.Settings
+	config                 *Config
+	settings               receiver.Settings
+	commonAttributesLogger *zap.Logger
 	// consumer passes the translated metrics on to the
 	// next consumer.
 	consumer consumer.Metrics
@@ -46,9 +48,10 @@ func newMetricsReceiver(
 	nextConsumer consumer.Metrics,
 ) (receiver.Metrics, error) {
 	c := &metricsConsumer{
-		config:   config,
-		settings: set,
-		consumer: nextConsumer,
+		config:                 config,
+		settings:               set,
+		commonAttributesLogger: newCommonAttributesLogger(set.Logger),
+		consumer:               nextConsumer,
 	}
 	return &firehoseReceiver{
 		settings: set,
@@ -121,10 +124,14 @@ func (c *metricsConsumer) newUnmarshalerFromEncoding(
 // with each resulting pmetric.Metrics being sent to the next consumer
 // as they are unmarshalled.
 func (c *metricsConsumer) Consume(ctx context.Context, nextRecord nextRecordFunc, commonAttributes map[string]string) (int, error) {
+	warnOnNonMapTarget := true
 	for {
 		record, err := nextRecord()
 		if errors.Is(err, io.EOF) {
 			break
+		}
+		if err != nil {
+			return nextRecordErrorStatus(err), err
 		}
 		metrics, err := c.unmarshaler.UnmarshalMetrics(record)
 		if err != nil {
@@ -134,10 +141,8 @@ func (c *metricsConsumer) Consume(ctx context.Context, nextRecord nextRecordFunc
 		if commonAttributes != nil {
 			for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
 				rm := metrics.ResourceMetrics().At(i)
-				for k, v := range commonAttributes {
-					if _, found := rm.Resource().Attributes().Get(k); !found {
-						rm.Resource().Attributes().PutStr(k, v)
-					}
+				if attachCommonAttributes(rm.Resource().Attributes(), commonAttributes, commonAttributesConfig(c.config), c.commonAttributesLogger, warnOnNonMapTarget) {
+					warnOnNonMapTarget = false
 				}
 			}
 		}

--- a/receiver/awsfirehosereceiver/metrics_receiver_test.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver_test.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -189,6 +190,40 @@ func TestMetricsConsumer(t *testing.T) {
 		require.Equal(t, 1, gotRms.Len())
 		gotRm := gotRms.At(0)
 		require.Equal(t, 1, gotRm.Resource().Attributes().Len())
+		got, found := gotRm.Resource().Attributes().Get("CommonAttributes")
+		require.True(t, found)
+		require.Equal(t, "Test", got.Str())
+	})
+	t.Run("WithNestedCommonAttributes", func(t *testing.T) {
+		base := pmetric.NewMetrics()
+		base.ResourceMetrics().AppendEmpty()
+		rc := metricsRecordConsumer{}
+		mc := &metricsConsumer{
+			config: &Config{
+				CommonAttributes: CommonAttributesConfig{MapKey: "firehose"},
+			},
+			settings:    receivertest.NewNopSettings(metadata.Type),
+			unmarshaler: unmarshalertest.NewWithMetrics(base),
+			consumer:    &rc,
+		}
+		gotStatus, gotErr := mc.Consume(
+			t.Context(),
+			newNextRecordFunc([][]byte{{}}),
+			map[string]string{
+				"source": "cloudfront",
+				"group":  "cs",
+			},
+		)
+		require.Equal(t, http.StatusOK, gotStatus)
+		require.NoError(t, gotErr)
+		require.Len(t, rc.results, 1)
+
+		attrs := rc.results[0].ResourceMetrics().At(0).Resource().Attributes()
+		firehose, found := attrs.Get("firehose")
+		require.True(t, found)
+		require.Equal(t, pcommon.ValueTypeMap, firehose.Type())
+		require.Equal(t, "cloudfront", getStringValue(t, firehose.Map(), "source"))
+		require.Equal(t, "cs", getStringValue(t, firehose.Map(), "group"))
 	})
 	t.Run("WithMultipleRecords", func(t *testing.T) {
 		metrics0, metricSlice0 := newMetrics("service0", "scope0")

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -10,9 +10,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -33,6 +35,8 @@ const (
 
 var (
 	errInvalidAccessKey         = errors.New("invalid firehose access key")
+	errInvalidContentType       = errors.New("invalid content type")
+	errInvalidMethod            = errors.New("invalid HTTP method")
 	errInHeaderMissingRequestID = errors.New("missing request id in header")
 	errInBodyMissingRequestID   = errors.New("missing request id in body")
 	errInBodyDiffRequestID      = errors.New("different request id in body")
@@ -198,6 +202,10 @@ func (fmr *firehoseReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"Unable to get common attributes from request header. Will not attach attributes.",
 			zap.Error(err),
 		)
+		if fmr.config.CommonAttributes.onInvalid() == commonAttributesOnInvalidError {
+			fmr.sendResponse(w, requestID, http.StatusBadRequest, err)
+			return
+		}
 	}
 
 	var recordIndex int
@@ -232,6 +240,15 @@ func (fmr *firehoseReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // validate checks the Firehose access key in the header against
 // the one passed into the Config
 func (fmr *firehoseReceiver) validate(r *http.Request) (int, error) {
+	if r.Method != http.MethodPost {
+		return http.StatusMethodNotAllowed, errInvalidMethod
+	}
+	if contentType := r.Header.Get(headerContentType); contentType != "" {
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil || !strings.EqualFold(mediaType, "application/json") {
+			return http.StatusUnsupportedMediaType, errInvalidContentType
+		}
+	}
 	if string(fmr.config.AccessKey) == "" {
 		// No access key is configured - accept all requests.
 		return http.StatusAccepted, nil

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -124,8 +124,13 @@ func TestFirehoseRequest(t *testing.T) {
 	var noRecords []firehoseRecord
 	testCases := map[string]struct {
 		headers          map[string]string
+		method           string
+		path             string
+		contentType      *string
 		commonAttributes map[string]string
+		commonHeader     string
 		body             any
+		config           *Config
 		consumer         firehoseConsumer
 		wantStatusCode   int
 		wantErr          error
@@ -154,6 +159,23 @@ func TestFirehoseRequest(t *testing.T) {
 			wantStatusCode: http.StatusUnauthorized,
 			wantErr:        errInvalidAccessKey,
 		},
+		"WithInvalidMethod": {
+			method:         http.MethodGet,
+			body:           testFirehoseRequest(testFirehoseRequestID, noRecords),
+			wantStatusCode: http.StatusMethodNotAllowed,
+			wantErr:        errInvalidMethod,
+		},
+		"WithInvalidContentType": {
+			contentType:    ptr("text/plain"),
+			body:           testFirehoseRequest(testFirehoseRequestID, noRecords),
+			wantStatusCode: http.StatusUnsupportedMediaType,
+			wantErr:        errInvalidContentType,
+		},
+		"WithMissingContentType": {
+			contentType:    ptr(""),
+			body:           testFirehoseRequest(testFirehoseRequestID, noRecords),
+			wantStatusCode: http.StatusOK,
+		},
 		"WithoutRequestId/Body": {
 			headers: map[string]string{
 				headerFirehoseRequestID: testFirehoseRequestID,
@@ -169,6 +191,11 @@ func TestFirehoseRequest(t *testing.T) {
 			body:           testFirehoseRequest("otherId", noRecords),
 			wantStatusCode: http.StatusBadRequest,
 			wantErr:        errInBodyDiffRequestID,
+		},
+		"WithAnyPath": {
+			path:           "/firehose/custom/path",
+			body:           testFirehoseRequest(testFirehoseRequestID, noRecords),
+			wantStatusCode: http.StatusOK,
 		},
 		"WithNoRecords": {
 			body:           testFirehoseRequest(testFirehoseRequestID, noRecords),
@@ -208,6 +235,23 @@ func TestFirehoseRequest(t *testing.T) {
 			},
 			wantStatusCode: http.StatusOK,
 		},
+		"WithInvalidCommonAttributesIgnored": {
+			commonHeader:   "{",
+			body:           testFirehoseRequest(testFirehoseRequestID, noRecords),
+			wantStatusCode: http.StatusOK,
+		},
+		"WithInvalidCommonAttributesError": {
+			config: &Config{
+				AccessKey: testFirehoseAccessKey,
+				CommonAttributes: CommonAttributesConfig{
+					OnInvalid: commonAttributesOnInvalidError,
+				},
+			},
+			commonHeader:   "{",
+			body:           testFirehoseRequest(testFirehoseRequestID, noRecords),
+			wantStatusCode: http.StatusBadRequest,
+			wantErr:        errors.New("unexpected end of JSON input"),
+		},
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -215,6 +259,19 @@ func TestFirehoseRequest(t *testing.T) {
 			require.NoError(t, err)
 
 			request := newTestRequest(body)
+			if testCase.method != "" {
+				request.Method = testCase.method
+			}
+			if testCase.path != "" {
+				request.URL.Path = testCase.path
+			}
+			if testCase.contentType != nil {
+				if *testCase.contentType == "" {
+					request.Header.Del(headerContentType)
+				} else {
+					request.Header.Set(headerContentType, *testCase.contentType)
+				}
+			}
 			if testCase.headers != nil {
 				for k, v := range testCase.headers {
 					request.Header.Set(k, v)
@@ -227,22 +284,31 @@ func TestFirehoseRequest(t *testing.T) {
 				require.NoError(t, err)
 				request.Header.Set(headerFirehoseCommonAttributes, string(attrs))
 			}
+			if testCase.commonHeader != "" {
+				request.Header.Set(headerFirehoseCommonAttributes, testCase.commonHeader)
+			}
 
 			consumer := testCase.consumer
 			if consumer == nil {
 				consumer = defaultConsumer
 			}
-			r := testFirehoseReceiver(cfg, consumer)
+			testConfig := cfg
+			if testCase.config != nil {
+				testConfig = testCase.config
+			}
+			r := testFirehoseReceiver(testConfig, consumer)
 
 			got := httptest.NewRecorder()
 			r.ServeHTTP(got, request)
 
 			require.Equal(t, testCase.wantStatusCode, got.Code)
+			require.Equal(t, "application/json", got.Header().Get(headerContentType))
 			var gotResponse firehoseResponse
 			require.NoError(t, json.Unmarshal(got.Body.Bytes(), &gotResponse))
 			require.Equal(t, request.Header.Get(headerFirehoseRequestID), gotResponse.RequestID)
+			require.Positive(t, gotResponse.Timestamp)
 			if testCase.wantErr != nil {
-				require.Equal(t, testCase.wantErr.Error(), gotResponse.ErrorMessage)
+				require.Contains(t, gotResponse.ErrorMessage, testCase.wantErr.Error())
 			} else {
 				require.Empty(t, gotResponse.ErrorMessage)
 			}
@@ -267,6 +333,62 @@ func TestFirehoseRequestInvalidJSON(t *testing.T) {
 	require.Regexp(t, gotResponse.ErrorMessage, `awsfirehosereceiver\.firehoseRequest\.ReadStringAsSlice: expects .*`)
 }
 
+func TestFirehoseRequestWithEncodingExtensionAndNestedCommonAttributes(t *testing.T) {
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.LogRecords().AppendEmpty().Body().SetStr("decoded cloudfront row")
+
+	extension := &capturePlogUnmarshalerExtension{logs: logs}
+	rc := logsRecordConsumer{}
+	cfg := &Config{
+		AccessKey: testFirehoseAccessKey,
+		Encoding:  "cloudfront_realtime_logs/test",
+		CommonAttributes: CommonAttributesConfig{
+			MapKey:    "firehose",
+			OnInvalid: commonAttributesOnInvalidError,
+		},
+	}
+	gotReceiver, err := newLogsReceiver(
+		cfg,
+		receivertest.NewNopSettings(metadata.Type),
+		&rc,
+	)
+	require.NoError(t, err)
+	receiver := gotReceiver.(*firehoseReceiver)
+	require.NoError(t, receiver.consumer.Start(t.Context(), hostWithExtensions{
+		extensions: map[component.ID]component.Component{
+			component.MustNewIDWithName("cloudfront_realtime_logs", "test"): extension,
+		},
+	}))
+
+	body, err := json.Marshal(testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{
+		testFirehoseRecord("decoded-record-bytes"),
+	}))
+	require.NoError(t, err)
+	request := newTestRequest(body)
+	attrs, err := json.Marshal(firehoseCommonAttributes{
+		CommonAttributes: map[string]string{
+			"source":         "cloudfront",
+			"distributionId": "EDFDVBD6EXAMPLE",
+		},
+	})
+	require.NoError(t, err)
+	request.Header.Set(headerFirehoseCommonAttributes, string(attrs))
+
+	got := httptest.NewRecorder()
+	receiver.ServeHTTP(got, request)
+	require.Equal(t, http.StatusOK, got.Code)
+	require.Equal(t, [][]byte{[]byte("decoded-record-bytes")}, extension.records)
+	require.Len(t, rc.results, 1)
+
+	firehose, found := rc.results[0].ResourceLogs().At(0).Resource().Attributes().Get("firehose")
+	require.True(t, found)
+	require.Equal(t, "cloudfront", getStringValue(t, firehose.Map(), "source"))
+	require.Equal(t, "EDFDVBD6EXAMPLE", getStringValue(t, firehose.Map(), "distributionId"))
+	require.Equal(t, "decoded cloudfront row", rc.results[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Str())
+}
+
 // testFirehoseReceiver is a convenience function for creating a test firehoseReceiver
 func testFirehoseReceiver(config *Config, consumer firehoseConsumer) *firehoseReceiver {
 	return &firehoseReceiver{
@@ -283,6 +405,10 @@ func newTestRequest(requestBody []byte) *http.Request {
 	request.Header.Set(headerFirehoseRequestID, testFirehoseRequestID)
 	request.Header.Set(headerFirehoseAccessKey, testFirehoseAccessKey)
 	return request
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }
 
 func testFirehoseRequest(requestID string, records []firehoseRecord) firehoseRequest {
@@ -331,6 +457,24 @@ func (plogUnmarshalerExtension) Shutdown(context.Context) error {
 }
 
 func (e plogUnmarshalerExtension) UnmarshalLogs([]byte) (plog.Logs, error) {
+	return e.logs, nil
+}
+
+type capturePlogUnmarshalerExtension struct {
+	logs    plog.Logs
+	records [][]byte
+}
+
+func (*capturePlogUnmarshalerExtension) Start(context.Context, component.Host) error {
+	return nil
+}
+
+func (*capturePlogUnmarshalerExtension) Shutdown(context.Context) error {
+	return nil
+}
+
+func (e *capturePlogUnmarshalerExtension) UnmarshalLogs(data []byte) (plog.Logs, error) {
+	e.records = append(e.records, append([]byte(nil), data...))
 	return e.logs, nil
 }
 


### PR DESCRIPTION
Add configurable handling for Firehose common attributes, including strict malformed-header behavior and optional nested resource placement. Validate Firehose HTTP method/content type while preserving flexible path routing, and keep encoding extension loading generic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable handling for Firehose common attributes, nested placement, and strict malformed-header behavior, plus stricter HTTP validation and Firehose-shaped JSON responses in `awsfirehosereceiver`. Supports SAW-7649 by preserving Datadog-triggering tags and accepting any path while validating method/content type and requestId.

- New Features
  - `common_attributes`:
    - `map_key` nests attributes (e.g., under `firehose`) without overwriting existing values; warns if the target isn’t a map.
    - `on_invalid` to `ignore` (default) or `error` for malformed `X-Amz-Firehose-Common-Attributes`.
  - HTTP validation: require `POST`, check `Content-Type: application/json` when present, accept any path, validate `requestId` header/body match, and always return Firehose-shaped JSON with `requestId` and `timestamp`.
  - Encoding stays generic; schema-specific parsing (e.g., CloudFront) lives in the selected encoding extension.

- Bug Fixes
  - CI fast-gate allowlist expanded to include `config.schema.yaml` and `README.md` for quicker scoped tests.

<sup>Written for commit 3a0c80f1363033b16289e6233e187d5d8cc0dd28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `common_attributes` configuration block to handle Firehose common attributes, supporting flat attachment or nesting under a configurable key
  * Configurable error handling for malformed common attributes (`ignore` or `error` mode)
  * Enhanced HTTP request validation for method type and content-type requirements

* **Documentation**
  * Updated README with common attributes configuration guidance, HTTP request handling specifications, and encoding extension requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->