### PR TITLE
perf(loadbalancingexporter): remove control-plane polling

### DIFF
--- a/.chloggen/saw-7944-control-plane-polling.yaml
+++ b/.chloggen/saw-7944-control-plane-polling.yaml
@@ -1,0 +1,14 @@
+change_type: enhancement
+
+component: exporter/loadbalancing
+
+note: Reduce load-balancing control-plane CPU and allocations for large backend sets.
+
+issues: [7944]
+
+subtext: |
+  Endpoint eligibility now uses an immutable constant-time snapshot, unchanged
+  endpoint sets skip ring rebuilds, consistent hashing avoids per-position
+  allocations, and central queue wakeups use notifications with bounded fallback.
+
+change_logs: [user]

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -17,6 +17,11 @@ import (
 
 const centralQueueLeasePollInterval = 10 * time.Millisecond
 const (
+	centralQueueLeaseFallbackInitialDelay = 50 * time.Millisecond
+	centralQueueLeaseFallbackMaxDelay     = time.Second
+)
+
+const (
 	centralQueueInitialRetryDelay = 100 * time.Millisecond
 	centralQueueMaxRetryDelay     = 5 * time.Second
 	centralQueueMaxRetryJitter    = 100 * time.Millisecond
@@ -173,7 +178,7 @@ func (q *centralQueue) enqueueAt(item centralQueueItem, now time.Time) error {
 }
 
 func (q *centralQueue) lease(ctx context.Context) (*centralQueueLease, error) {
-	return q.leaseWithPollInterval(ctx, centralQueueLeasePollInterval)
+	return q.leaseWithPollInterval(ctx, centralQueueLeaseFallbackInitialDelay)
 }
 
 func (q *centralQueue) leaseWithPollInterval(ctx context.Context, pollInterval time.Duration) (*centralQueueLease, error) {
@@ -183,32 +188,86 @@ func (q *centralQueue) leaseWithPollInterval(ctx context.Context, pollInterval t
 type centralQueueLeaseAcquireFunc func(queueCompressedBytes int64, window centralQueueWindow) (func(), bool)
 
 func (q *centralQueue) leaseWithAcquire(ctx context.Context, acquire centralQueueLeaseAcquireFunc) (*centralQueueLease, error) {
-	return q.leaseWithPollIntervalAndAcquire(ctx, centralQueueLeasePollInterval, acquire)
+	return q.leaseWithPollIntervalAndAcquire(ctx, centralQueueLeaseFallbackInitialDelay, acquire)
 }
 
-func (q *centralQueue) leaseWithPollIntervalAndAcquire(ctx context.Context, pollInterval time.Duration, acquire centralQueueLeaseAcquireFunc) (*centralQueueLease, error) {
-	var ticker *time.Ticker
-	var poll <-chan time.Time
-	if pollInterval > 0 {
-		ticker = time.NewTicker(pollInterval)
-		poll = ticker.C
-		defer ticker.Stop()
-	}
+func (q *centralQueue) leaseWithPollIntervalAndAcquire(ctx context.Context, fallbackInitialDelay time.Duration, acquire centralQueueLeaseAcquireFunc) (*centralQueueLease, error) {
+	var timer *time.Timer
+	defer func() {
+		stopCentralQueueTimer(timer)
+	}()
+
+	fallbackDelay := fallbackInitialDelay
+	fallbackMaxDelay := max(fallbackInitialDelay, centralQueueLeaseFallbackMaxDelay)
 	for {
-		lease, err := q.tryLeaseWithAcquire(time.Now(), acquire)
+		now := time.Now()
+		lease, err := q.tryLeaseWithAcquire(now, acquire)
 		if lease != nil {
+			// Pass the wakeup to another waiter when this queue has more work.
+			// The buffered notification coalesces the otherwise redundant wakeups.
+			q.notifyLeaseWaiters()
 			return lease, nil
 		}
 		if err != nil && !errors.Is(err, errCentralQueueInflightFull) && !errors.Is(err, errCentralQueueConsumersFull) {
 			return nil, err
 		}
 
+		waitDelay := q.nextLeaseWakeDelay(now, fallbackDelay, err)
+		var timerC <-chan time.Time
+		if waitDelay > 0 {
+			if timer == nil {
+				timer = time.NewTimer(waitDelay)
+			} else {
+				resetCentralQueueTimer(timer, waitDelay)
+			}
+			timerC = timer.C
+		} else {
+			stopCentralQueueTimer(timer)
+		}
+
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-q.notify:
-		case <-poll:
+			fallbackDelay = fallbackInitialDelay
+		case <-timerC:
+			fallbackDelay = min(fallbackDelay*2, fallbackMaxDelay)
 		}
+	}
+}
+
+func (q *centralQueue) nextLeaseWakeDelay(now time.Time, fallbackDelay time.Duration, leaseErr error) time.Duration {
+	q.mu.Lock()
+	hasPrepared := len(q.ready) > 0
+	var readyAtUnixNano int64
+	if len(q.readyBuckets) > 0 {
+		readyAtUnixNano = q.readyBuckets[0].readyAtUnixNano
+	}
+	q.mu.Unlock()
+
+	if readyAtUnixNano > now.UnixNano() {
+		return time.Duration(readyAtUnixNano - now.UnixNano())
+	}
+	if fallbackDelay > 0 && (hasPrepared || readyAtUnixNano > 0 ||
+		errors.Is(leaseErr, errCentralQueueInflightFull) ||
+		errors.Is(leaseErr, errCentralQueueConsumersFull)) {
+		return fallbackDelay
+	}
+	return 0
+}
+
+func resetCentralQueueTimer(timer *time.Timer, delay time.Duration) {
+	stopCentralQueueTimer(timer)
+	timer.Reset(delay)
+}
+
+func stopCentralQueueTimer(timer *time.Timer) {
+	if timer == nil || timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
 	}
 }
 

--- a/exporter/loadbalancingexporter/central_queue.go
+++ b/exporter/loadbalancingexporter/central_queue.go
@@ -245,12 +245,17 @@ func (q *centralQueue) nextLeaseWakeDelay(now time.Time, fallbackDelay time.Dura
 	}
 	q.mu.Unlock()
 
-	if readyAtUnixNano > now.UnixNano() {
-		return time.Duration(readyAtUnixNano - now.UnixNano())
-	}
-	if fallbackDelay > 0 && (hasPrepared || readyAtUnixNano > 0 ||
+	fallbackNeeded := hasPrepared ||
 		errors.Is(leaseErr, errCentralQueueInflightFull) ||
-		errors.Is(leaseErr, errCentralQueueConsumersFull)) {
+		errors.Is(leaseErr, errCentralQueueConsumersFull)
+	if readyAtUnixNano > now.UnixNano() {
+		readyDelay := time.Duration(readyAtUnixNano - now.UnixNano())
+		if fallbackDelay > 0 && fallbackNeeded {
+			return min(readyDelay, fallbackDelay)
+		}
+		return readyDelay
+	}
+	if fallbackDelay > 0 && (fallbackNeeded || readyAtUnixNano > 0) {
 		return fallbackDelay
 	}
 	return 0

--- a/exporter/loadbalancingexporter/central_queue_backend_limiter.go
+++ b/exporter/loadbalancingexporter/central_queue_backend_limiter.go
@@ -10,9 +10,11 @@ import (
 )
 
 type centralQueueBackendLimiter struct {
-	mu     sync.Mutex
-	active map[string]int
-	limit  int
+	mu                   sync.Mutex
+	active               map[string]int
+	limit                int
+	waiters              map[string]chan struct{}
+	fallbackInitialDelay time.Duration
 }
 
 type centralQueueBackendLease struct {
@@ -57,8 +59,10 @@ func tryAcquireCentralQueueBackendForWindow(lb *loadBalancer, limiter *centralQu
 
 func newCentralQueueBackendLimiter() *centralQueueBackendLimiter {
 	return &centralQueueBackendLimiter{
-		active: make(map[string]int),
-		limit:  defaultCentralQueueMaxInflightSendsPerBackend,
+		active:               make(map[string]int),
+		limit:                defaultCentralQueueMaxInflightSendsPerBackend,
+		waiters:              make(map[string]chan struct{}),
+		fallbackInitialDelay: centralQueueLeaseFallbackInitialDelay,
 	}
 }
 
@@ -66,21 +70,53 @@ func (l *centralQueueBackendLimiter) acquire(ctx context.Context, endpoint strin
 	if l == nil || endpoint == "" {
 		return &centralQueueBackendLease{}, nil
 	}
-	if l.tryAcquire(endpoint) {
+	acquired, notify := l.tryAcquireOrWait(endpoint)
+	if acquired {
 		return &centralQueueBackendLease{limiter: l, endpoint: endpoint}, nil
 	}
-	ticker := time.NewTicker(centralQueueLeasePollInterval)
-	defer ticker.Stop()
+	delay := l.fallbackInitialDelay
+	if delay <= 0 {
+		delay = centralQueueLeaseFallbackInitialDelay
+	}
+	maxDelay := max(delay, centralQueueLeaseFallbackMaxDelay)
+	timer := time.NewTimer(delay)
+	defer stopCentralQueueTimer(timer)
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-ticker.C:
-			if l.tryAcquire(endpoint) {
-				return &centralQueueBackendLease{limiter: l, endpoint: endpoint}, nil
+		case <-notify:
+			delay = l.fallbackInitialDelay
+			if delay <= 0 {
+				delay = centralQueueLeaseFallbackInitialDelay
 			}
+		case <-timer.C:
+			delay = min(delay*2, maxDelay)
 		}
+		acquired, notify = l.tryAcquireOrWait(endpoint)
+		if acquired {
+			return &centralQueueBackendLease{limiter: l, endpoint: endpoint}, nil
+		}
+		resetCentralQueueTimer(timer, delay)
 	}
+}
+
+func (l *centralQueueBackendLimiter) tryAcquireOrWait(endpoint string) (bool, <-chan struct{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.active[endpoint] < l.limit {
+		l.active[endpoint]++
+		return true, nil
+	}
+	if l.waiters == nil {
+		l.waiters = make(map[string]chan struct{})
+	}
+	notify := l.waiters[endpoint]
+	if notify == nil {
+		notify = make(chan struct{})
+		l.waiters[endpoint] = notify
+	}
+	return false, notify
 }
 
 func (l *centralQueueBackendLimiter) tryAcquire(endpoint string) bool {
@@ -95,13 +131,18 @@ func (l *centralQueueBackendLimiter) tryAcquire(endpoint string) bool {
 
 func (l *centralQueueBackendLimiter) release(endpoint string) {
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	active := l.active[endpoint]
 	if active <= 1 {
 		delete(l.active, endpoint)
-		return
+	} else {
+		l.active[endpoint] = active - 1
 	}
-	l.active[endpoint] = active - 1
+	notify := l.waiters[endpoint]
+	delete(l.waiters, endpoint)
+	l.mu.Unlock()
+	if notify != nil {
+		close(notify)
+	}
 }
 
 func (l *centralQueueBackendLease) release() {

--- a/exporter/loadbalancingexporter/central_queue_backend_limiter_test.go
+++ b/exporter/loadbalancingexporter/central_queue_backend_limiter_test.go
@@ -1,0 +1,99 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package loadbalancingexporter
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCentralQueueBackendLimiterReleaseWakesWaiter(t *testing.T) {
+	limiter := newCentralQueueBackendLimiter()
+	limiter.limit = 1
+	limiter.fallbackInitialDelay = time.Hour
+
+	first, err := limiter.acquire(t.Context(), "endpoint-1:4317")
+	require.NoError(t, err)
+
+	acquired := make(chan *centralQueueBackendLease, 1)
+	go func() {
+		lease, acquireErr := limiter.acquire(t.Context(), "endpoint-1:4317")
+		if acquireErr == nil {
+			acquired <- lease
+		}
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("backend slot acquired before release")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	start := time.Now()
+	first.release()
+	select {
+	case lease := <-acquired:
+		require.Less(t, time.Since(start), time.Second)
+		lease.release()
+	case <-time.After(time.Second):
+		t.Fatal("backend slot release did not wake waiter")
+	}
+}
+
+func TestCentralQueueBackendLimiterReleaseWakesOnlyMatchingEndpoint(t *testing.T) {
+	limiter := newCentralQueueBackendLimiter()
+	limiter.limit = 1
+	limiter.fallbackInitialDelay = time.Hour
+
+	firstA, err := limiter.acquire(t.Context(), "endpoint-a:4317")
+	require.NoError(t, err)
+	firstB, err := limiter.acquire(t.Context(), "endpoint-b:4317")
+	require.NoError(t, err)
+
+	acquiredA := make(chan *centralQueueBackendLease, 1)
+	acquiredB := make(chan *centralQueueBackendLease, 1)
+	go acquireCentralQueueBackendForTest(t.Context(), limiter, "endpoint-a:4317", acquiredA)
+	go acquireCentralQueueBackendForTest(t.Context(), limiter, "endpoint-b:4317", acquiredB)
+	require.Eventually(t, func() bool {
+		limiter.mu.Lock()
+		defer limiter.mu.Unlock()
+		return len(limiter.waiters) == 2
+	}, time.Second, time.Millisecond)
+
+	firstA.release()
+	select {
+	case lease := <-acquiredA:
+		lease.release()
+	case <-time.After(time.Second):
+		t.Fatal("endpoint A release did not wake endpoint A waiter")
+	}
+	select {
+	case <-acquiredB:
+		t.Fatal("endpoint A release woke endpoint B waiter")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	firstB.release()
+	select {
+	case lease := <-acquiredB:
+		lease.release()
+	case <-time.After(time.Second):
+		t.Fatal("endpoint B release did not wake endpoint B waiter")
+	}
+}
+
+func acquireCentralQueueBackendForTest(
+	ctx context.Context,
+	limiter *centralQueueBackendLimiter,
+	endpoint string,
+	acquired chan<- *centralQueueBackendLease,
+) {
+	lease, err := limiter.acquire(ctx, endpoint)
+	if err == nil {
+		acquired <- lease
+	}
+}

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -346,6 +346,91 @@ func TestCentralQueueLeaseWithAcquireRetriesWhenConsumersBecomeAvailable(t *test
 	lease.done()
 }
 
+func TestCentralQueueLeaseWithoutFallbackWakesAtBatchDeadline(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        100,
+		maxBatchDelay:                30 * time.Millisecond,
+		maxReadyWindows:              1,
+	})
+	start := time.Now()
+	require.NoError(t, q.enqueueAt(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("lane-a"),
+		compressedBytes:   10,
+		uncompressedBytes: 10,
+		count:             1,
+	}, start))
+	select {
+	case <-q.notify:
+	default:
+	}
+
+	lease, err := q.leaseWithPollInterval(t.Context(), 0)
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.GreaterOrEqual(t, time.Since(start), 20*time.Millisecond)
+	require.Less(t, time.Since(start), 500*time.Millisecond)
+	lease.done()
+}
+
+func TestCentralQueueLeaseWithoutFallbackWakesOnEnqueue(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        1,
+		maxReadyWindows:              1,
+	})
+	result := startCentralQueueLeaseWithoutPolling(t.Context(), q)
+	requireNoCentralQueueLeaseResult(t, result)
+
+	require.NoError(t, q.enqueue(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("lane-a"),
+		compressedBytes:   1,
+		uncompressedBytes: 1,
+		count:             1,
+	}))
+	lease := requireCentralQueueLeaseResult(t, result)
+	lease.done()
+}
+
+func TestCentralQueueLeaseFallbackBacksOffWhenConsumersRemainFull(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        1,
+		maxReadyWindows:              1,
+	})
+	require.NoError(t, q.enqueue(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("lane-a"),
+		compressedBytes:   1,
+		uncompressedBytes: 1,
+		count:             1,
+	}))
+	select {
+	case <-q.notify:
+	default:
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 260*time.Millisecond)
+	defer cancel()
+	var attempts atomic.Int64
+	lease, err := q.leaseWithAcquire(ctx, func(int64, centralQueueWindow) (func(), bool) {
+		attempts.Add(1)
+		return nil, false
+	})
+	require.Nil(t, lease)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.GreaterOrEqual(t, attempts.Load(), int64(2))
+	require.LessOrEqual(t, attempts.Load(), int64(4))
+}
+
 func TestCentralQueuePrunesEmptyBucketsAfterScheduling(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:        100,

--- a/exporter/loadbalancingexporter/central_queue_test.go
+++ b/exporter/loadbalancingexporter/central_queue_test.go
@@ -431,6 +431,51 @@ func TestCentralQueueLeaseFallbackBacksOffWhenConsumersRemainFull(t *testing.T) 
 	require.LessOrEqual(t, attempts.Load(), int64(4))
 }
 
+func TestCentralQueueLeaseFallbackPrecedesUnrelatedBatchDeadline(t *testing.T) {
+	q := newCentralQueue(centralQueueSettings{
+		maxCompressedBytes:           100,
+		maxInflightUncompressedBytes: 100,
+		maxUncompressedBatchBytes:    100,
+		targetCompressedBytes:        10,
+		maxBatchDelay:                time.Hour,
+		maxReadyWindows:              1,
+	})
+	require.NoError(t, q.enqueue(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("ready-lane"),
+		compressedBytes:   10,
+		uncompressedBytes: 10,
+		count:             1,
+	}))
+	require.NoError(t, q.enqueue(centralQueueItem{
+		signal:            signalKindLogs,
+		routingKey:        []byte("future-lane"),
+		compressedBytes:   1,
+		uncompressedBytes: 1,
+		count:             1,
+	}))
+	select {
+	case <-q.notify:
+	default:
+	}
+
+	var attempts atomic.Int64
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	start := time.Now()
+	lease, err := q.leaseWithPollIntervalAndAcquire(ctx, 20*time.Millisecond, func(int64, centralQueueWindow) (func(), bool) {
+		if attempts.Add(1) == 1 {
+			return nil, false
+		}
+		return func() {}, true
+	})
+	require.NoError(t, err)
+	require.NotNil(t, lease)
+	require.Less(t, time.Since(start), 500*time.Millisecond)
+	require.Equal(t, int64(2), attempts.Load())
+	lease.done()
+}
+
 func TestCentralQueuePrunesEmptyBucketsAfterScheduling(t *testing.T) {
 	q := newCentralQueue(centralQueueSettings{
 		maxCompressedBytes:        100,

--- a/exporter/loadbalancingexporter/consistent_hashing.go
+++ b/exporter/loadbalancingexporter/consistent_hashing.go
@@ -32,6 +32,9 @@ type hashRing struct {
 	items []ringItem
 	// endpoints holds the normalized unique endpoints represented by items.
 	endpoints []string
+	// configuredEndpoints holds the normalized input set, including an endpoint
+	// that received no position because the finite ring was saturated.
+	configuredEndpoints []string
 	// balancedLaneRoutingKeys caches central queue routing keys for this immutable ring.
 	balancedLaneRoutingKeys sync.Map
 }
@@ -40,8 +43,9 @@ type hashRing struct {
 func newHashRing(endpoints []string) *hashRing {
 	items := positionsForEndpoints(endpoints, defaultWeight)
 	return &hashRing{
-		items:     items,
-		endpoints: hashRingEndpoints(items),
+		items:               items,
+		endpoints:           hashRingEndpoints(items),
+		configuredEndpoints: normalizeEndpoints(endpoints),
 	}
 }
 
@@ -51,9 +55,7 @@ func (h *hashRing) endpointFor(identifier []byte) string {
 		// perhaps the ring itself couldn't get initialized yet?
 		return ""
 	}
-	hasher := crc32.NewIEEE()
-	hasher.Write(identifier)
-	hash := hasher.Sum32()
+	hash := crc32.ChecksumIEEE(identifier)
 	pos := hash % maxPositions
 
 	return h.findEndpoint(position(pos))
@@ -111,15 +113,11 @@ func bsearch(pos position, left, right []ringItem) ringItem {
 // The slice length of the result matches the numPoints.
 func positionsFor(endpoint string, numPoints int) []position {
 	res := make([]position, 0, numPoints)
-	buf := make([]byte, 4)
+	var buf [4]byte
+	endpointHash := crc32.Update(0, crc32.IEEETable, []byte(endpoint))
 	for i := range numPoints {
-		h := crc32.NewIEEE()
-		binary.LittleEndian.PutUint32(buf, uint32(i))
-		h.Write([]byte(endpoint))
-		h.Write(buf)
-		hash := h.Sum32()
-		pos := hash % maxPositions
-		res = append(res, position(pos))
+		binary.LittleEndian.PutUint32(buf[:], uint32(i))
+		res = append(res, position(crc32.Update(endpointHash, crc32.IEEETable, buf[:])%maxPositions))
 	}
 
 	return res
@@ -127,23 +125,30 @@ func positionsFor(endpoint string, numPoints int) []position {
 
 // positionsForEndpoints calculates all the positions for all the given endpoints
 func positionsForEndpoints(endpoints []string, weight int) []ringItem {
-	var items []ringItem
-	positions := map[position]bool{} // tracking the used positions
+	capacity := min(len(endpoints)*weight, int(maxPositions))
+	items := make([]ringItem, 0, capacity)
+	positions := make(map[position]struct{}, capacity)
+	var buf [4]byte
 	for _, endpoint := range endpoints {
+		endpointHash := crc32.Update(0, crc32.IEEETable, []byte(endpoint))
 		// for this initial implementation, we don't allow endpoints to have custom weights
-		for _, pos := range positionsFor(endpoint, weight) {
+		for i := range weight {
+			binary.LittleEndian.PutUint32(buf[:], uint32(i))
+			pos := position(crc32.Update(endpointHash, crc32.IEEETable, buf[:]) % maxPositions)
 			// if this position is occupied already, look ahead in the array for a free position
 			actualPos := pos
 			positionsProbed := 0
-			for positions[actualPos] && positionsProbed < linearProbeLimit {
+			_, occupied := positions[actualPos]
+			for occupied && positionsProbed < linearProbeLimit {
 				actualPos = (actualPos + 1) % position(maxPositions)
 				positionsProbed++
+				_, occupied = positions[actualPos]
 			}
 			if positionsProbed >= linearProbeLimit {
 				continue // Not able to find a free spot; skip this item
 			}
 
-			positions[actualPos] = true
+			positions[actualPos] = struct{}{}
 
 			item := ringItem{
 				pos:      actualPos,
@@ -160,14 +165,25 @@ func positionsForEndpoints(endpoints []string, weight int) []ringItem {
 	return items
 }
 
+func (h *hashRing) hasNormalizedEndpoints(endpoints []string) bool {
+	if h == nil || len(h.configuredEndpoints) != len(endpoints) {
+		return false
+	}
+	for i, endpoint := range endpoints {
+		if h.configuredEndpoints[i] != endpointWithPort(endpoint) {
+			return false
+		}
+	}
+	return true
+}
+
 func hashRingEndpoints(items []ringItem) []string {
 	if len(items) == 0 {
 		return nil
 	}
 	seen := make(map[string]struct{})
 	for _, item := range items {
-		endpoint := endpointWithPort(item.endpoint)
-		seen[endpoint] = struct{}{}
+		seen[endpointWithPort(item.endpoint)] = struct{}{}
 	}
 	endpoints := make([]string, 0, len(seen))
 	for endpoint := range seen {

--- a/exporter/loadbalancingexporter/consistent_hashing.go
+++ b/exporter/loadbalancingexporter/consistent_hashing.go
@@ -166,11 +166,32 @@ func positionsForEndpoints(endpoints []string, weight int) []ringItem {
 }
 
 func (h *hashRing) hasNormalizedEndpoints(endpoints []string) bool {
-	if h == nil || len(h.configuredEndpoints) != len(endpoints) {
+	if h == nil {
 		return false
 	}
-	for i, endpoint := range endpoints {
-		if h.configuredEndpoints[i] != endpointWithPort(endpoint) {
+
+	// Keep the already-normalized common path allocation-free.
+	if len(h.configuredEndpoints) == len(endpoints) {
+		matches := true
+		for i, endpoint := range endpoints {
+			if h.configuredEndpoints[i] != endpointWithPort(endpoint) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+
+	// Resolver inputs are normally normalized already, but canonicalize a
+	// reordered or duplicate-equivalent candidate before rebuilding the ring.
+	normalized := normalizeEndpoints(endpoints)
+	if len(h.configuredEndpoints) != len(normalized) {
+		return false
+	}
+	for i, endpoint := range normalized {
+		if h.configuredEndpoints[i] != endpoint {
 			return false
 		}
 	}

--- a/exporter/loadbalancingexporter/consistent_hashing_test.go
+++ b/exporter/loadbalancingexporter/consistent_hashing_test.go
@@ -292,4 +292,9 @@ func TestHashRingConfiguredEndpointsDoNotChangeRoutableEndpoints(t *testing.T) {
 
 	assert.Equal(t, []string{"endpoint-1:4317"}, ring.endpoints)
 	assert.True(t, ring.hasNormalizedEndpoints([]string{"endpoint-1:4317", "endpoint-without-position:4317"}))
+	assert.True(t, ring.hasNormalizedEndpoints([]string{
+		"endpoint-without-position",
+		"endpoint-1:4317",
+		"endpoint-1",
+	}))
 }

--- a/exporter/loadbalancingexporter/consistent_hashing_test.go
+++ b/exporter/loadbalancingexporter/consistent_hashing_test.go
@@ -4,7 +4,9 @@
 package loadbalancingexporter
 
 import (
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,6 +21,7 @@ func TestNewHashRing(t *testing.T) {
 
 	// verify
 	assert.Len(t, ring.items, 2*defaultWeight)
+	assert.Equal(t, []string{"endpoint-1:4317", "endpoint-2:4317"}, ring.configuredEndpoints)
 }
 
 func TestEndpointFor(t *testing.T) {
@@ -56,6 +59,54 @@ func TestPositionsFor(t *testing.T) {
 	// verify
 	assert.Len(t, positions, 10)
 }
+
+func TestPositionsForMatchesLegacyCRCConstruction(t *testing.T) {
+	for _, endpoint := range []string{"endpoint-1", "10.141.1.2:10417", "[::1]:4317"} {
+		expected := make([]position, 0, defaultWeight)
+		buf := make([]byte, 4)
+		for i := range defaultWeight {
+			hasher := crc32.NewIEEE()
+			binary.LittleEndian.PutUint32(buf, uint32(i))
+			_, _ = hasher.Write([]byte(endpoint))
+			_, _ = hasher.Write(buf)
+			expected = append(expected, position(hasher.Sum32()%maxPositions))
+		}
+		assert.Equal(t, expected, positionsFor(endpoint, defaultWeight))
+	}
+}
+
+func BenchmarkNewHashRing(b *testing.B) {
+	for _, endpointCount := range []int{86, 365, 720} {
+		b.Run(fmt.Sprintf("endpoints_%d", endpointCount), func(b *testing.B) {
+			endpoints := make([]string, endpointCount)
+			for i := range endpointCount {
+				endpoints[i] = fmt.Sprintf("10.141.%d.%d:10417", i/256, i%256)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				consistentHashBenchmarkRing = newHashRing(endpoints)
+			}
+		})
+	}
+}
+
+func BenchmarkHashRingEndpointFor(b *testing.B) {
+	ring := newHashRing([]string{"endpoint-1", "endpoint-2"})
+	identifier := []byte("bigid-routing-key")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		consistentHashBenchmarkEndpoint = ring.endpointFor(identifier)
+	}
+}
+
+var (
+	consistentHashBenchmarkRing     *hashRing
+	consistentHashBenchmarkEndpoint string
+)
 
 func TestBinarySearch(t *testing.T) {
 	// prepare
@@ -229,4 +280,16 @@ func TestEqual(t *testing.T) {
 			assert.Equal(t, tt.outcome, original.equal(tt.candidate))
 		})
 	}
+}
+
+func TestHashRingConfiguredEndpointsDoNotChangeRoutableEndpoints(t *testing.T) {
+	items := []ringItem{{pos: 1, endpoint: "endpoint-1"}}
+	ring := &hashRing{
+		items:               items,
+		endpoints:           hashRingEndpoints(items),
+		configuredEndpoints: normalizeEndpoints([]string{"endpoint-1", "endpoint-without-position"}),
+	}
+
+	assert.Equal(t, []string{"endpoint-1:4317"}, ring.endpoints)
+	assert.True(t, ring.hasNormalizedEndpoints([]string{"endpoint-1:4317", "endpoint-without-position:4317"}))
 }

--- a/exporter/loadbalancingexporter/endpoint_health.go
+++ b/exporter/loadbalancingexporter/endpoint_health.go
@@ -61,7 +61,10 @@ type endpointHealthManager struct {
 	pressureSnapshot   endpointHealthPressureSnapshot
 	failOpenActive     bool
 	nextExpiryUnixNano atomic.Int64
+	eligibleSnapshot   atomic.Pointer[endpointHealthEligibleSet]
 }
+
+type endpointHealthEligibleSet map[string]struct{}
 
 type endpointHealthPressureSnapshot struct {
 	present   int
@@ -427,6 +430,18 @@ func (m *endpointHealthManager) eligibleEndpointsNoRefresh() []string {
 	return eligible
 }
 
+func (m *endpointHealthManager) currentlyEligible(endpoint string) bool {
+	if !m.enabled() {
+		return false
+	}
+	snapshot := m.eligibleSnapshot.Load()
+	if snapshot == nil {
+		return false
+	}
+	_, ok := (*snapshot)[endpointWithPort(endpoint)]
+	return ok
+}
+
 func (m *endpointHealthManager) presentEndpoints() []string {
 	if !m.enabled() {
 		return nil
@@ -552,10 +567,20 @@ func (m *endpointHealthManager) eligibleEndpointsLockedWithRefresh(now time.Time
 	failOpen := m.shouldFailOpenLocked(len(present), len(eligible), quarantined)
 	failOpenStarted := failOpen && !m.failOpenActive
 	m.failOpenActive = failOpen
+	selected := m.selectEndpoints(eligible)
 	if failOpen {
-		return m.selectEndpoints(present), true, failOpenStarted
+		selected = m.selectEndpoints(present)
 	}
-	return m.selectEndpoints(eligible), false, false
+	m.storeEligibleSnapshot(selected)
+	return selected, failOpen, failOpenStarted
+}
+
+func (m *endpointHealthManager) storeEligibleSnapshot(endpoints []string) {
+	snapshot := make(endpointHealthEligibleSet, len(endpoints))
+	for _, endpoint := range endpoints {
+		snapshot[endpointWithPort(endpoint)] = struct{}{}
+	}
+	m.eligibleSnapshot.Store(&snapshot)
 }
 
 func (m *endpointHealthManager) selectEndpoints(endpoints []string) []string {

--- a/exporter/loadbalancingexporter/endpoint_health_test.go
+++ b/exporter/loadbalancingexporter/endpoint_health_test.go
@@ -43,6 +43,47 @@ func TestEndpointHealthBackendSubsetBoundsEligibleEndpoints(t *testing.T) {
 	}, pressure)
 }
 
+func TestEndpointHealthCurrentlyEligibleTracksTransitions(t *testing.T) {
+	manager := newEndpointHealthManager(endpointHealthSettings{
+		enabled:               true,
+		quarantineDuration:    time.Minute,
+		minEligibleBackends:   1,
+		maxQuarantinedPercent: 100,
+	})
+	manager.reconcile([]string{"endpoint-1:4317", "endpoint-2:4317"})
+
+	require.True(t, manager.currentlyEligible("endpoint-1:4317"))
+	require.True(t, manager.currentlyEligible("endpoint-2"))
+	require.False(t, manager.currentlyEligible("endpoint-3"))
+
+	decision := manager.markFailure("endpoint-1:4317", status.Error(codes.Unavailable, "unavailable"))
+	require.True(t, decision.quarantined)
+	require.False(t, manager.currentlyEligible("endpoint-1"))
+	require.True(t, manager.currentlyEligible("endpoint-2:4317"))
+}
+
+func BenchmarkEndpointHealthCurrentlyEligible(b *testing.B) {
+	for _, endpointCount := range []int{86, 365, 720} {
+		b.Run(fmt.Sprintf("endpoints_%d", endpointCount), func(b *testing.B) {
+			manager := newEndpointHealthManager(endpointHealthSettings{
+				enabled:               true,
+				minEligibleBackends:   1,
+				maxQuarantinedPercent: 100,
+			})
+			endpoints := backendSubsetTestEndpoints(endpointCount, 10417)
+			manager.reconcile(endpoints)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := range b.N {
+				if !manager.currentlyEligible(endpoints[i%len(endpoints)]) {
+					b.Fatal("expected endpoint to remain eligible")
+				}
+			}
+		})
+	}
+}
+
 func TestEndpointHealthBackendSubsetBoundsFailOpen(t *testing.T) {
 	selector := &backendSubsetSelector{seed: "gateway-1", maxEndpoints: 3}
 	manager := newEndpointHealthManager(endpointHealthSettings{

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -199,9 +199,10 @@ func (lb *loadBalancer) onBackendChanges(resolved []string) {
 		return
 	}
 
-	newRing := newHashRing(resolved)
-
-	if newRing.equal(lb.ring) {
+	lb.updateLock.RLock()
+	unchanged := lb.ring.hasNormalizedEndpoints(resolved)
+	lb.updateLock.RUnlock()
+	if unchanged {
 		return
 	}
 
@@ -209,7 +210,10 @@ func (lb *loadBalancer) onBackendChanges(resolved []string) {
 	ctx := context.Background()
 
 	lb.updateLock.Lock()
-	lb.installRingLocked(newRing)
+	if !lb.installRingForEndpointsLocked(resolved) {
+		lb.updateLock.Unlock()
+		return
+	}
 
 	// add the missing exporters first
 	lb.addMissingExporters(ctx, resolved)

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -247,7 +247,7 @@ func (lb *loadBalancer) onBackendChangesWithEndpointHealth(resolved []string) {
 
 func (lb *loadBalancer) commitEndpointHealthResolverUpdateLocked(resolved []string, created []createdExporter) ([]createdExporter, []removedExporter) {
 	eligible := lb.endpointHealth.eligibleEndpointsNoRefresh()
-	lb.installRingLocked(newHashRing(eligible))
+	lb.installRingForEndpointsLocked(eligible)
 
 	retained := resolved
 	if lb.endpointHealth.backendSubsetEnabled() {
@@ -292,6 +292,14 @@ func (lb *loadBalancer) installRingLocked(ring *hashRing) {
 	if admitted > 0 {
 		lb.telemetry.LoadbalancerBackendSubsetDisplacementTotal.Add(ctx, int64(admitted))
 	}
+}
+
+func (lb *loadBalancer) installRingForEndpointsLocked(endpoints []string) bool {
+	if lb.ring.hasNormalizedEndpoints(endpoints) {
+		return false
+	}
+	lb.installRingLocked(newHashRing(endpoints))
+	return true
 }
 
 type removedExporter struct {
@@ -419,7 +427,7 @@ func (lb *loadBalancer) createMissingExportersWithGuard(ctx context.Context, end
 }
 
 func (lb *loadBalancer) endpointHealthCurrentlyEligible(endpoint string) bool {
-	return slices.Contains(lb.endpointHealth.eligibleEndpoints(), endpointWithPort(endpoint))
+	return lb.endpointHealth.currentlyEligible(endpoint)
 }
 
 func (lb *loadBalancer) routableBackendCount() int {
@@ -581,7 +589,7 @@ func (lb *loadBalancer) handleBackendFailureHealthOnly(ctx context.Context, endp
 
 	lb.updateLock.Lock()
 	eligible := lb.endpointHealth.eligibleEndpointsNoRefresh()
-	lb.installRingLocked(newHashRing(eligible))
+	lb.installRingForEndpointsLocked(eligible)
 	var removed []removedExporter
 	if createdExporterExists(created, endpoint) {
 		if exp, ok := lb.exporters[endpoint]; ok {
@@ -620,7 +628,7 @@ func (lb *loadBalancer) handleBackendProbeFailure(ctx context.Context, endpoint 
 
 	lb.updateLock.Lock()
 	eligible := lb.endpointHealth.eligibleEndpointsNoRefresh()
-	lb.installRingLocked(newHashRing(eligible))
+	lb.installRingForEndpointsLocked(eligible)
 	var removed []removedExporter
 	endpointEligible := endpointListContains(eligible, endpoint)
 	if exp, ok := lb.exporters[endpoint]; ok && (!endpointEligible || createdExporterExists(created, endpoint)) {
@@ -657,7 +665,7 @@ func (lb *loadBalancer) handleBackendProbeSuccess(ctx context.Context, endpoint 
 
 	lb.updateLock.Lock()
 	eligible := lb.endpointHealth.eligibleEndpointsNoRefresh()
-	lb.installRingLocked(newHashRing(eligible))
+	lb.installRingForEndpointsLocked(eligible)
 	duplicates := lb.installCreatedExportersLocked(created, eligible)
 	removed := lb.removeBackendSubsetExtraExportersLocked(eligible)
 	lb.refreshRoutableBackendCountLocked()
@@ -706,7 +714,7 @@ func (lb *loadBalancer) handleBackendFailureWithDrain(ctx context.Context, endpo
 
 	lb.updateLock.Lock()
 	eligible := lb.endpointHealth.eligibleEndpointsNoRefresh()
-	lb.installRingLocked(newHashRing(eligible))
+	lb.installRingForEndpointsLocked(eligible)
 	var removed []removedExporter
 	endpointEligible := endpointListContains(eligible, endpoint)
 	if exp, ok := lb.exporters[endpoint]; ok && (!endpointEligible || createdExporterExists(created, endpoint)) {
@@ -764,7 +772,7 @@ func (lb *loadBalancer) handleBackendSuccess(endpoint string) {
 
 	lb.updateLock.Lock()
 	eligible := lb.endpointHealth.eligibleEndpointsNoRefresh()
-	lb.installRingLocked(newHashRing(eligible))
+	lb.installRingForEndpointsLocked(eligible)
 	duplicates := lb.installCreatedExportersLocked(created, eligible)
 	removed := lb.removeBackendSubsetExtraExportersLocked(eligible)
 	lb.refreshRoutableBackendCountLocked()
@@ -797,7 +805,7 @@ func (lb *loadBalancer) refreshExpiredEndpointHealth(ctx context.Context) {
 	created := lb.createMissingExporters(ctx, refresh.eligible, nil)
 	lb.updateLock.Lock()
 	eligible := lb.endpointHealth.eligibleEndpointsNoRefresh()
-	lb.installRingLocked(newHashRing(eligible))
+	lb.installRingForEndpointsLocked(eligible)
 	duplicates := lb.installCreatedExportersLocked(created, eligible)
 	removed := lb.removeBackendSubsetExtraExportersLocked(eligible)
 	lb.refreshRoutableBackendCountLocked()

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -303,6 +303,9 @@ func TestInstallRingForEndpointsLockedSkipsUnchangedSet(t *testing.T) {
 	require.False(t, lb.installRingForEndpointsLocked([]string{"endpoint-1:4317", "endpoint-2:4317"}))
 	require.Same(t, original, lb.ring)
 
+	require.False(t, lb.installRingForEndpointsLocked([]string{"endpoint-2", "endpoint-1", "endpoint-2:4317"}))
+	require.Same(t, original, lb.ring)
+
 	require.True(t, lb.installRingForEndpointsLocked([]string{"endpoint-1:4317", "endpoint-3:4317"}))
 	require.NotSame(t, original, lb.ring)
 	require.Equal(t, []string{"endpoint-1:4317", "endpoint-3:4317"}, lb.ring.endpoints)

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -296,6 +296,18 @@ func TestOnBackendChanges(t *testing.T) {
 	assert.Len(t, p.ring.items, 2*defaultWeight)
 }
 
+func TestInstallRingForEndpointsLockedSkipsUnchangedSet(t *testing.T) {
+	lb := &loadBalancer{ring: newHashRing([]string{"endpoint-1", "endpoint-2"})}
+	original := lb.ring
+
+	require.False(t, lb.installRingForEndpointsLocked([]string{"endpoint-1:4317", "endpoint-2:4317"}))
+	require.Same(t, original, lb.ring)
+
+	require.True(t, lb.installRingForEndpointsLocked([]string{"endpoint-1:4317", "endpoint-3:4317"}))
+	require.NotSame(t, original, lb.ring)
+	require.Equal(t, []string{"endpoint-1:4317", "endpoint-3:4317"}, lb.ring.endpoints)
+}
+
 func TestLoadBalancerBackendSubsetBoundsExporterChurn(t *testing.T) {
 	p, creates, shutdowns := newBackendSubsetTestLoadBalancer(t, 2)
 	resolved := backendSubsetTestEndpoints(500, 10417)

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -296,6 +296,32 @@ func TestOnBackendChanges(t *testing.T) {
 	assert.Len(t, p.ring.items, 2*defaultWeight)
 }
 
+func TestOnBackendChangesReconcilesConfiguredEndpointsWhenRingImageMatches(t *testing.T) {
+	ts, tb := getTelemetryAssets(t)
+	cfg := simpleConfig()
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
+		return newNopMockExporter(), nil
+	}
+
+	p, err := newLoadBalancer(ts.Logger, cfg, componentFactory, tb)
+	require.NoError(t, err)
+	p.onBackendChanges([]string{"endpoint-1"})
+
+	// Simulate a saturated ring where the new endpoint receives no position:
+	// the visible ring image matches the candidate while configured membership
+	// still differs.
+	candidate := newHashRing([]string{"endpoint-1", "endpoint-2"})
+	p.ring.items = candidate.items
+	p.ring.endpoints = candidate.endpoints
+	require.True(t, candidate.equal(p.ring))
+	require.False(t, p.ring.hasNormalizedEndpoints([]string{"endpoint-1", "endpoint-2"}))
+
+	p.onBackendChanges([]string{"endpoint-1", "endpoint-2"})
+
+	require.Equal(t, candidate.configuredEndpoints, p.ring.configuredEndpoints)
+	require.Contains(t, p.exporters, "endpoint-2:4317")
+}
+
 func TestInstallRingForEndpointsLockedSkipsUnchangedSet(t *testing.T) {
 	lb := &loadBalancer{ring: newHashRing([]string{"endpoint-1", "endpoint-2"})}
 	original := lb.ring


### PR DESCRIPTION
#### Description

Removes the pprof-confirmed load-balancer control-plane costs from SAW-7944:

- replaces O(N) endpoint eligibility scans per candidate with one immutable eligibility set and O(1) live membership
- avoids rebuilding the consistent hash ring when the normalized configured endpoint set is unchanged
- reconciles configured membership even when different endpoint sets produce the same saturated visible ring
- preserves actual routable ring endpoints separately from configured endpoints at saturated ring sizes
- replaces permanent 10 ms central-queue and backend-slot polling with notification-driven wakeups, exact batch-deadline timers, and bounded 50 ms to 1 s fallback backoff
- scopes backend-slot wakeups per endpoint to prevent wrong-backend wakeups
- removes per-position CRC hash allocations while preserving bit-identical routing

DNS defaults and worker matching semantics are unchanged. BigID capacity is unchanged; reduction remains gated on peak post-rollout pprof, queue age and drain, refusal and retry, backend health, and records completeness.

#### Link to tracking issue

SAW-7944

#### Testing

- `make lint`
- `make test-twice`: 1,268 tests across two race-enabled runs; four pre-existing documented skips
- `make govulncheck`: only the repository-scoped non-exploitable GO-2026-5932 advisory
- focused notification, deadline, limiter, hash parity, configured-membership collision, and eligibility regressions under repeated and race runs
- before/after endpoint membership benchmark: 9 to 82 us and 9 to 70 KB per lookup down to about 11 ns and 0 allocations at N=86/365/720
- before/after N=720 ring build: about 10.25 ms, 7.12 MB, and 73,756 allocations down to about 8.15 ms, 1.60 MB, and 875 allocations
- committed fix-delta autoreview clean
- independent Claude Fable architecture review: APPROVE

#### Documentation

No user-facing configuration changes. Existing DNS interval and capacity defaults remain unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved load-balancing responsiveness by adapting how queue leasing waits and retries based on current readiness.
  - Reduced overhead by skipping unnecessary hash-ring rebuilds when the resolved backend set hasn’t meaningfully changed.
  - Streamlined hashing and health eligibility evaluation to lower CPU and allocations for large backend sets.

- **Reliability**
  - Waiting requests are awakened promptly when capacity is released.
  - Endpoint-specific waiting prevents unrelated backends from impacting each other.
  - Added coverage to ensure queue fallback behavior and wake-up correctness under contention and timing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->