### PR TITLE
fix(splunkexporter): disable HTML escaping in Splunk HEC payloads

### DIFF
--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -679,10 +679,13 @@ func buildHTTPHeaders(config *Config, buildInfo component.BuildInfo) map[string]
 
 // marshalEvent marshals an event to JSON
 func marshalEvent(event *translator.Event, sizeLimit uint) ([]byte, error) {
-	b, err := json.Marshal(event)
-	if err != nil {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(event); err != nil {
 		return nil, err
 	}
+	b := bytes.TrimSuffix(buf.Bytes(), []byte("\n"))
 	if uint(len(b)) > sizeLimit {
 		return nil, fmt.Errorf("event size %d exceeds limit %d", len(b), sizeLimit)
 	}

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -956,6 +956,34 @@ func TestReceiveLogEvent(t *testing.T) {
 	compareWithTestData(t, actual[0].body, "testdata/hec_log_event.json")
 }
 
+func TestReceiveLogEventDoesNotHTMLEscapeMessageField(t *testing.T) {
+	logs := plog.NewLogs()
+	logRecord := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
+	body := logRecord.Body().SetEmptyMap()
+	body.PutStr("message", "Q2_PMT INFO - <isomsg>\n  <header>abc</header>\n</isomsg>")
+	body.PutStr("project", "switch-pmt")
+
+	cfg := NewFactory().CreateDefaultConfig().(*Config)
+	cfg.DisableCompression = true
+
+	actual, err := runLogExport(t, cfg, logs, 1)
+	assert.NoError(t, err)
+	require.Len(t, actual, 1)
+
+	requestBody := string(actual[0].body)
+	assert.Contains(t, requestBody, `<isomsg>`)
+	assert.Contains(t, requestBody, `</header>`)
+	assert.NotContains(t, requestBody, `\u003c`)
+	assert.NotContains(t, requestBody, `\u003e`)
+
+	payload := map[string]any{}
+	require.NoError(t, json.Unmarshal(actual[0].body, &payload))
+	event, ok := payload["event"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "switch-pmt", event["project"])
+	assert.Contains(t, event["message"], "<isomsg>")
+}
+
 func TestLogEventTimestampMicrosecondPrecision(t *testing.T) {
 	// Verify that nanosecond timestamp precision is turned to microseconds in the HEC payload
 	logs := plog.NewLogs()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable HTML escaping in Splunk HEC payloads so logs with angle brackets (like XML) are preserved and searchable. Addresses BHN prod log formatting issues in SAW-7899.

- **Bug Fixes**
  - Use `json.Encoder` with `SetEscapeHTML(false)` in `marshalEvent` within `splunkhecexporter`.
  - Trim trailing newline from encoded bytes to keep payload format unchanged.
  - Add test to ensure `<isomsg>` content is not escaped and JSON remains valid.

<sup>Written for commit 04c0455bff3fc84affa5fdbc9a377c67b3099ade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML character escaping in log message exports to Splunk HEC to preserve special characters like angle brackets in their raw form.

* **Tests**
  * Added test coverage for HTML special character preservation in exported log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->