### PR TITLE
fix(elasticsearchexporter): preserve ECS log message from structured bodies

### DIFF
--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -298,6 +298,7 @@ func (doc *Document) Dedup(protectedSet map[string]struct{}) {
 
 func newJSONVisitor(w io.Writer) *json.Visitor {
 	v := json.NewVisitor(w)
+	v.SetEscapeHTML(false)
 	// Enable ExplicitRadixPoint such that 1.0 is encoded as 1.0 instead of 1.
 	// This is required to generate the correct dynamic mapping in ES.
 	v.SetExplicitRadixPoint(true)

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -288,9 +288,6 @@ func encodeBodyAsMessage(body pcommon.Value) (string, bool, error) {
 	case pcommon.ValueTypeInt:
 		return strconv.FormatInt(body.Int(), 10), true, nil
 	case pcommon.ValueTypeDouble:
-		if math.IsNaN(body.Double()) || math.IsInf(body.Double(), 0) {
-			return "null", true, nil
-		}
 		return strconv.FormatFloat(body.Double(), 'g', -1, 64), true, nil
 	case pcommon.ValueTypeBool:
 		return strconv.FormatBool(body.Bool()), true, nil
@@ -307,10 +304,32 @@ func encodeStructuredBodyAsMessage(body pcommon.Value) (string, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
-	if err := enc.Encode(body.AsRaw()); err != nil {
+	if err := enc.Encode(sanitizeStructuredBodyForJSON(body.AsRaw())); err != nil {
 		return "", err
 	}
 	return string(bytes.TrimSuffix(buf.Bytes(), []byte("\n"))), nil
+}
+
+func sanitizeStructuredBodyForJSON(v any) any {
+	switch v := v.(type) {
+	case map[string]any:
+		sanitized := make(map[string]any, len(v))
+		for key, value := range v {
+			sanitized[key] = sanitizeStructuredBodyForJSON(value)
+		}
+		return sanitized
+	case []any:
+		sanitized := make([]any, len(v))
+		for i, value := range v {
+			sanitized[i] = sanitizeStructuredBodyForJSON(value)
+		}
+		return sanitized
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return nil
+		}
+	}
+	return v
 }
 
 func mergeMapsByPriority(lowerPriority, higherPriority pcommon.Map) pcommon.Map {

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -5,9 +5,12 @@ package elasticsearchexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -262,11 +265,52 @@ func (ecsModeEncoder) encodeLog(
 
 	document.AddString("log.level", record.SeverityText())
 
-	if record.Body().Type() == pcommon.ValueTypeStr {
-		document.AddAttribute("message", record.Body())
+	message, ok, err := encodeBodyAsMessage(record.Body())
+	if err != nil {
+		return err
+	}
+	if ok {
+		document.Add("message", objmodel.StringValue(message))
 	}
 
 	return document.Serialize(buf, true, logProtectedFields)
+}
+
+func encodeBodyAsMessage(body pcommon.Value) (string, bool, error) {
+	// ECS models log.message as a string. When upstream processors parse a JSON
+	// log body into OTLP map/slice/scalar values, preserve the original body as
+	// a string in message instead of omitting it or indexing it as mixed types.
+	switch body.Type() {
+	case pcommon.ValueTypeEmpty:
+		return "", false, nil
+	case pcommon.ValueTypeStr:
+		return body.Str(), true, nil
+	case pcommon.ValueTypeInt:
+		return strconv.FormatInt(body.Int(), 10), true, nil
+	case pcommon.ValueTypeDouble:
+		if math.IsNaN(body.Double()) || math.IsInf(body.Double(), 0) {
+			return "null", true, nil
+		}
+		return strconv.FormatFloat(body.Double(), 'g', -1, 64), true, nil
+	case pcommon.ValueTypeBool:
+		return strconv.FormatBool(body.Bool()), true, nil
+	case pcommon.ValueTypeBytes:
+		return hex.EncodeToString(body.Bytes().AsRaw()), true, nil
+	case pcommon.ValueTypeMap, pcommon.ValueTypeSlice:
+		message, err := encodeStructuredBodyAsMessage(body)
+		return message, true, err
+	}
+	return "", false, nil
+}
+
+func encodeStructuredBodyAsMessage(body pcommon.Value) (string, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(body.AsRaw()); err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSuffix(buf.Bytes(), []byte("\n"))), nil
 }
 
 func mergeMapsByPriority(lowerPriority, higherPriority pcommon.Map) pcommon.Map {

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -200,6 +200,180 @@ func TestEncodeLog(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expectedLogBodyWithEmptyTimestamp, buf.String())
 	})
+
+	t.Run("does not html escape log strings", func(t *testing.T) {
+		encoder, err := newEncoder(MappingNone)
+		require.NoError(t, err)
+
+		record := plog.NewLogRecord()
+		record.Body().SetStr("Q2_PMT INFO - <isomsg><header>a&b</header></isomsg>")
+
+		var buf bytes.Buffer
+		err = encoder.encodeLog(
+			encodingContext{
+				resource: pcommon.NewResource(),
+				scope:    pcommon.NewInstrumentationScope(),
+			},
+			record,
+			elasticsearch.Index{},
+			&buf,
+		)
+		require.NoError(t, err)
+
+		assert.Contains(t, buf.String(), "<isomsg>")
+		assert.Contains(t, buf.String(), "a&b")
+		assert.NotContains(t, buf.String(), `\u003c`)
+		assert.NotContains(t, buf.String(), `\u003e`)
+		assert.NotContains(t, buf.String(), `\u0026`)
+	})
+
+	t.Run("ecs mode serializes provided body values as message", func(t *testing.T) {
+		encoder, err := newEncoder(MappingECS)
+		require.NoError(t, err)
+
+		tests := []struct {
+			name          string
+			setBody       func(t *testing.T, body pcommon.Value)
+			wantMessage   string
+			wantExists    bool
+			wantJSONEqual bool
+		}{
+			{
+				name:       "unset body omitted",
+				wantExists: false,
+			},
+			{
+				name: "empty string body preserved",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetStr("")
+				},
+				wantMessage: "",
+				wantExists:  true,
+			},
+			{
+				name: "string body preserves xml tags",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetStr("Q2_PMT INFO - <isomsg><header>a&b</header></isomsg>")
+				},
+				wantMessage: "Q2_PMT INFO - <isomsg><header>a&b</header></isomsg>",
+				wantExists:  true,
+			},
+			{
+				name: "map body serialized as json string",
+				setBody: func(t *testing.T, body pcommon.Value) {
+					require.NoError(t, body.SetEmptyMap().FromRaw(map[string]any{
+						"ampersand": "a&b",
+						"msg":       "bhn shape probe message 20260629T234549Z-$-13",
+						"nested": map[string]any{
+							"child": "value",
+						},
+						"tags":  []any{"shape", "probe"},
+						"value": "<xmltag></xmltag>",
+					}))
+				},
+				wantMessage:   `{"ampersand":"a&b","msg":"bhn shape probe message 20260629T234549Z-$-13","nested":{"child":"value"},"tags":["shape","probe"],"value":"<xmltag></xmltag>"}`,
+				wantExists:    true,
+				wantJSONEqual: true,
+			},
+			{
+				name: "empty map body preserved",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetEmptyMap()
+				},
+				wantMessage:   `{}`,
+				wantExists:    true,
+				wantJSONEqual: true,
+			},
+			{
+				name: "slice body serialized as json string",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					slice := body.SetEmptySlice()
+					slice.AppendEmpty().SetStr("1")
+					slice.AppendEmpty().SetStr("<xmltag></xmltag>")
+					slice.AppendEmpty().SetStr("a&b")
+				},
+				wantMessage:   `["1","<xmltag></xmltag>","a&b"]`,
+				wantExists:    true,
+				wantJSONEqual: true,
+			},
+			{
+				name: "empty slice body preserved",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetEmptySlice()
+				},
+				wantMessage:   `[]`,
+				wantExists:    true,
+				wantJSONEqual: true,
+			},
+			{
+				name: "int body serialized as string",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetInt(42)
+				},
+				wantMessage: "42",
+				wantExists:  true,
+			},
+			{
+				name: "double body serialized as string",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetDouble(1.25)
+				},
+				wantMessage: "1.25",
+				wantExists:  true,
+			},
+			{
+				name: "bool body serialized as string",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetBool(true)
+				},
+				wantMessage: "true",
+				wantExists:  true,
+			},
+			{
+				name: "bytes body serialized as hex string",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetEmptyBytes().FromRaw([]byte{0xde, 0xad, 0xbe, 0xef})
+				},
+				wantMessage: "deadbeef",
+				wantExists:  true,
+			},
+		}
+
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				record := plog.NewLogRecord()
+				if tc.setBody != nil {
+					tc.setBody(t, record.Body())
+				}
+
+				var buf bytes.Buffer
+				err := encoder.encodeLog(
+					encodingContext{
+						resource: pcommon.NewResource(),
+						scope:    pcommon.NewInstrumentationScope(),
+					},
+					record,
+					elasticsearch.Index{},
+					&buf,
+				)
+				require.NoError(t, err)
+
+				message := gjson.Get(buf.String(), "message")
+				assert.Equal(t, tc.wantExists, message.Exists())
+				if !tc.wantExists {
+					return
+				}
+
+				if tc.wantJSONEqual {
+					require.JSONEq(t, tc.wantMessage, message.String())
+				}
+				assert.Equal(t, tc.wantMessage, message.String())
+				assert.NotContains(t, buf.String(), `\u003c`)
+				assert.NotContains(t, buf.String(), `\u003e`)
+				assert.NotContains(t, buf.String(), `\u0026`)
+			})
+		}
+	})
 }
 
 func TestEncodeMetric(t *testing.T) {

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"sort"
 	"strings"
@@ -285,6 +286,20 @@ func TestEncodeLog(t *testing.T) {
 				wantJSONEqual: true,
 			},
 			{
+				name: "map body with non-finite doubles serializes null",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					bodyMap := body.SetEmptyMap()
+					bodyMap.PutDouble("finite", 1.25)
+					bodyMap.PutDouble("nan", math.NaN())
+					nested := bodyMap.PutEmptyMap("nested")
+					nested.PutDouble("positive_inf", math.Inf(1))
+					nested.PutDouble("negative_inf", math.Inf(-1))
+				},
+				wantMessage:   `{"finite":1.25,"nan":null,"nested":{"negative_inf":null,"positive_inf":null}}`,
+				wantExists:    true,
+				wantJSONEqual: true,
+			},
+			{
 				name: "slice body serialized as json string",
 				setBody: func(_ *testing.T, body pcommon.Value) {
 					slice := body.SetEmptySlice()
@@ -293,6 +308,21 @@ func TestEncodeLog(t *testing.T) {
 					slice.AppendEmpty().SetStr("a&b")
 				},
 				wantMessage:   `["1","<xmltag></xmltag>","a&b"]`,
+				wantExists:    true,
+				wantJSONEqual: true,
+			},
+			{
+				name: "slice body with non-finite doubles serializes null",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					slice := body.SetEmptySlice()
+					slice.AppendEmpty().SetDouble(math.NaN())
+					slice.AppendEmpty().SetDouble(math.Inf(1))
+					slice.AppendEmpty().SetDouble(math.Inf(-1))
+					nested := slice.AppendEmpty().SetEmptyMap()
+					nested.PutDouble("finite", 2.5)
+					nested.PutDouble("nan", math.NaN())
+				},
+				wantMessage:   `[null,null,null,{"finite":2.5,"nan":null}]`,
 				wantExists:    true,
 				wantJSONEqual: true,
 			},
@@ -319,6 +349,30 @@ func TestEncodeLog(t *testing.T) {
 					body.SetDouble(1.25)
 				},
 				wantMessage: "1.25",
+				wantExists:  true,
+			},
+			{
+				name: "nan double body serialized as string",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetDouble(math.NaN())
+				},
+				wantMessage: "NaN",
+				wantExists:  true,
+			},
+			{
+				name: "positive infinity double body serialized as string",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetDouble(math.Inf(1))
+				},
+				wantMessage: "+Inf",
+				wantExists:  true,
+			},
+			{
+				name: "negative infinity double body serialized as string",
+				setBody: func(_ *testing.T, body pcommon.Value) {
+					body.SetDouble(math.Inf(-1))
+				},
+				wantMessage: "-Inf",
 				wantExists:  true,
 			},
 			{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ECS mapping in `elasticsearchexporter` to always emit `message` for structured log bodies by serializing them to JSON without HTML escaping. Restores `_source.message` in OpenSearch/Kibana, addressing Linear SAW-8225.

- **Bug Fixes**
  - In ECS mode, serialize map/slice bodies to JSON for `message`; keep strings as-is; format ints/bools/doubles as strings; encode bytes as hex; replace NaN/Inf with null only inside structured bodies.
  - Disable HTML escaping in both the ECS serializer and `objmodel` JSON writer (`SetEscapeHTML(false)`) to preserve `<`, `>`, and `&`.
  - Scope: only ECS synthesizes `message`; other mapping modes are unchanged structurally but now also avoid HTML escaping.
  - Add unit tests for all body types, NaN/Inf handling in structured bodies, and verification of no HTML-escaped sequences.

<sup>Written for commit 1f2187c75f1e74cce2db15f1b197f1fd5bf60a27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Log messages are now preserved more accurately in exported output, including special characters like `<`, `>` and `&` without unwanted escaping.
  * Structured, numeric, boolean, byte, and empty log bodies are now converted into a readable `message` field instead of being omitted or reduced to strings only.
  * Byte content is now represented in a consistent hex format, and complex values are serialized in JSON form for easier inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->