### PR TITLE
feat(splunkreceiver): log sampled Splunk HEC receiver rejections

### DIFF
--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
@@ -58,6 +59,10 @@ const (
 	httpContentEncodingHeader = "Content-Encoding"
 	httpContentTypeHeader     = "Content-Type"
 	httpJSONTypeHeader        = "application/json"
+
+	requestFailureLogSamplingTick       = time.Second
+	requestFailureLogSamplingFirst      = 10
+	requestFailureLogSamplingThereafter = 100
 )
 
 var (
@@ -92,6 +97,8 @@ type splunkReceiver struct {
 	obsrecv         *receiverhelper.ObsReport
 	gzipReaderPool  *sync.Pool
 	ackExt          ackextension.AckExtension
+
+	requestFailureLogger *zap.Logger
 }
 
 var (
@@ -119,13 +126,25 @@ func newReceiver(settings receiver.Settings, config Config) (*splunkReceiver, er
 		return nil, err
 	}
 	r := &splunkReceiver{
-		settings:       settings,
-		config:         &config,
-		obsrecv:        obsrecv,
-		gzipReaderPool: &sync.Pool{New: func() any { return new(gzip.Reader) }},
+		settings:             settings,
+		config:               &config,
+		obsrecv:              obsrecv,
+		gzipReaderPool:       &sync.Pool{New: func() any { return new(gzip.Reader) }},
+		requestFailureLogger: newRequestFailureLogger(settings.Logger),
 	}
 
 	return r, nil
+}
+
+func newRequestFailureLogger(logger *zap.Logger) *zap.Logger {
+	return logger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		return zapcore.NewSamplerWithOptions(
+			core,
+			requestFailureLogSamplingTick,
+			requestFailureLogSamplingFirst,
+			requestFailureLogSamplingThereafter,
+		)
+	}))
 }
 
 // Start tells the receiver to start its processing.
@@ -569,15 +588,20 @@ func (r *splunkReceiver) failRequest(
 		}
 	}
 
-	if r.settings.Logger.Core().Enabled(zap.DebugLevel) {
-		msg := string(jsonResponse)
-		r.settings.Logger.Debug(
-			"Splunk HEC receiver request failed",
-			zap.Int("http_status_code", httpStatusCode),
-			zap.String("msg", msg),
-			zap.Error(err), // It handles nil error
-		)
+	logger := r.requestFailureLogger
+	if logger == nil {
+		logger = r.settings.Logger
 	}
+	fields := []zap.Field{
+		zap.Int("http_status_code", httpStatusCode),
+		zap.String("msg", string(jsonResponse)),
+		zap.Error(err), // It handles nil error.
+	}
+	if httpStatusCode >= http.StatusInternalServerError {
+		logger.Error("Splunk HEC receiver request failed", fields...)
+		return
+	}
+	logger.Warn("Splunk HEC receiver request failed", fields...)
 }
 
 func (*splunkReceiver) handleHealthReq(writer http.ResponseWriter, _ *http.Request) {

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -32,6 +32,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
@@ -53,6 +55,74 @@ func assertHecSuccessResponseWithAckID(t *testing.T, resp *http.Response, body a
 	assert.Equal(t, http.StatusOK, status)
 	assert.Equal(t, "application/json", resp.Header.Get(httpContentTypeHeader))
 	assert.Equal(t, map[string]any{"code": float64(0), "text": "Success", "ackId": float64(ackID)}, body)
+}
+
+func Test_splunkhecReceiver_handleReq_LogsBadRequestAtWarn(t *testing.T) {
+	observedCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopSettings(metadata.Type)
+	settings.Logger = zap.New(observedCore)
+	config := createDefaultConfig().(*Config)
+	config.NetAddr.Endpoint = "localhost:0"
+
+	rcv, err := newReceiver(settings, *config)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", strings.NewReader("{"))
+	rcv.handleReq(w, req)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	assert.JSONEq(t, responseInvalidDataFormat, string(respBytes))
+
+	require.Equal(t, 1, observedLogs.Len())
+	entry := observedLogs.All()[0]
+	assert.Equal(t, zap.WarnLevel, entry.Level)
+	assert.Equal(t, "Splunk HEC receiver request failed", entry.Message)
+	context := entry.ContextMap()
+	assert.Equal(t, int64(http.StatusBadRequest), context["http_status_code"])
+	assert.Equal(t, responseInvalidDataFormat, context["msg"])
+	assert.Contains(t, context["error"], "invalid character")
+}
+
+func Test_splunkhecReceiver_failRequest_SamplesRepeatedWarnings(t *testing.T) {
+	observedCore, observedLogs := observer.New(zap.WarnLevel)
+	settings := receivertest.NewNopSettings(metadata.Type)
+	settings.Logger = zap.New(observedCore)
+	config := createDefaultConfig().(*Config)
+
+	rcv, err := newReceiver(settings, *config)
+	require.NoError(t, err)
+
+	for range requestFailureLogSamplingFirst + requestFailureLogSamplingThereafter + 1 {
+		rcv.failRequest(httptest.NewRecorder(), http.StatusBadRequest, invalidFormatRespBody, errors.New("bad request"))
+	}
+
+	assert.Equal(t, requestFailureLogSamplingFirst+1, observedLogs.Len())
+}
+
+func Test_splunkhecReceiver_failRequest_LogsInternalServerErrorAtError(t *testing.T) {
+	observedCore, observedLogs := observer.New(zap.ErrorLevel)
+	settings := receivertest.NewNopSettings(metadata.Type)
+	settings.Logger = zap.New(observedCore)
+	config := createDefaultConfig().(*Config)
+
+	rcv, err := newReceiver(settings, *config)
+	require.NoError(t, err)
+
+	rcv.failRequest(httptest.NewRecorder(), http.StatusInternalServerError, errInternalServerError, errors.New("consumer failed"))
+
+	require.Equal(t, 1, observedLogs.Len())
+	entry := observedLogs.All()[0]
+	assert.Equal(t, zap.ErrorLevel, entry.Level)
+	assert.Equal(t, "Splunk HEC receiver request failed", entry.Message)
+	context := entry.ContextMap()
+	assert.Equal(t, int64(http.StatusInternalServerError), context["http_status_code"])
+	assert.Equal(t, responseErrInternalServerError, context["msg"])
+	assert.Equal(t, "consumer failed", context["error"])
 }
 
 func Test_splunkhecreceiver_NewReceiver(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add sampled, structured logging for rejected Splunk HEC requests in `splunkhecreceiver` to surface 4xx/5xx failures without log spam. Supports SAW-7899 by making bad formats and receiver errors visible in production.

- **New Features**
  - Added a dedicated sampled logger using `zapcore.NewSamplerWithOptions` (1s window; first 10, then 1/100).
  - Logs 4xx rejections at warn and 5xx at error with fields: `http_status_code`, `msg`, and `error`.
  - Added tests for warn on bad request, sampling behavior, and error on 500.

<sup>Written for commit 6e399b07e781bf8df1a18785563a92f9ef66f2ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

