### PR TITLE
loadbalancingexporter: Prevent queue stalls during backend churn

### DIFF
--- a/.chloggen/saw-7944-central-queue-scheduling.yaml
+++ b/.chloggen/saw-7944-central-queue-scheduling.yaml
@@ -1,0 +1,13 @@
+change_type: enhancement
+
+component: exporter/loadbalancing
+
+note: Reduce central queue scheduling CPU and allocations by selecting ready windows in one pass.
+
+issues: [7944]
+
+subtext: |
+  The scheduler now avoids repeatedly materializing candidate windows while
+  preserving stale fallback, fairness, and lease behavior under backlog.
+
+change_logs: [user]

--- a/.chloggen/saw-7944-shutdown-consume-race.yaml
+++ b/.chloggen/saw-7944-shutdown-consume-race.yaml
@@ -1,0 +1,13 @@
+change_type: bug_fix
+
+component: exporter/loadbalancing
+
+note: Prevent late forced consumes from racing exporter shutdown.
+
+issues: [7944]
+
+subtext: |
+  Removed-backend cleanup now rejects new forced consumes after shutdown starts
+  so payloads can be rerouted or requeued without reusing a waiting WaitGroup.
+
+change_logs: [user]

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -230,11 +230,11 @@ func (q *centralQueue) tryLeaseWithAcquire(now time.Time, acquire centralQueueLe
 
 		state := centralQueueSchedulerStateReady
 		if len(q.ready) == 0 {
-			readyWindowLimit := q.settings.maxReadyWindows
 			if acquire != nil {
-				readyWindowLimit = 1
+				state = q.prepareSingleReadyWindowLocked(now)
+			} else {
+				state = q.prepareReadyWindowsLocked(now, q.settings.maxReadyWindows)
 			}
-			state = q.prepareReadyWindowsLocked(now, readyWindowLimit)
 		}
 		if len(q.ready) == 0 {
 			q.mu.Unlock()
@@ -277,6 +277,94 @@ func (q *centralQueue) tryLeaseWithAcquire(now time.Time, acquire centralQueueLe
 		lease.consumerRelease = release
 		return lease, nil
 	}
+}
+
+// prepareSingleReadyWindowLocked avoids collecting and sorting every candidate
+// when the adaptive consumer path can lease only one window. It preserves the
+// generic scheduler's stale-fallback, target, and fresh-fallback priority.
+func (q *centralQueue) prepareSingleReadyWindowLocked(now time.Time) centralQueueSchedulerState {
+	var staleFallback centralQueueWindowCandidate
+	var target centralQueueWindowCandidate
+	var freshFallback centralQueueWindowCandidate
+	var hasStaleFallback bool
+	var hasTarget bool
+	var hasFreshFallback bool
+	var targetBlocked bool
+	var freshFallbackBlocked bool
+
+	nowUnixNano := now.UnixNano()
+	staleCutoffUnixNano := int64(0)
+	if q.settings.forceScheduleAge > 0 {
+		staleCutoffUnixNano = now.Add(-q.settings.forceScheduleAge).UnixNano()
+	}
+
+	for _, bucket := range q.readyBuckets {
+		if bucket.readyAtUnixNano > nowUnixNano {
+			continue
+		}
+		candidate, _ := q.buildWindowCandidateFromBucketLocked(bucket, now)
+		if len(candidate.indexes) == 0 {
+			continue
+		}
+
+		blocked := q.windowInflightBlockedWithBase(candidate.window, q.currentInflightBytes)
+		switch {
+		case candidate.window.flushReason == centralQueueFlushReasonTargetReached:
+			if blocked {
+				targetBlocked = true
+				continue
+			}
+			if !hasTarget || centralQueueWindowCandidateLess(candidate, target) {
+				target = candidate
+				hasTarget = true
+			}
+		case staleCutoffUnixNano > 0 &&
+			candidate.window.oldestEnqueuedAt > 0 &&
+			candidate.window.oldestEnqueuedAt <= staleCutoffUnixNano:
+			if blocked {
+				continue
+			}
+			if !hasStaleFallback || centralQueueWindowCandidateLess(candidate, staleFallback) {
+				staleFallback = candidate
+				hasStaleFallback = true
+			}
+		default:
+			if blocked {
+				freshFallbackBlocked = true
+				continue
+			}
+			if !hasFreshFallback || centralQueueWindowCandidateLess(candidate, freshFallback) {
+				freshFallback = candidate
+				hasFreshFallback = true
+			}
+		}
+	}
+
+	switch {
+	case hasStaleFallback:
+		return q.scheduleSingleReadyWindowCandidateLocked(staleFallback, now)
+	case hasTarget:
+		return q.scheduleSingleReadyWindowCandidateLocked(target, now)
+	case targetBlocked:
+		return centralQueueSchedulerStateInflightBytes
+	case hasFreshFallback:
+		return q.scheduleSingleReadyWindowCandidateLocked(freshFallback, now)
+	case freshFallbackBlocked:
+		return centralQueueSchedulerStateInflightBytes
+	default:
+		return centralQueueSchedulerStateWaiting
+	}
+}
+
+func (q *centralQueue) scheduleSingleReadyWindowCandidateLocked(candidate centralQueueWindowCandidate, now time.Time) centralQueueSchedulerState {
+	scheduled, blocked := q.scheduleReadyWindowCandidatesLocked([]centralQueueWindowCandidate{candidate}, now, 1)
+	if scheduled {
+		return centralQueueSchedulerStateReadyWindowLimit
+	}
+	if blocked {
+		return centralQueueSchedulerStateInflightBytes
+	}
+	return centralQueueSchedulerStateWaiting
 }
 
 func (q *centralQueue) prepareReadyWindowsLocked(now time.Time, readyWindowLimit int) centralQueueSchedulerState {
@@ -548,16 +636,20 @@ func (q *centralQueue) buildWindowCandidateFromBucketLocked(bucket *centralQueue
 
 func sortCentralQueueWindowCandidates(candidates []centralQueueWindowCandidate) {
 	sort.Slice(candidates, func(i, j int) bool {
-		left := candidates[i].bucket
-		right := candidates[j].bucket
-		if left == nil || right == nil {
-			return right != nil
-		}
-		if left.readyAtUnixNano != right.readyAtUnixNano {
-			return left.readyAtUnixNano < right.readyAtUnixNano
-		}
-		return left.readySequence < right.readySequence
+		return centralQueueWindowCandidateLess(candidates[i], candidates[j])
 	})
+}
+
+func centralQueueWindowCandidateLess(leftCandidate, rightCandidate centralQueueWindowCandidate) bool {
+	left := leftCandidate.bucket
+	right := rightCandidate.bucket
+	if left == nil || right == nil {
+		return right != nil
+	}
+	if left.readyAtUnixNano != right.readyAtUnixNano {
+		return left.readyAtUnixNano < right.readyAtUnixNano
+	}
+	return left.readySequence < right.readySequence
 }
 
 func (q *centralQueue) scheduleReadyWindowCandidatesLocked(candidates []centralQueueWindowCandidate, now time.Time, readyWindowLimit int) (bool, bool) {

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -249,6 +249,62 @@ func TestCentralQueueTryLeaseWithAcquirePreparesOnlyOneReadyWindow(t *testing.T)
 	lease.done()
 }
 
+func TestCentralQueuePrepareSingleReadyWindowMatchesGenericScheduler(t *testing.T) {
+	now := time.Unix(100, 0)
+	for scenario := range 200 {
+		settings := centralQueueSettings{
+			maxCompressedBytes:           1 << 20,
+			maxInflightUncompressedBytes: 500,
+			maxUncompressedBatchBytes:    300,
+			targetCompressedBytes:        100,
+			maxBatchDelay:                2 * time.Second,
+			maxReadyWindows:              8,
+		}
+		fastQueue := newCentralQueue(settings)
+		genericQueue := newCentralQueue(settings)
+
+		for lane := range 12 {
+			routingKey := fmt.Appendf(nil, "lane-%02d", lane)
+			itemCount := 1 + (scenario+lane)%5
+			for itemIndex := range itemCount {
+				item := centralQueueItem{
+					signal:             signalKindLogs,
+					routingKey:         routingKey,
+					compressedBytes:    10 + (scenario+lane+itemIndex)%5*10,
+					uncompressedBytes:  20 + (scenario+lane*2+itemIndex)%4*20,
+					count:              1,
+					enqueuedAtUnixNano: now.Add(-time.Duration((scenario+lane*3+itemIndex)%20) * time.Second).UnixNano(),
+				}
+				if (scenario+lane+itemIndex)%13 == 0 {
+					item.nextAttemptUnixNano = now.Add(time.Second).UnixNano()
+				}
+				require.NoError(t, fastQueue.enqueueAt(item, now))
+				require.NoError(t, genericQueue.enqueueAt(item, now))
+			}
+		}
+
+		inflightBytes := int64((scenario % 4) * 100)
+		fastQueue.currentInflightBytes = inflightBytes
+		genericQueue.currentInflightBytes = inflightBytes
+
+		fastQueue.mu.Lock()
+		fastState := fastQueue.prepareSingleReadyWindowLocked(now)
+		fastQueue.mu.Unlock()
+
+		genericQueue.mu.Lock()
+		genericState := genericQueue.prepareReadyWindowsLocked(now, 1)
+		genericQueue.mu.Unlock()
+
+		require.Equalf(t, genericState, fastState, "scenario %d scheduler state", scenario)
+		require.Equalf(t, genericQueue.ready, fastQueue.ready, "scenario %d ready windows", scenario)
+		require.Equalf(t, genericQueue.itemCount, fastQueue.itemCount, "scenario %d item count", scenario)
+		require.Equalf(t, genericQueue.currentInflightBytes, fastQueue.currentInflightBytes, "scenario %d inflight bytes", scenario)
+		for routingKey, genericBucket := range genericQueue.bucketsByKey {
+			require.Equalf(t, genericBucket.items, fastQueue.bucketsByKey[routingKey].items, "scenario %d bucket %s", scenario, routingKey)
+		}
+	}
+}
+
 func TestCentralQueueLeaseWithAcquireRetriesWhenConsumersBecomeAvailable(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:           100,
@@ -1520,6 +1576,59 @@ func BenchmarkCentralQueueDrainInterleavedBacklog(b *testing.B) {
 
 		for q.len() > 0 {
 			lease, err := q.tryLease(now.Add(time.Second))
+			require.NoError(b, err)
+			if lease == nil {
+				b.Fatalf("queue stalled with %d items remaining", q.len())
+			}
+			lease.done()
+		}
+	}
+}
+
+func BenchmarkCentralQueueDrainInterleavedBacklogWithAcquire(b *testing.B) {
+	const (
+		laneCount             = 64
+		itemsPerLane          = 512
+		itemCompressedBytes   = 4 * 1024
+		itemUncompressedBytes = 16 * 1024
+		targetCompressedBytes = 256 * 1024
+	)
+
+	laneKeys := make([][]byte, laneCount)
+	for lane := range laneCount {
+		laneKeys[lane] = fmt.Appendf(nil, "lane-%02d", lane)
+	}
+	now := time.Unix(1000, 0)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		q := newCentralQueue(centralQueueSettings{
+			maxCompressedBytes:           int64(laneCount * itemsPerLane * itemCompressedBytes),
+			maxInflightUncompressedBytes: int64(laneCount * targetCompressedBytes * 16),
+			maxUncompressedBatchBytes:    laneCount * targetCompressedBytes,
+			targetCompressedBytes:        targetCompressedBytes,
+			maxBatchDelay:                time.Second,
+			maxReadyWindows:              laneCount,
+		})
+
+		b.StopTimer()
+		for itemIndex := range itemsPerLane {
+			for lane := range laneCount {
+				require.NoError(b, q.enqueueAt(centralQueueItem{
+					signal:            signalKindLogs,
+					routingKey:        laneKeys[lane],
+					compressedBytes:   itemCompressedBytes,
+					uncompressedBytes: itemUncompressedBytes,
+					count:             1,
+				}, now.Add(time.Duration(itemIndex)*time.Nanosecond)))
+			}
+		}
+		b.StartTimer()
+
+		for q.len() > 0 {
+			lease, err := q.tryLeaseWithAcquire(now.Add(time.Second), func(int64, centralQueueWindow) (func(), bool) {
+				return func() {}, true
+			})
 			require.NoError(b, err)
 			if lease == nil {
 				b.Fatalf("queue stalled with %d items remaining", q.len())

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -371,6 +371,11 @@ func (e *logExporterImp) consumeCentralQueueLogWindowAttempt(ctx context.Context
 	}
 	decision, err := e.consumeBatchWithDecision(ctx, le, ld, logFlushReasonDirect, true, false, false)
 	backendLease.release()
+	if errors.Is(err, errLogBatcherExporterStopping) && directRerouteAttemptAllowed(e.loadBalancer, rerouteAttempt) {
+		rerouteErr := e.consumeCentralQueueLogWindowAttempt(ctx, window, rerouteAttempt+1, nil)
+		e.loadBalancer.recordBackendReroute(ctx, "logs", endpointFailureExporterStopping, rerouteErr)
+		return rerouteErr
+	}
 	if err != nil && shouldRerouteDirectFailure(e.loadBalancer, le.endpoint, decision, rerouteAttempt) {
 		rerouteErr := e.consumeCentralQueueLogWindowAttempt(ctx, window, rerouteAttempt+1, nil)
 		e.loadBalancer.recordBackendReroute(ctx, "logs", decision.reason, rerouteErr)
@@ -465,7 +470,16 @@ func (e *logExporterImp) consumeLogDirect(ctx context.Context, ld plog.Logs, rer
 		retryLogs = plog.NewLogs()
 		ld.CopyTo(retryLogs)
 	}
+	return e.consumeLogDirectAttempt(ctx, le, ld, retryLogs, rerouteAttempt)
+}
+
+func (e *logExporterImp) consumeLogDirectAttempt(ctx context.Context, le *wrappedExporter, ld, retryLogs plog.Logs, rerouteAttempt int) error {
 	decision, err := e.consumeBatchWithDecision(ctx, le, ld, logFlushReasonDirect, true, true, false)
+	if errors.Is(err, errLogBatcherExporterStopping) && directRerouteAttemptAllowed(e.loadBalancer, rerouteAttempt) {
+		rerouteErr := e.consumeLogDirect(ctx, retryLogs, rerouteAttempt+1)
+		e.loadBalancer.recordBackendReroute(ctx, "logs", endpointFailureExporterStopping, rerouteErr)
+		return rerouteErr
+	}
 	if err != nil && shouldRerouteDirectFailure(e.loadBalancer, le.endpoint, decision, rerouteAttempt) {
 		rerouteErr := e.consumeLogDirect(ctx, retryLogs, rerouteAttempt+1)
 		e.loadBalancer.recordBackendReroute(ctx, "logs", decision.reason, rerouteErr)

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -536,9 +536,13 @@ func (e *logExporterImp) rerouteDrainBatch(ctx context.Context, ld plog.Logs, re
 }
 
 func (e *logExporterImp) consumeBatchWithDecision(ctx context.Context, le *wrappedExporter, ld plog.Logs, reason string, updateEndpointHealth, drainRemoved, healthOnly bool) (endpointHealthFailureDecision, error) {
+	var started bool
 	if reason == logFlushReasonDirect || reason == logFlushReasonResolverChange || reason == logFlushReasonShutdown {
-		le.forceStartConsume()
-	} else if !le.tryStartConsume() {
+		started = le.forceStartConsume()
+	} else {
+		started = le.tryStartConsume()
+	}
+	if !started {
 		return endpointHealthFailureDecision{}, errLogBatcherExporterStopping
 	}
 	defer le.doneConsume()

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -2107,6 +2107,44 @@ func TestConsumeLogLegacyPathIgnoresStoppingGate(t *testing.T) {
 	assert.Equal(t, int64(1), logsConsumed.Load())
 }
 
+func TestConsumeLogDirectReroutesExporterAfterShutdownStarts(t *testing.T) {
+	ts, tb, telemetry := getTelemetryAssetsWithReader(t)
+	cfg := simpleConfig()
+	enableEndpointHealth(cfg)
+
+	lb, err := newLoadBalancer(ts.Logger, cfg, nil, tb)
+	require.NoError(t, err)
+
+	stoppedExp := newWrappedExporter(newNopMockLogsExporter(), "endpoint-1:4317")
+	require.NoError(t, stoppedExp.Shutdown(t.Context()))
+
+	logsConsumed := atomic.Int64{}
+	liveExp := newWrappedExporter(newMockLogsExporter(func(_ context.Context, ld plog.Logs) error {
+		logsConsumed.Add(int64(ld.LogRecordCount()))
+		return nil
+	}), "endpoint-2:4317")
+	lb.ring = newHashRing([]string{"endpoint-2"})
+	lb.exporters = map[string]*wrappedExporter{
+		"endpoint-2:4317": liveExp,
+	}
+
+	p, err := newLogsExporter(ts, cfg)
+	require.NoError(t, err)
+	p.loadBalancer = lb
+
+	logs := simpleLogs()
+	retryLogs := plog.NewLogs()
+	logs.CopyTo(retryLogs)
+	require.NoError(t, p.consumeLogDirectAttempt(t.Context(), stoppedExp, logs, retryLogs, 0))
+	assert.Equal(t, int64(1), logsConsumed.Load())
+	metadatatest.AssertEqualLoadbalancerBackendRerouteTotal(t, telemetry, []metricdata.DataPoint[int64]{
+		{
+			Attributes: attribute.NewSet(attribute.String("signal", "logs"), attribute.String("result", "success"), attribute.String("reason", "exporter_stopping")),
+			Value:      1,
+		},
+	}, metricdatatest.IgnoreTimestamp())
+}
+
 func TestEnqueueEndpointBatchesReroutesStoppingExporterOnce(t *testing.T) {
 	ts, tb := getTelemetryAssets(t)
 	logsConsumed := atomic.Int64{}

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -395,7 +395,15 @@ func (e *metricExporterImp) consumeCentralQueueMetricWindowAttempt(ctx context.C
 		return nil
 	}
 
-	exp.forceStartConsume()
+	if !exp.forceStartConsume() {
+		backendLease.release()
+		if directRerouteAttemptAllowed(e.loadBalancer, rerouteAttempt) {
+			rerouteErr := e.consumeCentralQueueMetricWindowAttempt(ctx, window, rerouteAttempt+1, nil)
+			e.loadBalancer.recordBackendReroute(ctx, "metrics", endpointFailureExporterStopping, rerouteErr)
+			return rerouteErr
+		}
+		return errExporterIsStopping
+	}
 	defer exp.doneConsume()
 
 	recordMetricBackendRequest(ctx, e.telemetry, exp.metricSignalAttr, exp.metricRequestAttr, md)
@@ -695,9 +703,13 @@ func (e *metricExporterImp) consumeBatch(ctx context.Context, we *wrappedExporte
 		retryMetrics = pmetric.NewMetrics()
 		md.CopyTo(retryMetrics)
 	}
+	var started bool
 	if reason == metricFlushReasonResolverChange || reason == metricFlushReasonShutdown {
-		we.forceStartConsume()
-	} else if !we.tryStartConsume() {
+		started = we.forceStartConsume()
+	} else {
+		started = we.tryStartConsume()
+	}
+	if !started {
 		if retryAllowed {
 			return metricBatcherRerouteableError{
 				err:  errMetricBatcherExporterStopping,

--- a/exporter/loadbalancingexporter/wrapped_exporter.go
+++ b/exporter/loadbalancingexporter/wrapped_exporter.go
@@ -24,10 +24,11 @@ var errExporterIsStopping = errors.New("exporter is stopping")
 // consumeWG has to be incremented explicitly by the consumer of the wrapped exporter.
 type wrappedExporter struct {
 	component.Component
-	consumeWG sync.WaitGroup
-	consumeMu sync.Mutex
-	stopping  atomic.Bool
-	endpoint  string
+	consumeWG       sync.WaitGroup
+	consumeMu       sync.Mutex
+	stopping        atomic.Bool
+	shutdownStarted bool
+	endpoint        string
 
 	// we store the attributes here for both cases, to avoid new allocations on the hot path
 	endpointAttr      attribute.Set
@@ -58,6 +59,7 @@ func newWrappedExporter(exp component.Component, identifier string) *wrappedExpo
 func (we *wrappedExporter) Shutdown(ctx context.Context) error {
 	we.consumeMu.Lock()
 	we.stopping.Store(true)
+	we.shutdownStarted = true
 	we.consumeMu.Unlock()
 	we.consumeWG.Wait()
 	return we.Component.Shutdown(ctx)
@@ -77,14 +79,14 @@ func (we *wrappedExporter) tryStartConsume() bool {
 	return we.startConsume(false)
 }
 
-func (we *wrappedExporter) forceStartConsume() {
-	we.startConsume(true)
+func (we *wrappedExporter) forceStartConsume() bool {
+	return we.startConsume(true)
 }
 
 func (we *wrappedExporter) startConsume(allowStopping bool) bool {
 	we.consumeMu.Lock()
 	defer we.consumeMu.Unlock()
-	if !allowStopping && we.stopping.Load() {
+	if we.shutdownStarted || (!allowStopping && we.stopping.Load()) {
 		return false
 	}
 	we.consumeWG.Add(1)

--- a/exporter/loadbalancingexporter/wrapped_exporter_test.go
+++ b/exporter/loadbalancingexporter/wrapped_exporter_test.go
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrappedExporterRejectsForcedConsumeAfterShutdownStarts(t *testing.T) {
+	exp := newNopMockExporter()
+	require.True(t, exp.forceStartConsume())
+	activeConsumeReleased := false
+	defer func() {
+		if !activeConsumeReleased {
+			exp.doneConsume()
+		}
+	}()
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- exp.Shutdown(t.Context())
+	}()
+
+	require.Eventually(t, exp.isStopping, time.Second, 10*time.Millisecond)
+	lateConsumeStarted := exp.forceStartConsume()
+	if lateConsumeStarted {
+		exp.doneConsume()
+	}
+	require.False(t, lateConsumeStarted)
+
+	select {
+	case <-shutdownDone:
+		t.Fatal("shutdown returned before the active consume completed")
+	default:
+	}
+
+	exp.doneConsume()
+	activeConsumeReleased = true
+	require.NoError(t, <-shutdownDone)
+}


### PR DESCRIPTION
Reduces central-queue scheduler CPU and closes shutdown races that can strand or fail queued log and metric batches during backend churn.

Description
- select the best adaptive-consumer queue window in one pass while preserving scheduler ordering and inflight limits
- reject consumes after exporter shutdown begins and reroute stopping log/metric exporters once
- add randomized scheduler equivalence, shutdown-race, reroute, full suite, and race-suite coverage

Verification
- go test ./...
- go test -race ./...
- make lint
- make chlog-validate
- autoreview clean

Linear: SAW-7944

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path queue scheduling and export lifecycle during backend removal/shutdown; behavior is heavily tested but affects queued batch delivery under churn.
> 
> **Overview**
> **Central queue scheduling** picks a single ready window in one bucket scan when the adaptive consumer path leases with an acquire callback, instead of building and sorting full candidate lists. Stale-fallback, target, and fresh-fallback priority and inflight blocking stay aligned with the generic scheduler (200-scenario equivalence test).
> 
> **Shutdown / backend churn:** `wrappedExporter` sets `shutdownStarted` when `Shutdown` begins and refuses any new consume (including `forceStartConsume`) after that, so late work cannot wedge the `WaitGroup`. Log and metric exporters treat `exporter_stopping` like other direct failures and **reroute once** to another backend for central-queue windows and direct log export; metrics central-queue path releases the backend lease before rerouting when force consume fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b2d709d705180b373e152cfa02d033e9680043. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents central-queue stalls during backend churn by streamlining ready-window selection and fixing a shutdown race that let consumes start after exporter stop. Reduces scheduler CPU/allocations and reroutes batches away from stopping endpoints, per SAW-7944.

- **Refactors**
  - One-pass adaptive-consumer selection in `exporter/loadbalancingexporter/central_queue.go` preserves ordering, inflight limits, and stale/fresh fallback; adds targeted benchmark and scheduler-equivalence test.
  - Unifies candidate ordering via `centralQueueWindowCandidateLess`; new `BenchmarkCentralQueueDrainInterleavedBacklogWithAcquire` validates no stalls under backlog.

- **Bug Fixes**
  - Rejects forced consumes after shutdown begins using a `shutdownStarted` gate in `wrapped_exporter`; adds test to prevent `WaitGroup` reuse panic.
  - Reroutes direct and central-queue log/metric batches on `exporter_stopping` in `log_exporter.go` and `metrics_exporter.go`, with reroute telemetry recorded.

<sup>Written for commit 12b2d709d705180b373e152cfa02d033e9680043. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Sawmills/opentelemetry-collector-contrib/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reduced CPU usage and allocation overhead when scheduling central queue work while preserving fairness and lease behavior.

- **Bug Fixes**
  - Prevented late retry attempts from racing exporter shutdown.
  - Improved rerouting and requeuing when an exporter begins stopping.
  - Ensured active work completes safely during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->