### PR TITLE
feat(elasticsearchexporter): sample failed document input logs

### DIFF
--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -411,8 +411,8 @@ The Elasticsearch Exporter's own telemetry settings for testing and debugging pu
   - `preserve_error_reason` (default=true): Preserves backend-provided bulk item `error.reason` in failed document logs without asking Elasticsearch/OpenSearch to include source snippets. This keeps mapper parsing details visible for debugging while avoiding the `include_source_on_error` bulk request parameter that some OpenSearch versions reject. WARNING: backend error reasons may still include field names, rejected values, or other sensitive details.
   - `log_request_body` (default=false): Logs Elasticsearch client request body as a field in a log line at DEBUG level. It requires `service::telemetry::logs::level` to be set to `debug`. WARNING: Enabling this config may expose sensitive data.
   - `log_response_body` (default=false): Logs Elasticsearch client response body as a field in a log line at DEBUG level. It requires `service::telemetry::logs::level` to be set to `debug`. WARNING: Enabling this config may expose sensitive data.
-  - `log_failed_docs_input` (default=false): Include the input (action line and document line) causing indexing error under `input` field in a log line at DEBUG level. It requires `service::telemetry::logs::level` to be set to `debug`. WARNING: Enabling this config may expose sensitive data.
-  - `log_failed_docs_input_rate_limit` (default="1s"): Rate limiting of logs emitted by `log_failed_docs_input` config, e.g. "1s" means roughly 1 log line per second. A zero or negative value disables rate limiting.
+  - `log_failed_docs_input` (default=false): Include sampled bulk input (action line and document line) causing indexing errors under the `input` field in the exporter's own error logs. This does not require `service::telemetry::logs::level` to be set to `debug`. WARNING: Enabling this config may expose sensitive data.
+  - `log_failed_docs_input_rate_limit` (default="1s"): Per-error-key rate limiting of logs emitted by `log_failed_docs_input` config. The key includes index, error type, parsed error field, parsed expected type, and status code. A zero or negative value disables rate limiting.
 
 ### Metadata keys
 

--- a/exporter/elasticsearchexporter/bulkindexer.go
+++ b/exporter/elasticsearchexporter/bulkindexer.go
@@ -27,7 +27,6 @@ import (
 	conventions "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/logging"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/metadata"
 )
 
@@ -182,30 +181,30 @@ func newSyncBulkIndexer(
 		}
 	}
 	return &syncBulkIndexer{
-		config:                bulkIndexerConfig(client, config, false, logger),
-		maxFlushBytes:         maxFlushBytes,
-		flushTimeout:          config.Timeout,
-		retryConfig:           config.Retry,
-		metadataKeys:          config.MetadataKeys,
-		telemetryBuilder:      tb,
-		logger:                logger,
-		failedDocsInputLogger: newFailedDocsInputLogger(logger, config),
-		getErrorHintFunc:      getErrorHintFunc,
-		requireDataStream:     requireDataStream,
+		config:                 bulkIndexerConfig(client, config, false, logger),
+		maxFlushBytes:          maxFlushBytes,
+		flushTimeout:           config.Timeout,
+		retryConfig:            config.Retry,
+		metadataKeys:           config.MetadataKeys,
+		telemetryBuilder:       tb,
+		logger:                 logger,
+		failedDocsInputSampler: newFailedDocsInputSampler(config),
+		getErrorHintFunc:       getErrorHintFunc,
+		requireDataStream:      requireDataStream,
 	}
 }
 
 type syncBulkIndexer struct {
-	config                docappender.BulkIndexerConfig
-	maxFlushBytes         int64
-	flushTimeout          time.Duration
-	retryConfig           RetrySettings
-	metadataKeys          []string
-	telemetryBuilder      *metadata.TelemetryBuilder
-	logger                *zap.Logger
-	failedDocsInputLogger *zap.Logger
-	getErrorHintFunc      func(index, errorType string) string
-	requireDataStream     bool
+	config                 docappender.BulkIndexerConfig
+	maxFlushBytes          int64
+	flushTimeout           time.Duration
+	retryConfig            RetrySettings
+	metadataKeys           []string
+	telemetryBuilder       *metadata.TelemetryBuilder
+	logger                 *zap.Logger
+	failedDocsInputSampler *failedDocsInputSampler
+	getErrorHintFunc       func(index, errorType string) string
+	requireDataStream      bool
 }
 
 // StartSession creates a new docappender.BulkIndexer, and wraps
@@ -280,7 +279,7 @@ func (s *syncBulkIndexerSession) Flush(ctx context.Context) error {
 			s.s.metadataKeys,
 			s.s.telemetryBuilder,
 			s.s.logger,
-			s.s.failedDocsInputLogger,
+			s.s.failedDocsInputSampler,
 			s.s.getErrorHintFunc,
 		); err != nil {
 			return err
@@ -316,7 +315,7 @@ func flushBulkIndexer(
 	tMetaKeys []string,
 	tb *metadata.TelemetryBuilder,
 	logger *zap.Logger,
-	failedDocsInputLogger *zap.Logger,
+	failedDocsInputSampler *failedDocsInputSampler,
 	getErrorHintFunc func(index, errorType string) string,
 ) error {
 	itemsCount := bi.Items()
@@ -348,19 +347,19 @@ func flushBulkIndexer(
 		tb.ElasticsearchDocsRetriedHTTPRequest.Add(ctx, int64(retryCount*itemsCount), metric.WithAttributeSet(defaultAttrsSet))
 	}
 
-	var fields []zap.Field
+	var baseFields []zap.Field
 	// append metadata attributes to error log fields
 	for _, kv := range defaultMetaAttrs {
 		switch kv.Value.Type() {
 		case attribute.STRINGSLICE:
-			fields = append(fields, zap.Strings(string(kv.Key), kv.Value.AsStringSlice()))
+			baseFields = append(baseFields, zap.Strings(string(kv.Key), kv.Value.AsStringSlice()))
 		default:
 			// For other types, convert to string
-			fields = append(fields, zap.String(string(kv.Key), kv.Value.AsString()))
+			baseFields = append(baseFields, zap.String(string(kv.Key), kv.Value.AsString()))
 		}
 	}
 	if err != nil {
-		logger.Error("bulk indexer flush error", append(fields, zap.Error(err))...)
+		logger.Error("bulk indexer flush error", append(baseFields, zap.Error(err))...)
 		var bulkFailedErr docappender.ErrorFlushFailed
 		switch {
 		case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
@@ -428,13 +427,21 @@ func flushBulkIndexer(
 			continue
 		}
 
-		// Log failed docs
+		// Log failed docs.
+		fields := append([]zap.Field{}, baseFields...)
 		fields = append(fields,
 			zap.String("index", resp.Index),
 			zap.String("error.type", resp.Error.Type),
 			zap.String("error.reason", resp.Error.Reason),
 			zap.Int("http.response.status_code", resp.Status),
 		)
+		errorField, expectedType := parseFailedDocErrorReason(resp.Error.Reason)
+		if errorField != "" {
+			fields = append(fields, zap.String("error.field", errorField))
+		}
+		if expectedType != "" {
+			fields = append(fields, zap.String("error.expected_type", expectedType))
+		}
 
 		if getErrorHintFunc != nil {
 			if hint := getErrorHintFunc(resp.Index, resp.Error.Type); hint != "" {
@@ -443,10 +450,23 @@ func flushBulkIndexer(
 		}
 		logger.Error("failed to index document", fields...)
 
-		if resp.Input != "" {
-			fields = append(fields, zap.String("input", resp.Input))
+		if resp.Input != "" && failedDocsInputSampler != nil {
+			sampleKey := failedDocInputSampleKey{
+				index:        resp.Index,
+				errorType:    resp.Error.Type,
+				errorField:   errorField,
+				expectedType: expectedType,
+				status:       resp.Status,
+			}
+			if failedDocsInputSampler.allow(sampleKey) {
+				inputFields := append([]zap.Field{}, fields...)
+				inputFields = append(inputFields,
+					zap.String("document.hash", failedDocInputHash(resp.Input)),
+					zap.String("input", resp.Input),
+				)
+				logger.Error("failed to index document; sampled input", inputFields...)
+			}
 		}
-		failedDocsInputLogger.Debug("failed to index document; input may contain sensitive data", fields...)
 	}
 	if stat.Indexed > 0 {
 		tb.ElasticsearchDocsProcessed.Add(
@@ -528,13 +548,6 @@ func getErrorHint(mode MappingMode, index, errorType string) string {
 		}
 	}
 	return ""
-}
-
-func newFailedDocsInputLogger(logger *zap.Logger, config *Config) *zap.Logger {
-	if !config.LogFailedDocsInput {
-		return zap.NewNop()
-	}
-	return logger.WithOptions(logging.WithRateLimit(config.LogFailedDocsInputRateLimit))
 }
 
 type bulkIndexers struct {

--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
 	"github.com/elastic/go-docappender/v2"
@@ -374,6 +375,127 @@ func TestBulkIndexerLogsStatusCode(t *testing.T) {
 			continue
 		}
 		assert.Equal(t, int64(status), statusCode, "http.response.status_code does not match at index %d; msg: %s", i, msg.Message)
+	}
+}
+
+func TestBulkIndexerLogsFailedDocsInputWithoutDebugLevel(t *testing.T) {
+	responseBody := `{"errors": true, "items":[
+		{"create":{"_index":"logs-bhn-default","status":400,"error":{"type":"mapper_parsing_exception","reason":"failed to parse field [http.response.status_code] of type [long] in document with id 'abc'"}}}
+	]}`
+
+	cfg := Config{
+		QueueBatchConfig: configoptional.Default(exporterhelper.QueueBatchConfig{
+			NumConsumers: 1,
+		}),
+		TelemetrySettings: TelemetrySettings{
+			LogFailedDocsInput:          true,
+			LogFailedDocsInputRateLimit: time.Second,
+			PreserveErrorReason:         true,
+		},
+	}
+	esClient, err := elastictransport.New(elastictransport.Config{
+		URLs: []*url.URL{{Scheme: "http", Host: "localhost:9200"}},
+		Transport: &mockTransport{
+			RoundTripFunc: func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+					Body:       io.NopCloser(strings.NewReader(responseBody)),
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	ct := componenttest.NewTelemetry()
+	tb, err := metadata.NewTelemetryBuilder(
+		metadatatest.NewSettings(ct).TelemetrySettings,
+	)
+	require.NoError(t, err)
+
+	core, observed := observer.New(zap.NewAtomicLevelAt(zapcore.InfoLevel))
+	bi := newSyncBulkIndexer(esClient, &cfg, false, tb, zap.New(core), nil)
+
+	ctx := t.Context()
+	session := bi.StartSession(ctx)
+	require.NoError(t, session.Add(ctx, "logs-bhn-default", "", "", strings.NewReader(`{"http.response.status_code":"not-a-number"}`), nil, docappender.ActionCreate))
+	require.NoError(t, session.Flush(ctx))
+	session.End()
+	assert.NoError(t, bi.Close(ctx))
+
+	inputLogs := observed.FilterMessage("failed to index document; sampled input")
+	require.Equal(t, 1, inputLogs.Len(), "input log not found; observed.All()=%v", observed.All())
+	contextMap := inputLogs.All()[0].ContextMap()
+	assert.Contains(t, contextMap["input"], `"http.response.status_code":"not-a-number"`)
+	assert.NotEmpty(t, contextMap["document.hash"])
+	assert.Equal(t, "http.response.status_code", contextMap["error.field"])
+	assert.Equal(t, "long", contextMap["error.expected_type"])
+}
+
+func TestBulkIndexerSamplesFailedDocsInputByIndex(t *testing.T) {
+	responseBody := `{"errors": true, "items":[
+		{"create":{"_index":"logs-a","status":400,"error":{"type":"mapper_parsing_exception","reason":"failed to parse field [status] of type [long]"}}},
+		{"create":{"_index":"logs-b","status":400,"error":{"type":"mapper_parsing_exception","reason":"failed to parse field [status] of type [long]"}}},
+		{"create":{"_index":"logs-a","status":400,"error":{"type":"mapper_parsing_exception","reason":"failed to parse field [status] of type [long]"}}}
+	]}`
+
+	cfg := Config{
+		QueueBatchConfig: configoptional.Default(exporterhelper.QueueBatchConfig{
+			NumConsumers: 1,
+		}),
+		TelemetrySettings: TelemetrySettings{
+			LogFailedDocsInput:          true,
+			LogFailedDocsInputRateLimit: time.Hour,
+			PreserveErrorReason:         true,
+		},
+	}
+	esClient, err := elastictransport.New(elastictransport.Config{
+		URLs: []*url.URL{{Scheme: "http", Host: "localhost:9200"}},
+		Transport: &mockTransport{
+			RoundTripFunc: func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					Header:     http.Header{"X-Elastic-Product": []string{"Elasticsearch"}},
+					Body:       io.NopCloser(strings.NewReader(responseBody)),
+					StatusCode: http.StatusOK,
+				}, nil
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	ct := componenttest.NewTelemetry()
+	tb, err := metadata.NewTelemetryBuilder(
+		metadatatest.NewSettings(ct).TelemetrySettings,
+	)
+	require.NoError(t, err)
+
+	core, observed := observer.New(zap.NewAtomicLevelAt(zapcore.InfoLevel))
+	bi := newSyncBulkIndexer(esClient, &cfg, false, tb, zap.New(core), nil)
+
+	ctx := t.Context()
+	session := bi.StartSession(ctx)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, session.Add(ctx, "logs-a", "", "", strings.NewReader(`{"status":"bad"}`), nil, docappender.ActionCreate))
+	}
+	require.NoError(t, session.Flush(ctx))
+	session.End()
+	assert.NoError(t, bi.Close(ctx))
+
+	inputLogs := observed.FilterMessage("failed to index document; sampled input")
+	require.Equal(t, 2, inputLogs.Len(), "expected one sampled input per index; observed.All()=%v", observed.All())
+	assert.Equal(t, 1, inputLogs.FilterField(zap.String("index", "logs-a")).Len())
+	assert.Equal(t, 1, inputLogs.FilterField(zap.String("index", "logs-b")).Len())
+
+	failureLogs := observed.FilterMessage("failed to index document")
+	require.Equal(t, 3, failureLogs.Len(), "expected all failures to keep normal error logs; observed.All()=%v", observed.All())
+	for _, entry := range failureLogs.All() {
+		var indexFields int
+		for _, field := range entry.Context {
+			if field.Key == "index" {
+				indexFields++
+			}
+		}
+		assert.Equal(t, 1, indexFields, "failed-doc fields should not accumulate between log entries")
 	}
 }
 

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -127,6 +127,10 @@ type TelemetrySettings struct {
 	LogRequestBody  bool `mapstructure:"log_request_body"`
 	LogResponseBody bool `mapstructure:"log_response_body"`
 
+	// LogFailedDocsInput includes the bulk input (action line and document line)
+	// for sampled failed documents in the exporter's own logs.
+	// WARNING: enabling this may expose sensitive data and should only be used
+	// temporarily for debugging.
 	LogFailedDocsInput          bool          `mapstructure:"log_failed_docs_input"`
 	LogFailedDocsInputRateLimit time.Duration `mapstructure:"log_failed_docs_input_rate_limit"`
 	PreserveErrorReason         bool          `mapstructure:"preserve_error_reason"`

--- a/exporter/elasticsearchexporter/config.schema.yaml
+++ b/exporter/elasticsearchexporter/config.schema.yaml
@@ -104,8 +104,10 @@ $defs:
     type: object
     properties:
       log_failed_docs_input:
+        description: 'LogFailedDocsInput includes the bulk input (action line and document line) for sampled failed documents in the exporter''s own logs. WARNING: enabling this may expose sensitive data and should only be used temporarily for debugging.'
         type: boolean
       log_failed_docs_input_rate_limit:
+        description: 'LogFailedDocsInputRateLimit configures per-error-key rate limiting for failed document input logs. A zero or negative value disables rate limiting.'
         type: string
         format: duration
       log_request_body:

--- a/exporter/elasticsearchexporter/failed_docs_input_sampler.go
+++ b/exporter/elasticsearchexporter/failed_docs_input_sampler.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package elasticsearchexporter
+package elasticsearchexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter"
 
 import (
 	"crypto/sha256"

--- a/exporter/elasticsearchexporter/failed_docs_input_sampler.go
+++ b/exporter/elasticsearchexporter/failed_docs_input_sampler.go
@@ -1,0 +1,126 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package elasticsearchexporter
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxFailedDocInputSampleKeys = 1024
+
+var (
+	failedDocParseFieldTypeRE = regexp.MustCompile(`failed to parse field \[([^\]]+)\] of type \[([^\]]+)\]`)
+	failedDocParseFieldRE     = regexp.MustCompile(`failed to parse field \[([^\]]+)\]`)
+	failedDocObjectMappingRE  = regexp.MustCompile(`object mapping for \[([^\]]+)\].* as object`)
+)
+
+type failedDocInputSampleKey struct {
+	index        string
+	errorType    string
+	errorField   string
+	expectedType string
+	status       int
+}
+
+func (k failedDocInputSampleKey) String() string {
+	return strings.Join([]string{
+		k.index,
+		k.errorType,
+		k.errorField,
+		k.expectedType,
+		fmt.Sprint(k.status),
+	}, "\x00")
+}
+
+type failedDocsInputSampler struct {
+	interval time.Duration
+	now      func() time.Time
+
+	mu      sync.Mutex
+	lastLog map[string]time.Time
+}
+
+func newFailedDocsInputSampler(config *Config) *failedDocsInputSampler {
+	if !config.LogFailedDocsInput {
+		return nil
+	}
+	return &failedDocsInputSampler{
+		interval: config.LogFailedDocsInputRateLimit,
+		now:      time.Now,
+		lastLog:  make(map[string]time.Time),
+	}
+}
+
+func (s *failedDocsInputSampler) allow(key failedDocInputSampleKey) bool {
+	if s == nil || s.interval <= 0 {
+		return true
+	}
+
+	now := s.now()
+	keyString := key.String()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	last, ok := s.lastLog[keyString]
+	if ok && now.Sub(last) < s.interval {
+		return false
+	}
+	s.lastLog[keyString] = now
+	if len(s.lastLog) > maxFailedDocInputSampleKeys {
+		s.pruneLocked(now)
+	}
+	return true
+}
+
+func (s *failedDocsInputSampler) pruneLocked(now time.Time) {
+	maxAge := s.interval * 10
+	for key, last := range s.lastLog {
+		if now.Sub(last) > maxAge {
+			delete(s.lastLog, key)
+		}
+	}
+	if len(s.lastLog) <= maxFailedDocInputSampleKeys {
+		return
+	}
+	for key := range s.lastLog {
+		delete(s.lastLog, key)
+		if len(s.lastLog) <= maxFailedDocInputSampleKeys {
+			return
+		}
+	}
+}
+
+func parseFailedDocErrorReason(reason string) (field, expectedType string) {
+	if matches := failedDocParseFieldTypeRE.FindStringSubmatch(reason); matches != nil {
+		return matches[1], matches[2]
+	}
+	if matches := failedDocObjectMappingRE.FindStringSubmatch(reason); matches != nil {
+		return matches[1], "object"
+	}
+	if matches := failedDocParseFieldRE.FindStringSubmatch(reason); matches != nil {
+		return matches[1], ""
+	}
+	return "", ""
+}
+
+func failedDocInputHash(input string) string {
+	doc := failedDocDocumentLine(input)
+	sum := sha256.Sum256([]byte(doc))
+	return hex.EncodeToString(sum[:])
+}
+
+func failedDocDocumentLine(input string) string {
+	firstNewline := strings.IndexByte(input, '\n')
+	if firstNewline < 0 || firstNewline == len(input)-1 {
+		return strings.TrimSpace(input)
+	}
+	return strings.TrimSpace(input[firstNewline+1:])
+}

--- a/exporter/elasticsearchexporter/failed_docs_input_sampler_test.go
+++ b/exporter/elasticsearchexporter/failed_docs_input_sampler_test.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package elasticsearchexporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFailedDocsInputSampler(t *testing.T) {
+	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
+	sampler := &failedDocsInputSampler{
+		interval: time.Minute,
+		now:      func() time.Time { return now },
+		lastLog:  make(map[string]time.Time),
+	}
+
+	key := failedDocInputSampleKey{index: "logs-a", errorType: "mapper_parsing_exception", status: 400}
+	assert.True(t, sampler.allow(key))
+	assert.False(t, sampler.allow(key))
+
+	assert.True(t, sampler.allow(failedDocInputSampleKey{index: "logs-b", errorType: "mapper_parsing_exception", status: 400}))
+
+	now = now.Add(time.Minute)
+	assert.True(t, sampler.allow(key))
+}
+
+func TestParseFailedDocErrorReason(t *testing.T) {
+	tests := []struct {
+		name             string
+		reason           string
+		wantField        string
+		wantExpectedType string
+	}{
+		{
+			name:             "field and type",
+			reason:           `failed to parse field [http.response.status_code] of type [long] in document with id 'abc'`,
+			wantField:        "http.response.status_code",
+			wantExpectedType: "long",
+		},
+		{
+			name:             "object mapping",
+			reason:           `object mapping for [host] tried to parse field [host] as object, but found a concrete value`,
+			wantField:        "host",
+			wantExpectedType: "object",
+		},
+		{
+			name:      "field only",
+			reason:    `failed to parse field [message]`,
+			wantField: "message",
+		},
+		{
+			name:   "unknown",
+			reason: `some other indexing failure`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotField, gotExpectedType := parseFailedDocErrorReason(tt.reason)
+			assert.Equal(t, tt.wantField, gotField)
+			assert.Equal(t, tt.wantExpectedType, gotExpectedType)
+		})
+	}
+}
+
+func TestFailedDocInputHashUsesDocumentLine(t *testing.T) {
+	actionAndDoc := "{\"create\":{\"_index\":\"foo\"}}\n{\"foo\":\"bar\"}\n"
+	otherActionSameDoc := "{\"create\":{\"_index\":\"bar\"}}\n{\"foo\":\"bar\"}\n"
+	otherDoc := "{\"create\":{\"_index\":\"foo\"}}\n{\"foo\":\"baz\"}\n"
+
+	assert.Equal(t, failedDocInputHash(actionAndDoc), failedDocInputHash(otherActionSameDoc))
+	assert.NotEqual(t, failedDocInputHash(actionAndDoc), failedDocInputHash(otherDoc))
+}


### PR DESCRIPTION
Add a temporary diagnostics knob for logging sampled failed bulk item
  NDJSON without requiring global debug logging. The sample key includes
  index, error type, parsed field/type, and response status so mapping
  failures produce representative examples without logging every failed
  document.

  Also enrich failed-document logs with parsed mapping field/type details
  and avoid carrying fields across failed-document log entries.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add sampled failed-document input logging to the `elasticsearchexporter` so operators can capture representative bulk NDJSON for indexing failures without global debug logs. Aligns with SAW-8089 by enabling BHN to debug OpenSearch failures safely and with bounded log volume.

- **New Features**
  - Log failed bulk input at error level when `telemetry.log_failed_docs_input` is enabled; includes action + document from `go-docappender` and a `document.hash` of the document line.
  - Per-error-key sampling and rate limiting via `telemetry.log_failed_docs_input_rate_limit` (key: index, error type, parsed field, expected type, status).
  - Enrich failure logs with `error.field` and `error.expected_type` parsed from backend `error.reason` (covers parse and object-mapping errors).

- **Bug Fixes**
  - Prevent failed-document log fields from accumulating across log entries.

<sup>Written for commit 85730748ca1c26e932d2a54c5a93f68ed97a64f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable sampling for failed-document logging in the Elasticsearch exporter.
  * Failed bulk input can now be included in logs at a controlled rate, with repeated errors grouped by index and error details.

* **Bug Fixes**
  * Improved failure logs with clearer error context, including affected field and expected type when available.
  * Reduced duplicate log noise by limiting repeated failed-input entries.

* **Documentation**
  * Updated telemetry settings docs to explain the new logging and rate-limit behavior, including sensitive-data warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->